### PR TITLE
Update runtime commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,24 +70,24 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            artifact_name: avocado-cli
-            asset_name: avocado-cli-linux-x86_64
+            artifact_name: avocado
+            asset_name: avocado-linux-x86_64
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            artifact_name: avocado-cli
-            asset_name: avocado-cli-linux-x86_64-musl
+            artifact_name: avocado
+            asset_name: avocado-linux-x86_64-musl
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            artifact_name: avocado-cli.exe
-            asset_name: avocado-cli-windows-x86_64.exe
+            artifact_name: avocado.exe
+            asset_name: avocado-windows-x86_64.exe
           - os: macos-latest
             target: x86_64-apple-darwin
-            artifact_name: avocado-cli
-            asset_name: avocado-cli-macos-x86_64
+            artifact_name: avocado
+            asset_name: avocado-macos-x86_64
           - os: macos-latest
             target: aarch64-apple-darwin
-            artifact_name: avocado-cli
-            asset_name: avocado-cli-macos-aarch64
+            artifact_name: avocado
+            asset_name: avocado-macos-aarch64
 
     steps:
       - name: Checkout code
@@ -146,10 +146,10 @@ jobs:
           prerelease: ${{ contains(needs.validate-version.outputs.version, '-') }}
           generate_release_notes: true
           files: |
-            avocado-cli-linux-x86_64/avocado-cli
-            avocado-cli-linux-x86_64-musl/avocado-cli
-            avocado-cli-windows-x86_64.exe/avocado-cli.exe
-            avocado-cli-macos-x86_64/avocado-cli
-            avocado-cli-macos-aarch64/avocado-cli
+            avocado-linux-x86_64/avocado
+            avocado-linux-x86_64-musl/avocado
+            avocado-windows-x86_64.exe/avocado.exe
+            avocado-macos-x86_64/avocado
+            avocado-macos-aarch64/avocado
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ Thumbs.db
 coverage/
 *.profraw
 
+# Avocado state directories
+_avocado/
+
 # Documentation build
 docs/_build/
 /site

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "avocado-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/avocado-framework/avocado-cli"
 keywords = ["cli", "build", "provisioning", "containers", "extensions"]
 categories = ["command-line-utilities", "development-tools"]
 
+[[bin]]
+name = "avocado"
+path = "src/main.rs"
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,0 +1,318 @@
+//! Build command implementation that runs SDK compile, extension build, and runtime build.
+
+use anyhow::{Context, Result};
+use std::collections::HashSet;
+
+use crate::commands::{ext::ExtBuildCommand, runtime::RuntimeBuildCommand, sdk::SdkCompileCommand};
+use crate::utils::{
+    config::Config,
+    output::{print_info, print_success, OutputLevel},
+};
+
+/// Implementation of the 'build' command that runs all build subcommands.
+pub struct BuildCommand {
+    /// Path to configuration file
+    pub config_path: String,
+    /// Enable verbose output
+    pub verbose: bool,
+    /// Runtime name to build (if not provided, builds all runtimes)
+    pub runtime: Option<String>,
+    /// Global target architecture
+    pub target: Option<String>,
+    /// Additional arguments to pass to the container runtime
+    pub container_args: Option<Vec<String>>,
+    /// Additional arguments to pass to DNF commands
+    pub dnf_args: Option<Vec<String>>,
+}
+
+impl BuildCommand {
+    /// Create a new BuildCommand instance
+    pub fn new(
+        config_path: String,
+        verbose: bool,
+        runtime: Option<String>,
+        target: Option<String>,
+        container_args: Option<Vec<String>>,
+        dnf_args: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            config_path,
+            verbose,
+            runtime,
+            target,
+            container_args,
+            dnf_args,
+        }
+    }
+
+    /// Execute the build command
+    pub async fn execute(&self) -> Result<()> {
+        // Load the configuration and parse raw TOML
+        let config = Config::load(&self.config_path)
+            .with_context(|| format!("Failed to load config from {}", self.config_path))?;
+        let content = std::fs::read_to_string(&self.config_path)?;
+        let parsed: toml::Value = toml::from_str(&content)?;
+
+        print_info(
+            "Starting comprehensive build process...",
+            OutputLevel::Normal,
+        );
+
+        // Determine which runtimes to build
+        let runtimes_to_build = self.get_runtimes_to_build(&parsed)?;
+
+        if runtimes_to_build.is_empty() {
+            print_info("No runtimes found to build.", OutputLevel::Normal);
+            return Ok(());
+        }
+
+        // Step 1: Analyze dependencies to find extensions that need SDK compilation
+        print_info(
+            "Step 1/3: Analyzing dependencies and compiling SDK code",
+            OutputLevel::Normal,
+        );
+        let required_extensions = self.find_required_extensions(&parsed, &runtimes_to_build)?;
+        let sdk_sections = self.find_sdk_compile_sections(&config, &required_extensions)?;
+
+        if !sdk_sections.is_empty() {
+            if self.verbose {
+                print_info(
+                    &format!(
+                        "Found {} SDK compile sections needed: {}",
+                        sdk_sections.len(),
+                        sdk_sections.join(", ")
+                    ),
+                    OutputLevel::Normal,
+                );
+            }
+
+            let sdk_compile_cmd = SdkCompileCommand::new(
+                self.config_path.clone(),
+                self.verbose,
+                sdk_sections,
+                self.target.clone(),
+                self.container_args.clone(),
+                self.dnf_args.clone(),
+            );
+            sdk_compile_cmd
+                .execute()
+                .await
+                .with_context(|| "Failed to compile SDK sections")?;
+        } else {
+            print_info("No SDK compilation needed.", OutputLevel::Normal);
+        }
+
+        // Step 2: Build extensions
+        print_info("Step 2/3: Building extensions", OutputLevel::Normal);
+        if !required_extensions.is_empty() {
+            for extension in &required_extensions {
+                if self.verbose {
+                    print_info(
+                        &format!("Building extension '{extension}'"),
+                        OutputLevel::Normal,
+                    );
+                }
+
+                let ext_build_cmd = ExtBuildCommand::new(
+                    extension.clone(),
+                    self.config_path.clone(),
+                    self.verbose,
+                    self.target.clone(),
+                    self.container_args.clone(),
+                    self.dnf_args.clone(),
+                );
+                ext_build_cmd
+                    .execute()
+                    .await
+                    .with_context(|| format!("Failed to build extension '{extension}'"))?;
+            }
+        } else {
+            print_info("No extensions to build.", OutputLevel::Normal);
+        }
+
+        // Step 3: Build runtimes
+        if let Some(ref runtime_name) = self.runtime {
+            print_info(
+                &format!("Step 3/3: Building runtime '{runtime_name}'"),
+                OutputLevel::Normal,
+            );
+        } else {
+            print_info("Step 3/3: Building all runtimes", OutputLevel::Normal);
+        }
+
+        for runtime_name in &runtimes_to_build {
+            if self.verbose {
+                print_info(
+                    &format!("Building runtime '{runtime_name}'"),
+                    OutputLevel::Normal,
+                );
+            }
+
+            let runtime_build_cmd = RuntimeBuildCommand::new(
+                runtime_name.clone(),
+                self.config_path.clone(),
+                self.verbose,
+                self.target.clone(),
+                self.container_args.clone(),
+                self.dnf_args.clone(),
+            );
+            runtime_build_cmd
+                .execute()
+                .await
+                .with_context(|| format!("Failed to build runtime '{runtime_name}'"))?;
+        }
+
+        print_success("All components built successfully!", OutputLevel::Normal);
+        Ok(())
+    }
+
+    /// Determine which runtimes to build based on the --runtime parameter
+    fn get_runtimes_to_build(&self, parsed: &toml::Value) -> Result<Vec<String>> {
+        let runtime_section = parsed
+            .get("runtime")
+            .and_then(|r| r.as_table())
+            .ok_or_else(|| anyhow::anyhow!("No runtime configuration found"))?;
+
+        if let Some(ref runtime_name) = self.runtime {
+            // Single runtime specified
+            if !runtime_section.contains_key(runtime_name) {
+                return Err(anyhow::anyhow!(
+                    "Runtime '{}' not found in configuration",
+                    runtime_name
+                ));
+            }
+            Ok(vec![runtime_name.clone()])
+        } else {
+            // Build all runtimes
+            Ok(runtime_section.keys().cloned().collect())
+        }
+    }
+
+    /// Find all extensions required by the specified runtimes
+    fn find_required_extensions(
+        &self,
+        parsed: &toml::Value,
+        runtimes: &[String],
+    ) -> Result<Vec<String>> {
+        let mut required_extensions = HashSet::new();
+
+        let runtime_section = parsed.get("runtime").and_then(|r| r.as_table()).unwrap();
+
+        for runtime_name in runtimes {
+            if let Some(runtime_config) = runtime_section.get(runtime_name) {
+                if let Some(dependencies) = runtime_config
+                    .get("dependencies")
+                    .and_then(|d| d.as_table())
+                {
+                    for (_dep_name, dep_spec) in dependencies {
+                        if let Some(ext_name) = dep_spec.get("ext").and_then(|v| v.as_str()) {
+                            required_extensions.insert(ext_name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut extensions: Vec<String> = required_extensions.into_iter().collect();
+        extensions.sort();
+        Ok(extensions)
+    }
+
+    /// Find SDK compile sections needed for the required extensions
+    fn find_sdk_compile_sections(
+        &self,
+        config: &Config,
+        required_extensions: &[String],
+    ) -> Result<Vec<String>> {
+        let mut needed_sections = HashSet::new();
+
+        // Get extension SDK dependencies
+        let content = std::fs::read_to_string(&self.config_path)?;
+        let extension_sdk_dependencies = config
+            .get_extension_sdk_dependencies(&content)
+            .with_context(|| "Failed to parse extension SDK dependencies")?;
+
+        // For each required extension, check if it has SDK dependencies that need compilation
+        for extension in required_extensions {
+            if let Some(_ext_deps) = extension_sdk_dependencies.get(extension) {
+                // If the extension has SDK dependencies, we might need to compile them
+                // For now, we'll check if there are compile sections defined and add them all
+                // In a more sophisticated implementation, we'd analyze which specific sections
+                // are needed based on the extension's SDK dependencies
+                if self.verbose {
+                    print_info(
+                        &format!("Extension '{extension}' has SDK dependencies"),
+                        OutputLevel::Normal,
+                    );
+                }
+            }
+        }
+
+        // Get compile sections from config - we'll compile all of them if any extensions need SDK code
+        if !required_extensions.is_empty() {
+            let compile_dependencies = config.get_compile_dependencies();
+            for section_name in compile_dependencies.keys() {
+                needed_sections.insert(section_name.clone());
+            }
+        }
+
+        let mut sections: Vec<String> = needed_sections.into_iter().collect();
+        sections.sort();
+        Ok(sections)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let cmd = BuildCommand::new(
+            "avocado.toml".to_string(),
+            true,
+            Some("my-runtime".to_string()),
+            Some("x86_64".to_string()),
+            Some(vec!["--privileged".to_string()]),
+            Some(vec!["--nogpgcheck".to_string()]),
+        );
+
+        assert_eq!(cmd.config_path, "avocado.toml");
+        assert!(cmd.verbose);
+        assert_eq!(cmd.runtime, Some("my-runtime".to_string()));
+        assert_eq!(cmd.target, Some("x86_64".to_string()));
+        assert_eq!(cmd.container_args, Some(vec!["--privileged".to_string()]));
+        assert_eq!(cmd.dnf_args, Some(vec!["--nogpgcheck".to_string()]));
+    }
+
+    #[test]
+    fn test_new_all_runtimes() {
+        let cmd = BuildCommand::new("config.toml".to_string(), false, None, None, None, None);
+
+        assert_eq!(cmd.config_path, "config.toml");
+        assert!(!cmd.verbose);
+        assert_eq!(cmd.runtime, None);
+        assert_eq!(cmd.target, None);
+        assert_eq!(cmd.container_args, None);
+        assert_eq!(cmd.dnf_args, None);
+    }
+
+    #[test]
+    fn test_new_with_runtime() {
+        let cmd = BuildCommand::new(
+            "avocado.toml".to_string(),
+            false,
+            Some("test-runtime".to_string()),
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(cmd.config_path, "avocado.toml");
+        assert!(!cmd.verbose);
+        assert_eq!(cmd.runtime, Some("test-runtime".to_string()));
+        assert_eq!(cmd.target, None);
+        assert_eq!(cmd.container_args, None);
+        assert_eq!(cmd.dnf_args, None);
+    }
+}

--- a/src/commands/ext/install.rs
+++ b/src/commands/ext/install.rs
@@ -280,7 +280,6 @@ impl ExtInstallCommand {
                 };
                 let command = format!(
                     r#"
-RPM_CONFIGDIR="$AVOCADO_SDK_PREFIX/usr/lib/rpm" \
 RPM_ETCCONFIGDIR=$DNF_SDK_TARGET_PREFIX \
 $DNF_SDK_HOST \
     $DNF_SDK_HOST_OPTS \

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -57,14 +57,30 @@ impl InitCommand {
 
         // Create the configuration content
         let config_content = format!(
-            r#"[runtime.default]
+            r#"[runtime.dev]
 target = "{target}"
 
-[runtime.default.dependencies]
-nativesdk-avocado-images = "*"
+[runtime.dev.dependencies]
+avocado-img-bootfiles = "*"
+avocado-img-rootfs = "*"
+avocado-img-initramfs = "*"
+avocado-dev = {{ ext = "avocado-dev" }}
 
 [sdk]
 image = "avocadolinux/sdk:apollo-edge"
+
+[sdk.dependencies]
+nativesdk-qemu-system-x86-64 = "*"
+
+[ext.avocado-dev]
+sysext = true
+confext = true
+
+[ext.avocado-dev.dependencies]
+avocado-hitl = "*"
+
+[ext.avocado-dev.sdk.dependencies]
+nativesdk-avocado-hitl = "*"
 "#
         );
 
@@ -110,8 +126,18 @@ mod tests {
 
         let content = fs::read_to_string(&config_path).unwrap();
         assert!(content.contains("target = \"qemux86-64\""));
-        assert!(content.contains("nativesdk-avocado-images = \"*\""));
+        assert!(content.contains("[runtime.dev]"));
+        assert!(content.contains("avocado-img-bootfiles = \"*\""));
+        assert!(content.contains("avocado-img-rootfs = \"*\""));
+        assert!(content.contains("avocado-img-initramfs = \"*\""));
+        assert!(content.contains("avocado-dev = { ext = \"avocado-dev\" }"));
         assert!(content.contains("image = \"avocadolinux/sdk:apollo-edge\""));
+        assert!(content.contains("nativesdk-qemu-system-x86-64 = \"*\""));
+        assert!(content.contains("[ext.avocado-dev]"));
+        assert!(content.contains("sysext = true"));
+        assert!(content.contains("confext = true"));
+        assert!(content.contains("avocado-hitl = \"*\""));
+        assert!(content.contains("nativesdk-avocado-hitl = \"*\""));
     }
 
     #[test]

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,0 +1,198 @@
+//! Install command implementation that runs SDK, extension, and runtime installs.
+
+use anyhow::{Context, Result};
+
+use crate::commands::{
+    ext::ExtInstallCommand, runtime::RuntimeInstallCommand, sdk::SdkInstallCommand,
+};
+use crate::utils::{
+    config::Config,
+    output::{print_info, print_success, OutputLevel},
+};
+
+/// Implementation of the 'install' command that runs all install subcommands.
+pub struct InstallCommand {
+    /// Path to configuration file
+    pub config_path: String,
+    /// Enable verbose output
+    pub verbose: bool,
+    /// Force operation without prompts
+    pub force: bool,
+    /// Runtime name to install dependencies for (if not provided, installs for all runtimes)
+    pub runtime: Option<String>,
+    /// Global target architecture
+    pub target: Option<String>,
+    /// Additional arguments to pass to the container runtime
+    pub container_args: Option<Vec<String>>,
+    /// Additional arguments to pass to DNF commands
+    pub dnf_args: Option<Vec<String>>,
+}
+
+impl InstallCommand {
+    /// Create a new InstallCommand instance
+    pub fn new(
+        config_path: String,
+        verbose: bool,
+        force: bool,
+        runtime: Option<String>,
+        target: Option<String>,
+        container_args: Option<Vec<String>>,
+        dnf_args: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            config_path,
+            verbose,
+            force,
+            runtime,
+            target,
+            container_args,
+            dnf_args,
+        }
+    }
+
+    /// Execute the install command
+    pub async fn execute(&self) -> Result<()> {
+        // Load the configuration to check what components exist
+        let _config = Config::load(&self.config_path)
+            .with_context(|| format!("Failed to load config from {}", self.config_path))?;
+
+        print_info(
+            "Starting comprehensive install process...",
+            OutputLevel::Normal,
+        );
+
+        // 1. Install SDK dependencies
+        print_info("Step 1/3: Installing SDK dependencies", OutputLevel::Normal);
+        let sdk_install_cmd = SdkInstallCommand::new(
+            self.config_path.clone(),
+            self.verbose,
+            self.force,
+            self.target.clone(),
+            self.container_args.clone(),
+            self.dnf_args.clone(),
+        );
+        sdk_install_cmd
+            .execute()
+            .await
+            .with_context(|| "Failed to install SDK dependencies")?;
+
+        // 2. Install extension dependencies
+        print_info(
+            "Step 2/3: Installing extension dependencies",
+            OutputLevel::Normal,
+        );
+        let ext_install_cmd = ExtInstallCommand::new(
+            None, // Install all extensions
+            self.config_path.clone(),
+            self.verbose,
+            self.force,
+            self.target.clone(),
+            self.container_args.clone(),
+            self.dnf_args.clone(),
+        );
+        ext_install_cmd
+            .execute()
+            .await
+            .with_context(|| "Failed to install extension dependencies")?;
+
+        // 3. Install runtime dependencies
+        if let Some(ref runtime_name) = self.runtime {
+            print_info(
+                &format!("Step 3/3: Installing runtime dependencies for '{runtime_name}'"),
+                OutputLevel::Normal,
+            );
+        } else {
+            print_info(
+                "Step 3/3: Installing runtime dependencies for all runtimes",
+                OutputLevel::Normal,
+            );
+        }
+        let runtime_install_cmd = RuntimeInstallCommand::new(
+            self.runtime.clone(), // Use the specified runtime or None for all runtimes
+            self.config_path.clone(),
+            self.verbose,
+            self.force,
+            self.target.clone(),
+            self.container_args.clone(),
+            self.dnf_args.clone(),
+        );
+        runtime_install_cmd
+            .execute()
+            .await
+            .with_context(|| "Failed to install runtime dependencies")?;
+
+        print_success(
+            "All components installed successfully!",
+            OutputLevel::Normal,
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let cmd = InstallCommand::new(
+            "avocado.toml".to_string(),
+            true,
+            false,
+            Some("my-runtime".to_string()),
+            Some("x86_64".to_string()),
+            Some(vec!["--privileged".to_string()]),
+            Some(vec!["--nogpgcheck".to_string()]),
+        );
+
+        assert_eq!(cmd.config_path, "avocado.toml");
+        assert!(cmd.verbose);
+        assert!(!cmd.force);
+        assert_eq!(cmd.runtime, Some("my-runtime".to_string()));
+        assert_eq!(cmd.target, Some("x86_64".to_string()));
+        assert_eq!(cmd.container_args, Some(vec!["--privileged".to_string()]));
+        assert_eq!(cmd.dnf_args, Some(vec!["--nogpgcheck".to_string()]));
+    }
+
+    #[test]
+    fn test_new_minimal() {
+        let cmd = InstallCommand::new(
+            "config.toml".to_string(),
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(cmd.config_path, "config.toml");
+        assert!(!cmd.verbose);
+        assert!(!cmd.force);
+        assert_eq!(cmd.runtime, None);
+        assert_eq!(cmd.target, None);
+        assert_eq!(cmd.container_args, None);
+        assert_eq!(cmd.dnf_args, None);
+    }
+
+    #[test]
+    fn test_new_with_runtime() {
+        let cmd = InstallCommand::new(
+            "avocado.toml".to_string(),
+            false,
+            true,
+            Some("test-runtime".to_string()),
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(cmd.config_path, "avocado.toml");
+        assert!(!cmd.verbose);
+        assert!(cmd.force);
+        assert_eq!(cmd.runtime, Some("test-runtime".to_string()));
+        assert_eq!(cmd.target, None);
+        assert_eq!(cmd.container_args, None);
+        assert_eq!(cmd.dnf_args, None);
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod build;
 pub mod clean;
 pub mod ext;
 pub mod init;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod clean;
 pub mod ext;
 pub mod init;
+pub mod install;
 pub mod runtime;
 pub mod sdk;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,5 +3,6 @@ pub mod clean;
 pub mod ext;
 pub mod init;
 pub mod install;
+pub mod provision;
 pub mod runtime;
 pub mod sdk;

--- a/src/commands/provision.rs
+++ b/src/commands/provision.rs
@@ -1,0 +1,108 @@
+//! Provision command implementation that acts as a shortcut to runtime provision.
+
+use anyhow::Result;
+
+use crate::commands::runtime::RuntimeProvisionCommand;
+
+/// Implementation of the 'provision' command that calls through to runtime provision.
+pub struct ProvisionCommand {
+    /// Runtime name to provision
+    pub runtime: String,
+    /// Path to configuration file
+    pub config_path: String,
+    /// Enable verbose output
+    pub verbose: bool,
+    /// Force operation without prompts
+    pub force: bool,
+    /// Global target architecture
+    pub target: Option<String>,
+    /// Additional arguments to pass to the container runtime
+    pub container_args: Option<Vec<String>>,
+    /// Additional arguments to pass to DNF commands
+    pub dnf_args: Option<Vec<String>>,
+}
+
+impl ProvisionCommand {
+    /// Create a new ProvisionCommand instance
+    pub fn new(
+        runtime: String,
+        config_path: String,
+        verbose: bool,
+        force: bool,
+        target: Option<String>,
+        container_args: Option<Vec<String>>,
+        dnf_args: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            runtime,
+            config_path,
+            verbose,
+            force,
+            target,
+            container_args,
+            dnf_args,
+        }
+    }
+
+    /// Execute the provision command by calling runtime provision
+    pub async fn execute(&self) -> Result<()> {
+        let runtime_provision_cmd = RuntimeProvisionCommand::new(
+            self.runtime.clone(),
+            self.config_path.clone(),
+            self.verbose,
+            self.force,
+            self.target.clone(),
+            self.container_args.clone(),
+            self.dnf_args.clone(),
+        );
+
+        runtime_provision_cmd.execute().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let cmd = ProvisionCommand::new(
+            "my-runtime".to_string(),
+            "avocado.toml".to_string(),
+            true,
+            false,
+            Some("x86_64".to_string()),
+            Some(vec!["--privileged".to_string()]),
+            Some(vec!["--nogpgcheck".to_string()]),
+        );
+
+        assert_eq!(cmd.runtime, "my-runtime");
+        assert_eq!(cmd.config_path, "avocado.toml");
+        assert!(cmd.verbose);
+        assert!(!cmd.force);
+        assert_eq!(cmd.target, Some("x86_64".to_string()));
+        assert_eq!(cmd.container_args, Some(vec!["--privileged".to_string()]));
+        assert_eq!(cmd.dnf_args, Some(vec!["--nogpgcheck".to_string()]));
+    }
+
+    #[test]
+    fn test_new_minimal() {
+        let cmd = ProvisionCommand::new(
+            "test-runtime".to_string(),
+            "config.toml".to_string(),
+            false,
+            true,
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(cmd.runtime, "test-runtime");
+        assert_eq!(cmd.config_path, "config.toml");
+        assert!(!cmd.verbose);
+        assert!(cmd.force);
+        assert_eq!(cmd.target, None);
+        assert_eq!(cmd.container_args, None);
+        assert_eq!(cmd.dnf_args, None);
+    }
+}

--- a/src/commands/runtime/clean.rs
+++ b/src/commands/runtime/clean.rs
@@ -1,0 +1,194 @@
+use anyhow::Result;
+
+use crate::utils::config::load_config;
+use crate::utils::container::{RunConfig, SdkContainer};
+use crate::utils::output::{print_error, print_info, print_success, OutputLevel};
+use crate::utils::target::resolve_target;
+
+pub struct RuntimeCleanCommand {
+    runtime: String,
+    config_path: String,
+    verbose: bool,
+    target: Option<String>,
+    container_args: Option<Vec<String>>,
+    dnf_args: Option<Vec<String>>,
+}
+
+impl RuntimeCleanCommand {
+    pub fn new(
+        runtime: String,
+        config_path: String,
+        verbose: bool,
+        target: Option<String>,
+        container_args: Option<Vec<String>>,
+        dnf_args: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            runtime,
+            config_path,
+            verbose,
+            target,
+            container_args,
+            dnf_args,
+        }
+    }
+
+    pub async fn execute(&self) -> Result<()> {
+        let _config = load_config(&self.config_path)?;
+        let content = std::fs::read_to_string(&self.config_path)?;
+        let parsed: toml::Value = toml::from_str(&content)?;
+
+        self.validate_runtime_exists(&parsed)?;
+        let container_image = self.get_container_image(&parsed)?;
+        let target = self.resolve_target_architecture(&parsed)?;
+
+        self.clean_runtime(&container_image, &target).await
+    }
+
+    fn validate_runtime_exists(&self, parsed: &toml::Value) -> Result<()> {
+        let runtime_section = parsed.get("runtime").ok_or_else(|| {
+            print_error(
+                &format!("Runtime '{}' not found in configuration.", self.runtime),
+                OutputLevel::Normal,
+            );
+            anyhow::anyhow!("No runtime section found")
+        })?;
+
+        let runtime_table = runtime_section
+            .as_table()
+            .ok_or_else(|| anyhow::anyhow!("Invalid runtime section format"))?;
+
+        if !runtime_table.contains_key(&self.runtime) {
+            print_error(
+                &format!("Runtime '{}' not found in configuration.", self.runtime),
+                OutputLevel::Normal,
+            );
+            return Err(anyhow::anyhow!("Runtime not found"));
+        }
+
+        Ok(())
+    }
+
+    fn get_container_image(&self, parsed: &toml::Value) -> Result<String> {
+        parsed
+            .get("sdk")
+            .and_then(|sdk| sdk.get("image"))
+            .and_then(|img| img.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                anyhow::anyhow!("No container image specified in config under 'sdk.image'.")
+            })
+    }
+
+    fn resolve_target_architecture(&self, parsed: &toml::Value) -> Result<String> {
+        let config_target = self.extract_config_target(parsed);
+        let resolved_target = resolve_target(self.target.as_deref(), config_target.as_deref());
+
+        resolved_target.ok_or_else(|| {
+            anyhow::anyhow!(
+                "No target architecture specified for runtime '{}'. Use --target, AVOCADO_TARGET env var, or config under 'runtime.{}.target'.",
+                self.runtime, self.runtime
+            )
+        })
+    }
+
+    fn extract_config_target(&self, parsed: &toml::Value) -> Option<String> {
+        parsed
+            .get("runtime")
+            .and_then(|runtime| runtime.as_table())
+            .and_then(|runtime_table| runtime_table.get(&self.runtime))
+            .and_then(|runtime_config| runtime_config.get("target"))
+            .and_then(|target| target.as_str())
+            .map(|s| s.to_string())
+    }
+
+    async fn clean_runtime(&self, container_image: &str, target: &str) -> Result<()> {
+        print_info(
+            &format!("Cleaning runtime '{}'...", self.runtime),
+            OutputLevel::Normal,
+        );
+
+        let container_helper = SdkContainer::new();
+        let clean_command = format!("rm -rf $AVOCADO_PREFIX/runtimes/{}", self.runtime);
+
+        if self.verbose {
+            print_info(
+                &format!("Running command: {clean_command}"),
+                OutputLevel::Normal,
+            );
+        }
+
+        let config = RunConfig {
+            container_image: container_image.to_string(),
+            target: target.to_string(),
+            command: clean_command,
+            verbose: self.verbose,
+            source_environment: false, // don't source environment
+            interactive: false,
+            repo_url: None,
+            repo_release: None,
+            container_args: self.container_args.clone(),
+            dnf_args: self.dnf_args.clone(),
+            ..Default::default()
+        };
+        let success = container_helper.run_in_container(config).await?;
+
+        if success {
+            print_success(
+                &format!("Successfully cleaned runtime '{}'.", self.runtime),
+                OutputLevel::Normal,
+            );
+            Ok(())
+        } else {
+            print_error(
+                &format!("Failed to clean runtime '{}'.", self.runtime),
+                OutputLevel::Normal,
+            );
+            Err(anyhow::anyhow!("Clean command failed"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let cmd = RuntimeCleanCommand::new(
+            "test-runtime".to_string(),
+            "avocado.toml".to_string(),
+            false,
+            Some("x86_64".to_string()),
+            None,
+            None,
+        );
+
+        assert_eq!(cmd.runtime, "test-runtime");
+        assert_eq!(cmd.config_path, "avocado.toml");
+        assert!(!cmd.verbose);
+        assert_eq!(cmd.target, Some("x86_64".to_string()));
+    }
+
+    #[test]
+    fn test_new_with_verbose_and_args() {
+        let cmd = RuntimeCleanCommand::new(
+            "test-runtime".to_string(),
+            "avocado.toml".to_string(),
+            true,
+            None,
+            Some(vec!["--cap-add=SYS_ADMIN".to_string()]),
+            Some(vec!["--nogpgcheck".to_string()]),
+        );
+
+        assert_eq!(cmd.runtime, "test-runtime");
+        assert_eq!(cmd.config_path, "avocado.toml");
+        assert!(cmd.verbose);
+        assert_eq!(cmd.target, None);
+        assert_eq!(
+            cmd.container_args,
+            Some(vec!["--cap-add=SYS_ADMIN".to_string()])
+        );
+        assert_eq!(cmd.dnf_args, Some(vec!["--nogpgcheck".to_string()]));
+    }
+}

--- a/src/commands/runtime/dnf.rs
+++ b/src/commands/runtime/dnf.rs
@@ -1,0 +1,383 @@
+use anyhow::Result;
+
+use crate::utils::config::Config;
+use crate::utils::container::{RunConfig, SdkContainer};
+use crate::utils::output::{print_error, print_info, print_success, OutputLevel};
+use crate::utils::target::resolve_target;
+
+pub struct RuntimeDnfCommand {
+    config_path: String,
+    runtime: String,
+    command: Vec<String>,
+    verbose: bool,
+    target: Option<String>,
+    container_args: Option<Vec<String>>,
+    dnf_args: Option<Vec<String>>,
+}
+
+impl RuntimeDnfCommand {
+    pub fn new(
+        config_path: String,
+        runtime: String,
+        command: Vec<String>,
+        verbose: bool,
+        target: Option<String>,
+        container_args: Option<Vec<String>>,
+        dnf_args: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            config_path,
+            runtime,
+            command,
+            verbose,
+            target,
+            container_args,
+            dnf_args,
+        }
+    }
+
+    pub async fn execute(&self) -> Result<()> {
+        let config = Config::load(&self.config_path)?;
+        let content = std::fs::read_to_string(&self.config_path)?;
+        let parsed: toml::Value = toml::from_str(&content)?;
+
+        self.validate_runtime_exists(&parsed)?;
+        let container_image = self.get_container_image(&parsed)?;
+        let target = self.resolve_target_architecture(&parsed)?;
+
+        // Get repo_url and repo_release from config
+        let repo_url = config.get_sdk_repo_url();
+        let repo_release = config.get_sdk_repo_release();
+
+        self.execute_dnf_command(&parsed, &container_image, &target, repo_url, repo_release)
+            .await
+    }
+
+    fn validate_runtime_exists(&self, parsed: &toml::Value) -> Result<()> {
+        let runtime_section = parsed.get("runtime").ok_or_else(|| {
+            print_error(
+                &format!("Runtime '{}' not found in configuration.", self.runtime),
+                OutputLevel::Normal,
+            );
+            anyhow::anyhow!("No runtime section found")
+        })?;
+
+        let runtime_table = runtime_section
+            .as_table()
+            .ok_or_else(|| anyhow::anyhow!("Invalid runtime section format"))?;
+
+        if !runtime_table.contains_key(&self.runtime) {
+            print_error(
+                &format!("Runtime '{}' not found in configuration.", self.runtime),
+                OutputLevel::Normal,
+            );
+            return Err(anyhow::anyhow!("Runtime not found"));
+        }
+
+        Ok(())
+    }
+
+    fn get_container_image(&self, parsed: &toml::Value) -> Result<String> {
+        parsed
+            .get("sdk")
+            .and_then(|sdk| sdk.get("image"))
+            .and_then(|img| img.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                anyhow::anyhow!("No container image specified in config under 'sdk.image'.")
+            })
+    }
+
+    fn resolve_target_architecture(&self, parsed: &toml::Value) -> Result<String> {
+        let config_target = self.extract_config_target(parsed);
+        let resolved_target = resolve_target(self.target.as_deref(), config_target.as_deref());
+
+        resolved_target.ok_or_else(|| {
+            anyhow::anyhow!(
+                "No target architecture specified for runtime '{}'. Use --target, AVOCADO_TARGET env var, or config under 'runtime.{}.target'.",
+                self.runtime, self.runtime
+            )
+        })
+    }
+
+    fn extract_config_target(&self, parsed: &toml::Value) -> Option<String> {
+        parsed
+            .get("runtime")
+            .and_then(|runtime| runtime.as_table())
+            .and_then(|runtime_table| runtime_table.get(&self.runtime))
+            .and_then(|runtime_config| runtime_config.get("target"))
+            .and_then(|target| target.as_str())
+            .map(|s| s.to_string())
+    }
+
+    async fn execute_dnf_command(
+        &self,
+        parsed: &toml::Value,
+        container_image: &str,
+        target: &str,
+        repo_url: Option<&String>,
+        repo_release: Option<&String>,
+    ) -> Result<()> {
+        let container_helper = SdkContainer::new();
+
+        // Perform runtime setup first
+        self.setup_runtime_environment(
+            parsed,
+            &container_helper,
+            container_image,
+            target,
+            repo_url,
+            repo_release,
+        )
+        .await?;
+
+        // Build and execute DNF command
+        let dnf_command = self.build_dnf_command();
+        self.run_dnf_command(
+            &container_helper,
+            container_image,
+            target,
+            &dnf_command,
+            repo_url,
+            repo_release,
+        )
+        .await
+    }
+
+    async fn setup_runtime_environment(
+        &self,
+        _config: &toml::Value,
+        container_helper: &SdkContainer,
+        container_image: &str,
+        target: &str,
+        repo_url: Option<&String>,
+        repo_release: Option<&String>,
+    ) -> Result<()> {
+        let check_cmd = format!("test -d $AVOCADO_PREFIX/runtimes/{}", self.runtime);
+
+        let config = RunConfig {
+            container_image: container_image.to_string(),
+            target: target.to_string(),
+            command: check_cmd,
+            verbose: self.verbose,
+            source_environment: false, // don't source environment
+            interactive: false,
+            repo_url: repo_url.cloned(),
+            repo_release: repo_release.cloned(),
+            container_args: self.container_args.clone(),
+            dnf_args: self.dnf_args.clone(),
+            ..Default::default()
+        };
+        let dir_exists = container_helper.run_in_container(config).await?;
+
+        if !dir_exists {
+            self.create_runtime_directory(
+                container_helper,
+                container_image,
+                target,
+                repo_url,
+                repo_release,
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn create_runtime_directory(
+        &self,
+        container_helper: &SdkContainer,
+        container_image: &str,
+        target: &str,
+        repo_url: Option<&String>,
+        repo_release: Option<&String>,
+    ) -> Result<()> {
+        let setup_cmd = format!(
+            "mkdir -p $AVOCADO_PREFIX/runtimes/{}/var/lib && cp -rf $AVOCADO_PREFIX/rootfs/var/lib/rpm $AVOCADO_PREFIX/runtimes/{}/var/lib",
+            self.runtime, self.runtime
+        );
+
+        let config = RunConfig {
+            container_image: container_image.to_string(),
+            target: target.to_string(),
+            command: setup_cmd,
+            verbose: self.verbose,
+            source_environment: false, // don't source environment
+            interactive: false,
+            repo_url: repo_url.cloned(),
+            repo_release: repo_release.cloned(),
+            container_args: self.container_args.clone(),
+            dnf_args: self.dnf_args.clone(),
+            ..Default::default()
+        };
+        let setup_success = container_helper.run_in_container(config).await?;
+
+        if !setup_success {
+            print_error(
+                &format!(
+                    "Failed to set up runtime directory for '{}'.",
+                    self.runtime
+                ),
+                OutputLevel::Normal,
+            );
+            return Err(anyhow::anyhow!("Failed to create runtime directory"));
+        }
+
+        if self.verbose {
+            print_info(
+                &format!("Created runtime directory for '{}'.", self.runtime),
+                OutputLevel::Normal,
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn run_dnf_command(
+        &self,
+        container_helper: &SdkContainer,
+        container_image: &str,
+        target: &str,
+        dnf_command: &str,
+        repo_url: Option<&String>,
+        repo_release: Option<&String>,
+    ) -> Result<()> {
+        if self.verbose {
+            print_info(
+                &format!("Running DNF command: {dnf_command}"),
+                OutputLevel::Normal,
+            );
+        }
+
+        let config = RunConfig {
+            container_image: container_image.to_string(),
+            target: target.to_string(),
+            command: dnf_command.to_string(),
+            verbose: self.verbose,
+            source_environment: true, // source environment for DNF
+            interactive: true,
+            repo_url: repo_url.cloned(),
+            repo_release: repo_release.cloned(),
+            container_args: self.container_args.clone(),
+            dnf_args: self.dnf_args.clone(),
+            ..Default::default()
+        };
+        let success = container_helper.run_in_container(config).await?;
+
+        if success {
+            print_success("DNF command completed successfully.", OutputLevel::Normal);
+            Ok(())
+        } else {
+            print_error("DNF command failed.", OutputLevel::Normal);
+            Err(anyhow::anyhow!("DNF command failed"))
+        }
+    }
+
+    fn build_dnf_command(&self) -> String {
+        let installroot = format!("$AVOCADO_PREFIX/runtimes/{}", self.runtime);
+        let command_args_str = self.command.join(" ");
+        let dnf_args_str = if let Some(args) = &self.dnf_args {
+            format!(" {} ", args.join(" "))
+        } else {
+            String::new()
+        };
+
+        format!(
+            r#"
+RPM_CONFIGDIR="$AVOCADO_SDK_PREFIX/usr/lib/rpm" \
+RPM_ETCCONFIGDIR="$DNF_SDK_TARGET_PREFIX" \
+$DNF_SDK_HOST \
+    $DNF_SDK_HOST_OPTS \
+    $DNF_SDK_TARGET_REPO_CONF \
+    --installroot={installroot} \
+    {dnf_args_str} \
+    {command_args_str}
+"#
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let cmd = RuntimeDnfCommand::new(
+            "avocado.toml".to_string(),
+            "test-runtime".to_string(),
+            vec!["list".to_string(), "installed".to_string()],
+            false,
+            Some("x86_64".to_string()),
+            None,
+            None,
+        );
+
+        assert_eq!(cmd.config_path, "avocado.toml");
+        assert_eq!(cmd.runtime, "test-runtime");
+        assert_eq!(cmd.command, vec!["list", "installed"]);
+        assert!(!cmd.verbose);
+        assert_eq!(cmd.target, Some("x86_64".to_string()));
+    }
+
+    #[test]
+    fn test_new_with_verbose_and_args() {
+        let cmd = RuntimeDnfCommand::new(
+            "avocado.toml".to_string(),
+            "test-runtime".to_string(),
+            vec!["install".to_string(), "gcc".to_string()],
+            true,
+            None,
+            Some(vec!["--cap-add=SYS_ADMIN".to_string()]),
+            Some(vec!["--nogpgcheck".to_string()]),
+        );
+
+        assert_eq!(cmd.config_path, "avocado.toml");
+        assert_eq!(cmd.runtime, "test-runtime");
+        assert_eq!(cmd.command, vec!["install", "gcc"]);
+        assert!(cmd.verbose);
+        assert_eq!(cmd.target, None);
+        assert_eq!(cmd.container_args, Some(vec!["--cap-add=SYS_ADMIN".to_string()]));
+        assert_eq!(cmd.dnf_args, Some(vec!["--nogpgcheck".to_string()]));
+    }
+
+    #[test]
+    fn test_build_dnf_command() {
+        let cmd = RuntimeDnfCommand::new(
+            "avocado.toml".to_string(),
+            "test-runtime".to_string(),
+            vec!["list".to_string(), "installed".to_string()],
+            false,
+            None,
+            None,
+            Some(vec!["--nogpgcheck".to_string()]),
+        );
+
+        let dnf_command = cmd.build_dnf_command();
+
+        assert!(dnf_command.contains("--installroot=$AVOCADO_PREFIX/runtimes/test-runtime"));
+        assert!(dnf_command.contains("list installed"));
+        assert!(dnf_command.contains("--nogpgcheck"));
+        assert!(dnf_command.contains("RPM_CONFIGDIR"));
+        assert!(dnf_command.contains("$DNF_SDK_HOST"));
+    }
+
+    #[test]
+    fn test_build_dnf_command_no_args() {
+        let cmd = RuntimeDnfCommand::new(
+            "avocado.toml".to_string(),
+            "my-runtime".to_string(),
+            vec!["search".to_string(), "python".to_string()],
+            false,
+            None,
+            None,
+            None,
+        );
+
+        let dnf_command = cmd.build_dnf_command();
+
+        assert!(dnf_command.contains("--installroot=$AVOCADO_PREFIX/runtimes/my-runtime"));
+        assert!(dnf_command.contains("search python"));
+        assert!(!dnf_command.contains("--nogpgcheck"));
+    }
+}

--- a/src/commands/runtime/dnf.rs
+++ b/src/commands/runtime/dnf.rs
@@ -214,10 +214,7 @@ impl RuntimeDnfCommand {
 
         if !setup_success {
             print_error(
-                &format!(
-                    "Failed to set up runtime directory for '{}'.",
-                    self.runtime
-                ),
+                &format!("Failed to set up runtime directory for '{}'.", self.runtime),
                 OutputLevel::Normal,
             );
             return Err(anyhow::anyhow!("Failed to create runtime directory"));
@@ -337,7 +334,10 @@ mod tests {
         assert_eq!(cmd.command, vec!["install", "gcc"]);
         assert!(cmd.verbose);
         assert_eq!(cmd.target, None);
-        assert_eq!(cmd.container_args, Some(vec!["--cap-add=SYS_ADMIN".to_string()]));
+        assert_eq!(
+            cmd.container_args,
+            Some(vec!["--cap-add=SYS_ADMIN".to_string()])
+        );
         assert_eq!(cmd.dnf_args, Some(vec!["--nogpgcheck".to_string()]));
     }
 

--- a/src/commands/runtime/install.rs
+++ b/src/commands/runtime/install.rs
@@ -1,0 +1,639 @@
+use anyhow::{Context, Result};
+
+use crate::utils::config::Config;
+use crate::utils::container::{RunConfig, SdkContainer};
+use crate::utils::output::{print_debug, print_error, print_info, print_success, OutputLevel};
+use crate::utils::target::resolve_target;
+
+pub struct RuntimeInstallCommand {
+    runtime: Option<String>,
+    config_path: String,
+    verbose: bool,
+    force: bool,
+    target: Option<String>,
+    container_args: Option<Vec<String>>,
+    dnf_args: Option<Vec<String>>,
+}
+
+impl RuntimeInstallCommand {
+    pub fn new(
+        runtime: Option<String>,
+        config_path: String,
+        verbose: bool,
+        force: bool,
+        target: Option<String>,
+        container_args: Option<Vec<String>>,
+        dnf_args: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            runtime,
+            config_path,
+            verbose,
+            force,
+            target,
+            container_args,
+            dnf_args,
+        }
+    }
+
+    pub async fn execute(&self) -> Result<()> {
+        // Load the configuration and parse raw TOML
+        let config = Config::load(&self.config_path)?;
+        let content = std::fs::read_to_string(&self.config_path)?;
+        let parsed: toml::Value = toml::from_str(&content)?;
+
+        // Get repo_url and repo_release from config
+        let repo_url = config.get_sdk_repo_url();
+        let repo_release = config.get_sdk_repo_release();
+
+        // Check if runtime section exists
+        let runtime_section = match parsed.get("runtime") {
+            Some(runtime) => runtime,
+            None => {
+                if self.runtime.is_some() {
+                    print_error(
+                        &format!(
+                            "Runtime '{}' not found in configuration.",
+                            self.runtime.as_ref().unwrap()
+                        ),
+                        OutputLevel::Normal,
+                    );
+                    return Ok(());
+                } else {
+                    print_info("No runtimes found in configuration.", OutputLevel::Normal);
+                    return Ok(());
+                }
+            }
+        };
+
+        // Determine which runtimes to install dependencies for
+        let runtimes_to_install = if let Some(runtime_name) = &self.runtime {
+            // Single runtime specified
+            if !runtime_section.as_table().unwrap().contains_key(runtime_name) {
+                print_error(
+                    &format!("Runtime '{runtime_name}' not found in configuration."),
+                    OutputLevel::Normal,
+                );
+                return Ok(());
+            }
+            vec![runtime_name.clone()]
+        } else {
+            // No runtime specified - install for all runtimes
+            match runtime_section.as_table() {
+                Some(table) => table.keys().cloned().collect(),
+                None => vec![],
+            }
+        };
+
+        if runtimes_to_install.is_empty() {
+            print_info("No runtimes to install dependencies for.", OutputLevel::Normal);
+            return Ok(());
+        }
+
+        // Get SDK configuration
+        let sdk_config = parsed.get("sdk").context("No SDK configuration found")?;
+        let container_image = sdk_config
+            .get("image")
+            .and_then(|v| v.as_str())
+            .context("No SDK container image specified in configuration")?;
+
+        // Initialize container helper
+        let container_helper = SdkContainer::new();
+
+        // Install dependencies for each runtime
+        for runtime_name in &runtimes_to_install {
+            print_info(
+                &format!("Installing dependencies for runtime '{runtime_name}'"),
+                OutputLevel::Normal,
+            );
+
+            let success = self
+                .install_single_runtime(
+                    &parsed,
+                    runtime_name,
+                    &container_helper,
+                    container_image,
+                    repo_url,
+                    repo_release,
+                )
+                .await?;
+
+            if !success {
+                print_error(
+                    &format!("Failed to install dependencies for runtime '{runtime_name}'"),
+                    OutputLevel::Normal,
+                );
+                return Ok(());
+            }
+        }
+
+        print_success(
+            &format!(
+                "Successfully installed dependencies for {} runtime(s)",
+                runtimes_to_install.len()
+            ),
+            OutputLevel::Normal,
+        );
+
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn install_single_runtime(
+        &self,
+        config: &toml::Value,
+        runtime: &str,
+        container_helper: &SdkContainer,
+        container_image: &str,
+        repo_url: Option<&String>,
+        repo_release: Option<&String>,
+    ) -> Result<bool> {
+        // Get runtime configuration
+        let runtime_config = config["runtime"][runtime].clone();
+
+        // Get target from runtime config
+        let config_target = runtime_config
+            .get("target")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        // Resolve target architecture
+        let target_arch = resolve_target(self.target.as_deref(), config_target.as_deref())
+            .with_context(|| {
+                format!(
+                    "No target architecture specified for runtime '{runtime}'. Use --target, AVOCADO_TARGET env var, or config under 'runtime.{runtime}.target'"
+                )
+            })?;
+
+        // Create the commands to check and set up the runtime installroot
+        let installroot_path = format!("$AVOCADO_PREFIX/runtimes/{runtime}");
+        let check_command = format!("[ -d {installroot_path} ]");
+        let setup_command = format!(
+            "mkdir -p {installroot_path}/var/lib && cp -rf $AVOCADO_PREFIX/rootfs/var/lib/rpm {installroot_path}/var/lib"
+        );
+
+        // First check if the installroot already exists
+        let run_config = RunConfig {
+            container_image: container_image.to_string(),
+            target: target_arch.clone(),
+            command: check_command,
+            verbose: self.verbose,
+            source_environment: false, // don't source environment
+            interactive: false,
+            repo_url: repo_url.cloned(),
+            repo_release: repo_release.cloned(),
+            container_args: self.container_args.clone(),
+            dnf_args: self.dnf_args.clone(),
+            ..Default::default()
+        };
+        let installroot_exists = container_helper.run_in_container(run_config).await?;
+
+        if !installroot_exists {
+            // Create the installroot
+            let run_config = RunConfig {
+                container_image: container_image.to_string(),
+                target: target_arch.clone(),
+                command: setup_command,
+                verbose: self.verbose,
+                source_environment: false, // don't source environment
+                interactive: false,
+                repo_url: repo_url.cloned(),
+                repo_release: repo_release.cloned(),
+                container_args: self.container_args.clone(),
+                dnf_args: self.dnf_args.clone(),
+                ..Default::default()
+            };
+            let success = container_helper.run_in_container(run_config).await?;
+
+            if success {
+                print_success(
+                    &format!("Created installroot for runtime '{runtime}'."),
+                    OutputLevel::Normal,
+                );
+            } else {
+                print_error(
+                    &format!("Failed to create installroot for runtime '{runtime}'."),
+                    OutputLevel::Normal,
+                );
+                return Ok(false);
+            }
+        }
+
+        // Install dependencies if they exist
+        let dependencies = runtime_config.get("dependencies");
+
+        if let Some(toml::Value::Table(deps_map)) = dependencies {
+            // Build list of packages to install (excluding extension references)
+            let mut packages = Vec::new();
+            for (package_name, version_spec) in deps_map {
+                // Skip extension dependencies (identified by 'ext' key)
+                if let toml::Value::Table(spec_map) = version_spec {
+                    if spec_map.contains_key("ext") {
+                        if self.verbose {
+                            print_debug(
+                                &format!("Skipping extension dependency '{package_name}' (will be handled by runtime build)"),
+                                OutputLevel::Normal,
+                            );
+                        }
+                        continue;
+                    }
+                }
+
+                let package_name_and_version = if version_spec.as_str().is_some() {
+                    let version = version_spec.as_str().unwrap();
+                    if version == "*" {
+                        package_name.clone()
+                    } else {
+                        format!("{package_name}-{version}")
+                    }
+                } else if let toml::Value::Table(spec_map) = version_spec {
+                    if let Some(version) = spec_map.get("version") {
+                        let version = version.as_str().unwrap_or("*");
+                        if version == "*" {
+                            package_name.clone()
+                        } else {
+                            format!("{package_name}-{version}")
+                        }
+                    } else {
+                        package_name.clone()
+                    }
+                } else {
+                    package_name.clone()
+                };
+
+                packages.push(package_name_and_version);
+            }
+
+            if !packages.is_empty() {
+                print_info(
+                    &format!("Installing {} package(s) for runtime '{runtime}'", packages.len()),
+                    OutputLevel::Normal,
+                );
+
+                let yes = if self.force { "-y" } else { "" };
+                let dnf_args_str = if let Some(args) = &self.dnf_args {
+                    format!(" {} ", args.join(" "))
+                } else {
+                    String::new()
+                };
+
+                let dnf_command = format!(
+                    r#"RPM_CONFIGDIR="$AVOCADO_SDK_PREFIX/usr/lib/rpm" \
+RPM_ETCCONFIGDIR="$DNF_SDK_TARGET_PREFIX" \
+$DNF_SDK_HOST \
+    $DNF_SDK_HOST_OPTS \
+    $DNF_SDK_TARGET_REPO_CONF \
+    --installroot={installroot_path} \
+    {} \
+    install \
+    {} \
+    {}"#,
+                    dnf_args_str,
+                    yes,
+                    packages.join(" ")
+                );
+
+                if self.verbose {
+                    print_debug(
+                        &format!("Installing packages: {}", packages.join(", ")),
+                        OutputLevel::Normal,
+                    );
+                }
+
+                let run_config = RunConfig {
+                    container_image: container_image.to_string(),
+                    target: target_arch.clone(),
+                    command: dnf_command,
+                    verbose: self.verbose,
+                    source_environment: true, // need environment for DNF
+                    interactive: !self.force,
+                    repo_url: repo_url.cloned(),
+                    repo_release: repo_release.cloned(),
+                    container_args: self.container_args.clone(),
+                    dnf_args: self.dnf_args.clone(),
+                    ..Default::default()
+                };
+                let success = container_helper.run_in_container(run_config).await?;
+
+                if !success {
+                    print_error(
+                        &format!("Failed to install packages for runtime '{runtime}'"),
+                        OutputLevel::Normal,
+                    );
+                    return Ok(false);
+                }
+
+                print_success(
+                    &format!("Successfully installed packages for runtime '{runtime}'"),
+                    OutputLevel::Normal,
+                );
+            } else {
+                print_info(
+                    &format!("No packages to install for runtime '{runtime}'"),
+                    OutputLevel::Normal,
+                );
+            }
+        } else {
+            print_info(
+                &format!("No dependencies configured for runtime '{runtime}'"),
+                OutputLevel::Normal,
+            );
+        }
+
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn create_test_config_file(temp_dir: &TempDir, content: &str) -> String {
+        let config_path = temp_dir.path().join("avocado.toml");
+        fs::write(&config_path, content).unwrap();
+        config_path.to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn test_new() {
+        let cmd = RuntimeInstallCommand::new(
+            Some("test-runtime".to_string()),
+            "avocado.toml".to_string(),
+            false,
+            false,
+            Some("x86_64".to_string()),
+            None,
+            None,
+        );
+
+        assert_eq!(cmd.runtime, Some("test-runtime".to_string()));
+        assert_eq!(cmd.config_path, "avocado.toml");
+        assert!(!cmd.verbose);
+        assert!(!cmd.force);
+        assert_eq!(cmd.target, Some("x86_64".to_string()));
+    }
+
+    #[test]
+    fn test_new_all_runtimes() {
+        let cmd = RuntimeInstallCommand::new(
+            None,
+            "avocado.toml".to_string(),
+            true,
+            true,
+            None,
+            Some(vec!["--arg1".to_string()]),
+            Some(vec!["--dnf-arg".to_string()]),
+        );
+
+        assert_eq!(cmd.runtime, None);
+        assert_eq!(cmd.config_path, "avocado.toml");
+        assert!(cmd.verbose);
+        assert!(cmd.force);
+        assert_eq!(cmd.target, None);
+        assert_eq!(cmd.container_args, Some(vec!["--arg1".to_string()]));
+        assert_eq!(cmd.dnf_args, Some(vec!["--dnf-arg".to_string()]));
+    }
+
+    #[tokio::test]
+    async fn test_execute_no_runtime_section() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_content = r#"
+[sdk]
+image = "test-image"
+"#;
+        let config_path = create_test_config_file(&temp_dir, config_content);
+
+        let cmd = RuntimeInstallCommand::new(
+            Some("test-runtime".to_string()),
+            config_path,
+            false,
+            false,
+            Some("x86_64".to_string()),
+            None,
+            None,
+        );
+
+        // Should handle missing runtime section gracefully
+        let result = cmd.execute().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_execute_runtime_not_found() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_content = r#"
+[sdk]
+image = "test-image"
+
+[runtime.other-runtime]
+target = "x86_64"
+"#;
+        let config_path = create_test_config_file(&temp_dir, config_content);
+
+        let cmd = RuntimeInstallCommand::new(
+            Some("test-runtime".to_string()),
+            config_path,
+            false,
+            false,
+            Some("x86_64".to_string()),
+            None,
+            None,
+        );
+
+        // Should handle missing specific runtime gracefully
+        let result = cmd.execute().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_execute_no_sdk_config() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_content = r#"
+[runtime.test-runtime]
+target = "x86_64"
+
+[runtime.test-runtime.dependencies]
+gcc = "11.0"
+"#;
+        let config_path = create_test_config_file(&temp_dir, config_content);
+
+        let cmd = RuntimeInstallCommand::new(
+            Some("test-runtime".to_string()),
+            config_path,
+            false,
+            false,
+            Some("x86_64".to_string()),
+            None,
+            None,
+        );
+
+        // Should fail without SDK configuration
+        let result = cmd.execute().await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No SDK configuration found"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_no_container_image() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_content = r#"
+[sdk]
+# Missing image field
+
+[runtime.test-runtime]
+target = "x86_64"
+
+[runtime.test-runtime.dependencies]
+gcc = "11.0"
+"#;
+        let config_path = create_test_config_file(&temp_dir, config_content);
+
+        let cmd = RuntimeInstallCommand::new(
+            Some("test-runtime".to_string()),
+            config_path,
+            false,
+            false,
+            Some("x86_64".to_string()),
+            None,
+            None,
+        );
+
+        // Should fail without container image
+        let result = cmd.execute().await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No SDK container image specified"));
+    }
+
+    #[test]
+    fn test_runtime_install_with_package_dependencies() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_content = r#"
+[sdk]
+image = "test-image"
+
+[runtime.test-runtime]
+target = "x86_64"
+
+[runtime.test-runtime.dependencies]
+gcc = "11.0"
+python3 = "*"
+curl = { version = "7.0" }
+app-ext = { ext = "my-extension" }
+
+[ext.my-extension]
+version = "2.0"
+sysext = true
+"#;
+        let config_path = create_test_config_file(&temp_dir, config_content);
+
+        let cmd = RuntimeInstallCommand::new(
+            Some("test-runtime".to_string()),
+            config_path,
+            false,
+            false,
+            Some("x86_64".to_string()),
+            None,
+            None,
+        );
+
+        // This would test the actual installation logic, but since we can't run containers in tests,
+        // we'll just verify the command was created correctly
+        assert_eq!(cmd.runtime, Some("test-runtime".to_string()));
+        assert_eq!(cmd.target, Some("x86_64".to_string()));
+    }
+
+    #[test]
+    fn test_runtime_install_all_runtimes() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_content = r#"
+[sdk]
+image = "test-image"
+
+[runtime.runtime1]
+target = "x86_64"
+
+[runtime.runtime1.dependencies]
+gcc = "11.0"
+
+[runtime.runtime2]
+target = "aarch64"
+
+[runtime.runtime2.dependencies]
+python3 = "*"
+"#;
+        let config_path = create_test_config_file(&temp_dir, config_content);
+
+        let cmd = RuntimeInstallCommand::new(
+            None, // Install for all runtimes
+            config_path,
+            false,
+            false,
+            Some("x86_64".to_string()),
+            None,
+            None,
+        );
+
+        // This would install dependencies for both runtime1 and runtime2
+        assert_eq!(cmd.runtime, None);
+    }
+
+    #[test]
+    fn test_runtime_install_no_dependencies() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_content = r#"
+[sdk]
+image = "test-image"
+
+[runtime.test-runtime]
+target = "x86_64"
+# No dependencies section
+"#;
+        let config_path = create_test_config_file(&temp_dir, config_content);
+
+        let cmd = RuntimeInstallCommand::new(
+            Some("test-runtime".to_string()),
+            config_path,
+            false,
+            false,
+            Some("x86_64".to_string()),
+            None,
+            None,
+        );
+
+        // Should handle runtime with no dependencies gracefully
+        assert_eq!(cmd.runtime, Some("test-runtime".to_string()));
+    }
+
+    #[test]
+    fn test_runtime_install_with_container_and_dnf_args() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_content = r#"
+[sdk]
+image = "test-image"
+
+[runtime.test-runtime]
+target = "x86_64"
+
+[runtime.test-runtime.dependencies]
+gcc = "*"
+"#;
+        let config_path = create_test_config_file(&temp_dir, config_content);
+
+        let cmd = RuntimeInstallCommand::new(
+            Some("test-runtime".to_string()),
+            config_path,
+            true,
+            true,
+            Some("x86_64".to_string()),
+            Some(vec!["--cap-add=SYS_ADMIN".to_string()]),
+            Some(vec!["--nogpgcheck".to_string()]),
+        );
+
+        assert_eq!(cmd.container_args, Some(vec!["--cap-add=SYS_ADMIN".to_string()]));
+        assert_eq!(cmd.dnf_args, Some(vec!["--nogpgcheck".to_string()]));
+        assert!(cmd.verbose);
+        assert!(cmd.force);
+    }
+}

--- a/src/commands/runtime/install.rs
+++ b/src/commands/runtime/install.rs
@@ -69,7 +69,11 @@ impl RuntimeInstallCommand {
         // Determine which runtimes to install dependencies for
         let runtimes_to_install = if let Some(runtime_name) = &self.runtime {
             // Single runtime specified
-            if !runtime_section.as_table().unwrap().contains_key(runtime_name) {
+            if !runtime_section
+                .as_table()
+                .unwrap()
+                .contains_key(runtime_name)
+            {
                 print_error(
                     &format!("Runtime '{runtime_name}' not found in configuration."),
                     OutputLevel::Normal,
@@ -86,7 +90,10 @@ impl RuntimeInstallCommand {
         };
 
         if runtimes_to_install.is_empty() {
-            print_info("No runtimes to install dependencies for.", OutputLevel::Normal);
+            print_info(
+                "No runtimes to install dependencies for.",
+                OutputLevel::Normal,
+            );
             return Ok(());
         }
 
@@ -266,7 +273,10 @@ impl RuntimeInstallCommand {
 
             if !packages.is_empty() {
                 print_info(
-                    &format!("Installing {} package(s) for runtime '{runtime}'", packages.len()),
+                    &format!(
+                        "Installing {} package(s) for runtime '{runtime}'",
+                        packages.len()
+                    ),
                     OutputLevel::Normal,
                 );
 
@@ -472,7 +482,10 @@ gcc = "11.0"
         // Should fail without SDK configuration
         let result = cmd.execute().await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("No SDK configuration found"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No SDK configuration found"));
     }
 
     #[tokio::test]
@@ -503,7 +516,10 @@ gcc = "11.0"
         // Should fail without container image
         let result = cmd.execute().await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("No SDK container image specified"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No SDK container image specified"));
     }
 
     #[test]
@@ -631,7 +647,10 @@ gcc = "*"
             Some(vec!["--nogpgcheck".to_string()]),
         );
 
-        assert_eq!(cmd.container_args, Some(vec!["--cap-add=SYS_ADMIN".to_string()]));
+        assert_eq!(
+            cmd.container_args,
+            Some(vec!["--cap-add=SYS_ADMIN".to_string()])
+        );
         assert_eq!(cmd.dnf_args, Some(vec!["--nogpgcheck".to_string()]));
         assert!(cmd.verbose);
         assert!(cmd.force);

--- a/src/commands/runtime/mod.rs
+++ b/src/commands/runtime/mod.rs
@@ -1,4 +1,5 @@
 pub mod build;
+pub mod clean;
 pub mod deps;
 pub mod dnf;
 pub mod install;
@@ -6,6 +7,7 @@ pub mod list;
 pub mod provision;
 
 pub use build::RuntimeBuildCommand;
+pub use clean::RuntimeCleanCommand;
 pub use deps::RuntimeDepsCommand;
 pub use dnf::RuntimeDnfCommand;
 pub use install::RuntimeInstallCommand;

--- a/src/commands/runtime/mod.rs
+++ b/src/commands/runtime/mod.rs
@@ -1,9 +1,11 @@
 pub mod build;
 pub mod deps;
+pub mod install;
 pub mod list;
 pub mod provision;
 
 pub use build::RuntimeBuildCommand;
 pub use deps::RuntimeDepsCommand;
+pub use install::RuntimeInstallCommand;
 pub use list::RuntimeListCommand;
 pub use provision::RuntimeProvisionCommand;

--- a/src/commands/runtime/mod.rs
+++ b/src/commands/runtime/mod.rs
@@ -1,11 +1,13 @@
 pub mod build;
 pub mod deps;
+pub mod dnf;
 pub mod install;
 pub mod list;
 pub mod provision;
 
 pub use build::RuntimeBuildCommand;
 pub use deps::RuntimeDepsCommand;
+pub use dnf::RuntimeDnfCommand;
 pub use install::RuntimeInstallCommand;
 pub use list::RuntimeListCommand;
 pub use provision::RuntimeProvisionCommand;

--- a/src/commands/sdk/deps.rs
+++ b/src/commands/sdk/deps.rs
@@ -127,9 +127,7 @@ impl SdkDepsCommand {
         sections: &mut HashMap<String, Vec<(String, String, String)>>,
     ) {
         if let Some(sdk_deps) = config.get_sdk_dependencies() {
-            let section_packages = sections
-                .entry("SDK Dependencies".to_string())
-                .or_default();
+            let section_packages = sections.entry("SDK Dependencies".to_string()).or_default();
             for (package_name, package_spec) in sdk_deps {
                 let resolved_deps =
                     self.resolve_package_dependencies(config, package_name, package_spec);

--- a/src/commands/sdk/deps.rs
+++ b/src/commands/sdk/deps.rs
@@ -1,7 +1,7 @@
 //! SDK deps command implementation.
 
 use anyhow::{Context, Result};
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use crate::utils::{
     config::Config,
@@ -25,88 +25,146 @@ impl SdkDepsCommand {
         let config = Config::load(&self.config_path)
             .with_context(|| format!("Failed to load config from {}", self.config_path))?;
 
-        let packages = self.list_packages_from_config(&config);
-        self.display_packages(&packages);
+        // Read the config file content for extension parsing
+        let config_content = std::fs::read_to_string(&self.config_path)
+            .with_context(|| format!("Failed to read config file {}", self.config_path))?;
+
+        let sections = self.list_packages_by_section(&config, &config_content)?;
+        let total_count = self.display_packages_by_section(&sections);
 
         print_success(
-            &format!("Listed {} dependency(s).", packages.len()),
+            &format!("Listed {} dependency(s).", total_count),
             OutputLevel::Normal,
         );
 
         Ok(())
     }
 
-    fn display_packages(&self, packages: &[(String, String, String)]) {
-        for (dep_type, pkg_name, pkg_version) in packages {
-            println!("({dep_type}) {pkg_name} ({pkg_version})");
+    fn display_packages_by_section(&self, sections: &HashMap<String, Vec<(String, String, String)>>) -> usize {
+        let mut total_count = 0;
+        let mut first_section = true;
+
+        // Define section order for consistent output
+        let section_order = vec![
+            "SDK Dependencies".to_string(),
+            "Compile Dependencies".to_string(),
+        ];
+
+        // Display ordered sections first
+        for section_name in &section_order {
+            if let Some(packages) = sections.get(section_name) {
+                if !packages.is_empty() {
+                    if !first_section {
+                        println!();
+                    }
+                    first_section = false;
+
+                    println!("\x1b[1;37m{}\x1b[0m", section_name);
+                    for (dep_type, pkg_name, pkg_version) in packages {
+                        println!("({dep_type}) {pkg_name} ({pkg_version})");
+                        total_count += 1;
+                    }
+                }
+            }
         }
+
+        // Display extension sections (sorted alphabetically)
+        let mut extension_sections: Vec<_> = sections
+            .iter()
+            .filter(|(name, _)| !section_order.contains(name))
+            .collect();
+        extension_sections.sort_by_key(|(name, _)| name.as_str());
+
+        for (section_name, packages) in extension_sections {
+            if !packages.is_empty() {
+                if !first_section {
+                    println!();
+                }
+                first_section = false;
+
+                println!("\x1b[1;37m{}\x1b[0m", section_name);
+                for (dep_type, pkg_name, pkg_version) in packages {
+                    println!("({dep_type}) {pkg_name} ({pkg_version})");
+                    total_count += 1;
+                }
+            }
+        }
+
+        total_count
     }
 
-    /// List all packages from SDK dependencies and compile dependencies in config
-    fn list_packages_from_config(&self, config: &Config) -> Vec<(String, String, String)> {
-        let mut all_packages = Vec::new();
+    /// List all packages grouped by section
+    fn list_packages_by_section(&self, config: &Config, config_content: &str) -> Result<HashMap<String, Vec<(String, String, String)>>> {
+        let mut sections = HashMap::new();
 
         // Process SDK dependencies
-        self.collect_sdk_dependencies(config, &mut all_packages);
+        self.collect_sdk_dependencies_by_section(config, &mut sections);
+
+        // Process extension SDK dependencies
+        self.collect_extension_sdk_dependencies_by_section(config, config_content, &mut sections)?;
 
         // Process compile dependencies
-        self.collect_compile_dependencies(config, &mut all_packages);
+        self.collect_compile_dependencies_by_section(config, &mut sections);
 
-        self.deduplicate_and_sort(all_packages)
+        // Sort packages within each section
+        for (_, packages) in sections.iter_mut() {
+            packages.sort_by(|a, b| a.1.cmp(&b.1)); // Sort by package name
+        }
+
+        Ok(sections)
     }
 
-    fn collect_sdk_dependencies(
+    fn collect_sdk_dependencies_by_section(
         &self,
         config: &Config,
-        packages: &mut Vec<(String, String, String)>,
+        sections: &mut HashMap<String, Vec<(String, String, String)>>,
     ) {
         if let Some(sdk_deps) = config.get_sdk_dependencies() {
+            let section_packages = sections.entry("SDK Dependencies".to_string()).or_insert_with(Vec::new);
             for (package_name, package_spec) in sdk_deps {
                 let resolved_deps =
                     self.resolve_package_dependencies(config, package_name, package_spec);
-                packages.extend(resolved_deps);
+                section_packages.extend(resolved_deps);
             }
         }
     }
 
-    fn collect_compile_dependencies(
+    fn collect_extension_sdk_dependencies_by_section(
         &self,
         config: &Config,
-        packages: &mut Vec<(String, String, String)>,
-    ) {
-        let compile_dependencies = config.get_compile_dependencies();
-        for (_section_name, dependencies) in compile_dependencies {
+        config_content: &str,
+        sections: &mut HashMap<String, Vec<(String, String, String)>>,
+    ) -> Result<()> {
+        let extension_sdk_deps = config.get_extension_sdk_dependencies(config_content)?;
+
+        for (ext_name, dependencies) in extension_sdk_deps {
+            let section_name = format!("Extension SDK Dependencies ({})", ext_name);
+            let section_packages = sections.entry(section_name).or_insert_with(Vec::new);
             for (package_name, package_spec) in dependencies {
                 let resolved_deps =
-                    self.resolve_package_dependencies(config, package_name, package_spec);
-                packages.extend(resolved_deps);
+                    self.resolve_package_dependencies(config, &package_name, &package_spec);
+                section_packages.extend(resolved_deps);
             }
         }
+        Ok(())
     }
 
-    fn deduplicate_and_sort(
+    fn collect_compile_dependencies_by_section(
         &self,
-        packages: Vec<(String, String, String)>,
-    ) -> Vec<(String, String, String)> {
-        let mut seen = HashSet::new();
-        let mut unique_packages = Vec::new();
-
-        for package in packages {
-            if seen.insert(package.clone()) {
-                unique_packages.push(package);
+        config: &Config,
+        sections: &mut HashMap<String, Vec<(String, String, String)>>,
+    ) {
+        let compile_dependencies = config.get_compile_dependencies();
+        if !compile_dependencies.is_empty() {
+            let section_packages = sections.entry("Compile Dependencies".to_string()).or_insert_with(Vec::new);
+            for (_section_name, dependencies) in compile_dependencies {
+                for (package_name, package_spec) in dependencies {
+                    let resolved_deps =
+                        self.resolve_package_dependencies(config, package_name, package_spec);
+                    section_packages.extend(resolved_deps);
+                }
             }
         }
-
-        // Sort: extensions first, then packages, both alphabetically
-        unique_packages.sort_by(|a, b| {
-            match (a.0.as_str(), b.0.as_str()) {
-                ("ext", "pkg") => std::cmp::Ordering::Less,
-                ("pkg", "ext") => std::cmp::Ordering::Greater,
-                _ => a.1.cmp(&b.1), // Sort by package name alphabetically
-            }
-        });
-
-        unique_packages
     }
 
     /// Resolve dependencies for a package specification
@@ -264,7 +322,7 @@ cmake = "*"
     }
 
     #[test]
-    fn test_list_packages_from_config() {
+    fn test_list_packages_by_section() {
         let cmd = SdkDepsCommand::new("test.toml".to_string());
 
         let config_content = r#"
@@ -282,15 +340,75 @@ dependencies = { make = "4.3" }
         write!(temp_file, "{config_content}").unwrap();
         let config = Config::load(temp_file.path()).unwrap();
 
-        let packages = cmd.list_packages_from_config(&config);
+        let sections = cmd.list_packages_by_section(&config, config_content).unwrap();
 
-        // Should have 3 packages: cmake, gcc, and make
-        assert_eq!(packages.len(), 3);
+        // Should have 2 sections: SDK Dependencies and Compile Dependencies
+        assert_eq!(sections.len(), 2);
 
-        // Verify packages exist (order may vary due to sorting)
-        let package_names: Vec<&String> = packages.iter().map(|(_, name, _)| name).collect();
-        assert!(package_names.contains(&&"cmake".to_string()));
-        assert!(package_names.contains(&&"gcc".to_string()));
-        assert!(package_names.contains(&&"make".to_string()));
+        // Check SDK Dependencies section
+        let sdk_packages = sections.get("SDK Dependencies").unwrap();
+        assert_eq!(sdk_packages.len(), 2);
+        let sdk_package_names: Vec<&String> = sdk_packages.iter().map(|(_, name, _)| name).collect();
+        assert!(sdk_package_names.contains(&&"cmake".to_string()));
+        assert!(sdk_package_names.contains(&&"gcc".to_string()));
+
+        // Check Compile Dependencies section
+        let compile_packages = sections.get("Compile Dependencies").unwrap();
+        assert_eq!(compile_packages.len(), 1);
+        let compile_package_names: Vec<&String> = compile_packages.iter().map(|(_, name, _)| name).collect();
+        assert!(compile_package_names.contains(&&"make".to_string()));
+    }
+
+    #[test]
+    fn test_multiple_extensions_with_same_dependency() {
+        let cmd = SdkDepsCommand::new("test.toml".to_string());
+
+        let config_content = r#"
+[sdk]
+image = "test-image"
+
+[sdk.dependencies]
+cmake = "*"
+
+[ext.avocado-dev]
+sysext = true
+confext = true
+
+[ext.avocado-dev.sdk.dependencies]
+nativesdk-avocado-hitl = "*"
+
+[ext.avocado-dev1]
+sysext = true
+confext = true
+
+[ext.avocado-dev1.sdk.dependencies]
+nativesdk-avocado-hitl = "*"
+"#;
+        let mut temp_file = NamedTempFile::new().unwrap();
+        write!(temp_file, "{config_content}").unwrap();
+        let config = Config::load(temp_file.path()).unwrap();
+
+        let sections = cmd.list_packages_by_section(&config, config_content).unwrap();
+
+        // Should have 3 sections: SDK Dependencies and 2 Extension sections
+        assert_eq!(sections.len(), 3);
+
+        // Check SDK Dependencies section
+        let sdk_packages = sections.get("SDK Dependencies").unwrap();
+        assert_eq!(sdk_packages.len(), 1);
+        let sdk_package_names: Vec<&String> = sdk_packages.iter().map(|(_, name, _)| name).collect();
+        assert!(sdk_package_names.contains(&&"cmake".to_string()));
+
+        // Check first extension
+        let ext1_packages = sections.get("Extension SDK Dependencies (avocado-dev)").unwrap();
+        assert_eq!(ext1_packages.len(), 1);
+        let ext1_package_names: Vec<&String> = ext1_packages.iter().map(|(_, name, _)| name).collect();
+        assert!(ext1_package_names.contains(&&"nativesdk-avocado-hitl".to_string()));
+
+        // Check second extension
+        let ext2_packages = sections.get("Extension SDK Dependencies (avocado-dev1)").unwrap();
+        assert_eq!(ext2_packages.len(), 1);
+        let ext2_package_names: Vec<&String> = ext2_packages.iter().map(|(_, name, _)| name).collect();
+        assert!(ext2_package_names.contains(&&"nativesdk-avocado-hitl".to_string()));
     }
 }

--- a/src/commands/sdk/install.rs
+++ b/src/commands/sdk/install.rs
@@ -76,7 +76,8 @@ impl SdkInstallCommand {
         let sdk_dependencies = config.get_sdk_dependencies();
 
         // Get extension SDK dependencies
-        let extension_sdk_dependencies = config.get_extension_sdk_dependencies(&config_content)
+        let extension_sdk_dependencies = config
+            .get_extension_sdk_dependencies(&config_content)
             .with_context(|| "Failed to parse extension SDK dependencies")?;
 
         // Get compile section dependencies
@@ -101,7 +102,7 @@ impl SdkInstallCommand {
         for (ext_name, ext_deps) in &extension_sdk_dependencies {
             if self.verbose {
                 print_info(
-                    &format!("Adding SDK dependencies from extension '{}'", ext_name),
+                    &format!("Adding SDK dependencies from extension '{ext_name}'"),
                     OutputLevel::Normal,
                 );
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,9 @@ enum SdkCommands {
         /// Enable verbose output
         #[arg(short, long)]
         verbose: bool,
+        /// Source the avocado SDK environment before running command
+        #[arg(short, long)]
+        env: bool,
         /// Command and arguments to run in container
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<String>,
@@ -550,6 +553,7 @@ async fn main() -> Result<()> {
                 rm,
                 interactive,
                 verbose,
+                env,
                 command,
                 container_args,
                 dnf_args,
@@ -566,6 +570,7 @@ async fn main() -> Result<()> {
                     rm,
                     interactive,
                     verbose,
+                    env,
                     cmd,
                     cli.target,
                     container_args,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ use commands::ext::{
 };
 use commands::init::InitCommand;
 use commands::runtime::{
-    RuntimeBuildCommand, RuntimeDepsCommand, RuntimeDnfCommand, RuntimeInstallCommand,
-    RuntimeListCommand, RuntimeProvisionCommand,
+    RuntimeBuildCommand, RuntimeCleanCommand, RuntimeDepsCommand, RuntimeDnfCommand,
+    RuntimeInstallCommand, RuntimeListCommand, RuntimeProvisionCommand,
 };
 use commands::sdk::{
     SdkCleanCommand, SdkCompileCommand, SdkDepsCommand, SdkDnfCommand, SdkInstallCommand,
@@ -274,6 +274,24 @@ enum RuntimeCommands {
         #[arg(long = "dnf-arg", num_args = 1, allow_hyphen_values = true, action = clap::ArgAction::Append)]
         dnf_args: Option<Vec<String>>,
     },
+    /// Clean runtime installroot directory
+    Clean {
+        /// Path to avocado.toml configuration file
+        #[arg(short = 'C', long, default_value = "avocado.toml")]
+        config: String,
+        /// Enable verbose output
+        #[arg(short, long)]
+        verbose: bool,
+        /// Name of the runtime to clean
+        #[arg(short = 'r', long = "runtime", required = true)]
+        runtime: String,
+        /// Additional arguments to pass to the container runtime
+        #[arg(long = "container-arg", num_args = 1, allow_hyphen_values = true, action = clap::ArgAction::Append)]
+        container_args: Option<Vec<String>>,
+        /// Additional arguments to pass to DNF commands
+        #[arg(long = "dnf-arg", num_args = 1, allow_hyphen_values = true, action = clap::ArgAction::Append)]
+        dnf_args: Option<Vec<String>>,
+    },
 }
 
 #[tokio::main]
@@ -379,6 +397,24 @@ async fn main() -> Result<()> {
                     dnf_args,
                 );
                 dnf_cmd.execute().await?;
+                Ok(())
+            }
+            RuntimeCommands::Clean {
+                config,
+                verbose,
+                runtime,
+                container_args,
+                dnf_args,
+            } => {
+                let clean_cmd = RuntimeCleanCommand::new(
+                    runtime,
+                    config,
+                    verbose,
+                    cli.target,
+                    container_args,
+                    dnf_args,
+                );
+                clean_cmd.execute().await?;
                 Ok(())
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,8 @@ use commands::ext::{
 };
 use commands::init::InitCommand;
 use commands::runtime::{
-    RuntimeBuildCommand, RuntimeDepsCommand, RuntimeDnfCommand, RuntimeInstallCommand, RuntimeListCommand, RuntimeProvisionCommand,
+    RuntimeBuildCommand, RuntimeDepsCommand, RuntimeDnfCommand, RuntimeInstallCommand,
+    RuntimeListCommand, RuntimeProvisionCommand,
 };
 use commands::sdk::{
     SdkCleanCommand, SdkCompileCommand, SdkDepsCommand, SdkDnfCommand, SdkInstallCommand,

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -67,8 +67,8 @@ impl Config {
 
     /// Load configuration from a TOML string
     pub fn load_from_str(content: &str) -> Result<Self> {
-        let config: Config = toml::from_str(content)
-            .with_context(|| "Failed to parse TOML configuration")?;
+        let config: Config =
+            toml::from_str(content).with_context(|| "Failed to parse TOML configuration")?;
 
         Ok(config)
     }
@@ -112,9 +112,12 @@ impl Config {
 
     /// Get extension SDK dependencies from configuration
     /// Returns a HashMap where keys are extension names and values are their SDK dependencies
-    pub fn get_extension_sdk_dependencies(&self, config_content: &str) -> Result<HashMap<String, HashMap<String, toml::Value>>> {
-        let parsed: toml::Value = toml::from_str(config_content)
-            .with_context(|| "Failed to parse TOML configuration")?;
+    pub fn get_extension_sdk_dependencies(
+        &self,
+        config_content: &str,
+    ) -> Result<HashMap<String, HashMap<String, toml::Value>>> {
+        let parsed: toml::Value =
+            toml::from_str(config_content).with_context(|| "Failed to parse TOML configuration")?;
 
         let mut extension_sdk_deps = HashMap::new();
 
@@ -234,20 +237,37 @@ nativesdk-tool = "*"
 "#;
 
         let config = Config::load_from_str(config_content).unwrap();
-        let extension_deps = config.get_extension_sdk_dependencies(config_content).unwrap();
+        let extension_deps = config
+            .get_extension_sdk_dependencies(config_content)
+            .unwrap();
 
         assert_eq!(extension_deps.len(), 2);
 
         // Check avocado-dev extension dependencies
         let avocado_dev_deps = extension_deps.get("avocado-dev").unwrap();
         assert_eq!(avocado_dev_deps.len(), 2);
-        assert_eq!(avocado_dev_deps.get("nativesdk-avocado-hitl").unwrap().as_str(), Some("*"));
-        assert_eq!(avocado_dev_deps.get("nativesdk-something-else").unwrap().as_str(), Some("1.2.3"));
+        assert_eq!(
+            avocado_dev_deps
+                .get("nativesdk-avocado-hitl")
+                .unwrap()
+                .as_str(),
+            Some("*")
+        );
+        assert_eq!(
+            avocado_dev_deps
+                .get("nativesdk-something-else")
+                .unwrap()
+                .as_str(),
+            Some("1.2.3")
+        );
 
         // Check another-ext extension dependencies
         let another_ext_deps = extension_deps.get("another-ext").unwrap();
         assert_eq!(another_ext_deps.len(), 1);
-        assert_eq!(another_ext_deps.get("nativesdk-tool").unwrap().as_str(), Some("*"));
+        assert_eq!(
+            another_ext_deps.get("nativesdk-tool").unwrap().as_str(),
+            Some("*")
+        );
     }
 
     #[test]

--- a/src/utils/output.rs
+++ b/src/utils/output.rs
@@ -39,9 +39,9 @@ pub fn print_plain(message: &str, _level: OutputLevel) {
 }
 
 /// Print a debug message to stderr with gray color (only in debug builds)
-pub fn print_debug(message: &str, _level: OutputLevel) {
+pub fn print_debug(_message: &str, _level: OutputLevel) {
     #[cfg(debug_assertions)]
-    eprintln!("\x1b[90m[DEBUG]\x1b[0m {message}");
+    eprintln!("\x1b[90m[DEBUG]\x1b[0m {_message}");
 }
 
 /// Flush stdout to ensure immediate output

--- a/tests/commands/avocado/runtime/clean.rs
+++ b/tests/commands/avocado/runtime/clean.rs
@@ -1,0 +1,107 @@
+//! Tests for runtime clean command.
+
+use crate::common;
+
+#[test]
+fn test_long_help() {
+    common::assert_cmd(&["runtime", "clean", "--help"], None, None);
+}
+
+#[test]
+fn test_short_help() {
+    common::assert_cmd(&["runtime", "clean", "-h"], None, None);
+}
+
+#[test]
+fn test_clean_missing_config() {
+    common::refute_cmd(
+        &[
+            "runtime",
+            "clean",
+            "-C",
+            "nonexistent.toml",
+            "-r",
+            "test-runtime",
+        ],
+        None,
+        None,
+    );
+}
+
+#[test]
+fn test_clean_missing_runtime_flag() {
+    // Should fail because runtime flag is required
+    common::refute_cmd(&["runtime", "clean"], None, None);
+}
+
+#[test]
+fn test_clean_with_verbose() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(
+        &["runtime", "clean", "--verbose", "-r", "test-runtime"],
+        None,
+        None,
+    );
+}
+
+#[test]
+fn test_clean_with_runtime_flag() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["runtime", "clean", "-r", "test-runtime"], None, None);
+}
+
+#[test]
+fn test_clean_with_container_args() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(
+        &[
+            "runtime",
+            "clean",
+            "-r",
+            "test-runtime",
+            "--container-arg",
+            "--cap-add=SYS_ADMIN",
+        ],
+        None,
+        None,
+    );
+}
+
+#[test]
+fn test_clean_with_dnf_args() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(
+        &[
+            "runtime",
+            "clean",
+            "-r",
+            "test-runtime",
+            "--dnf-arg",
+            "--nogpgcheck",
+        ],
+        None,
+        None,
+    );
+}
+
+#[test]
+fn test_clean_with_all_options() {
+    // Test with all available options
+    common::refute_cmd(
+        &[
+            "runtime",
+            "clean",
+            "-C",
+            "custom.toml",
+            "--verbose",
+            "-r",
+            "test-runtime",
+            "--container-arg",
+            "--cap-add=SYS_ADMIN",
+            "--dnf-arg",
+            "--nogpgcheck",
+        ],
+        None,
+        None,
+    );
+}

--- a/tests/commands/avocado/runtime/dnf.rs
+++ b/tests/commands/avocado/runtime/dnf.rs
@@ -14,7 +14,19 @@ fn test_short_help() {
 
 #[test]
 fn test_dnf_missing_config() {
-    common::refute_cmd(&["runtime", "dnf", "-C", "nonexistent.toml", "-r", "test-runtime", "list"], None, None);
+    common::refute_cmd(
+        &[
+            "runtime",
+            "dnf",
+            "-C",
+            "nonexistent.toml",
+            "-r",
+            "test-runtime",
+            "list",
+        ],
+        None,
+        None,
+    );
 }
 
 #[test]
@@ -26,35 +38,94 @@ fn test_dnf_missing_runtime_flag() {
 #[test]
 fn test_dnf_with_verbose() {
     // This will fail with a real config but tests argument parsing
-    common::refute_cmd(&["runtime", "dnf", "--verbose", "-r", "test-runtime", "list"], None, None);
+    common::refute_cmd(
+        &["runtime", "dnf", "--verbose", "-r", "test-runtime", "list"],
+        None,
+        None,
+    );
 }
 
 #[test]
 fn test_dnf_with_runtime_flag() {
     // This will fail with a real config but tests argument parsing
-    common::refute_cmd(&["runtime", "dnf", "-r", "test-runtime", "list", "installed"], None, None);
+    common::refute_cmd(
+        &["runtime", "dnf", "-r", "test-runtime", "list", "installed"],
+        None,
+        None,
+    );
 }
 
 #[test]
 fn test_dnf_with_container_args() {
     // This will fail with a real config but tests argument parsing
-    common::refute_cmd(&["runtime", "dnf", "-r", "test-runtime", "--container-arg", "--cap-add=SYS_ADMIN", "search", "python"], None, None);
+    common::refute_cmd(
+        &[
+            "runtime",
+            "dnf",
+            "-r",
+            "test-runtime",
+            "--container-arg",
+            "--cap-add=SYS_ADMIN",
+            "search",
+            "python",
+        ],
+        None,
+        None,
+    );
 }
 
 #[test]
 fn test_dnf_with_dnf_args() {
     // This will fail with a real config but tests argument parsing
-    common::refute_cmd(&["runtime", "dnf", "-r", "test-runtime", "--dnf-arg", "--nogpgcheck", "install", "gcc"], None, None);
+    common::refute_cmd(
+        &[
+            "runtime",
+            "dnf",
+            "-r",
+            "test-runtime",
+            "--dnf-arg",
+            "--nogpgcheck",
+            "install",
+            "gcc",
+        ],
+        None,
+        None,
+    );
 }
 
 #[test]
 fn test_dnf_complex_command() {
     // Test with multiple arguments to the DNF command
-    common::refute_cmd(&["runtime", "dnf", "-r", "test-runtime", "install", "--enablerepo=updates", "gcc", "make"], None, None);
+    common::refute_cmd(
+        &[
+            "runtime",
+            "dnf",
+            "-r",
+            "test-runtime",
+            "install",
+            "--enablerepo=updates",
+            "gcc",
+            "make",
+        ],
+        None,
+        None,
+    );
 }
 
 #[test]
 fn test_dnf_with_hyphen_values() {
     // Test that hyphen values are allowed in command arguments
-    common::refute_cmd(&["runtime", "dnf", "-r", "test-runtime", "install", "--exclude=kernel*", "gcc"], None, None);
+    common::refute_cmd(
+        &[
+            "runtime",
+            "dnf",
+            "-r",
+            "test-runtime",
+            "install",
+            "--exclude=kernel*",
+            "gcc",
+        ],
+        None,
+        None,
+    );
 }

--- a/tests/commands/avocado/runtime/dnf.rs
+++ b/tests/commands/avocado/runtime/dnf.rs
@@ -1,0 +1,60 @@
+//! Tests for runtime dnf command.
+
+use crate::common;
+
+#[test]
+fn test_long_help() {
+    common::assert_cmd(&["runtime", "dnf", "--help"], None, None);
+}
+
+#[test]
+fn test_short_help() {
+    common::assert_cmd(&["runtime", "dnf", "-h"], None, None);
+}
+
+#[test]
+fn test_dnf_missing_config() {
+    common::refute_cmd(&["runtime", "dnf", "-C", "nonexistent.toml", "-r", "test-runtime", "list"], None, None);
+}
+
+#[test]
+fn test_dnf_missing_runtime_flag() {
+    // Should fail because runtime flag is required
+    common::refute_cmd(&["runtime", "dnf", "list"], None, None);
+}
+
+#[test]
+fn test_dnf_with_verbose() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["runtime", "dnf", "--verbose", "-r", "test-runtime", "list"], None, None);
+}
+
+#[test]
+fn test_dnf_with_runtime_flag() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["runtime", "dnf", "-r", "test-runtime", "list", "installed"], None, None);
+}
+
+#[test]
+fn test_dnf_with_container_args() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["runtime", "dnf", "-r", "test-runtime", "--container-arg", "--cap-add=SYS_ADMIN", "search", "python"], None, None);
+}
+
+#[test]
+fn test_dnf_with_dnf_args() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["runtime", "dnf", "-r", "test-runtime", "--dnf-arg", "--nogpgcheck", "install", "gcc"], None, None);
+}
+
+#[test]
+fn test_dnf_complex_command() {
+    // Test with multiple arguments to the DNF command
+    common::refute_cmd(&["runtime", "dnf", "-r", "test-runtime", "install", "--enablerepo=updates", "gcc", "make"], None, None);
+}
+
+#[test]
+fn test_dnf_with_hyphen_values() {
+    // Test that hyphen values are allowed in command arguments
+    common::refute_cmd(&["runtime", "dnf", "-r", "test-runtime", "install", "--exclude=kernel*", "gcc"], None, None);
+}

--- a/tests/commands/avocado/runtime/install.rs
+++ b/tests/commands/avocado/runtime/install.rs
@@ -14,7 +14,11 @@ fn test_short_help() {
 
 #[test]
 fn test_install_missing_config() {
-    common::refute_cmd(&["runtime", "install", "-C", "nonexistent.toml"], None, None);
+    common::refute_cmd(
+        &["runtime", "install", "-C", "nonexistent.toml"],
+        None,
+        None,
+    );
 }
 
 #[test]
@@ -38,13 +42,26 @@ fn test_install_with_force() {
 #[test]
 fn test_install_with_container_args() {
     // This will fail with a real config but tests argument parsing
-    common::refute_cmd(&["runtime", "install", "--container-arg", "--cap-add=SYS_ADMIN"], None, None);
+    common::refute_cmd(
+        &[
+            "runtime",
+            "install",
+            "--container-arg",
+            "--cap-add=SYS_ADMIN",
+        ],
+        None,
+        None,
+    );
 }
 
 #[test]
 fn test_install_with_dnf_args() {
     // This will fail with a real config but tests argument parsing
-    common::refute_cmd(&["runtime", "install", "--dnf-arg", "--nogpgcheck"], None, None);
+    common::refute_cmd(
+        &["runtime", "install", "--dnf-arg", "--nogpgcheck"],
+        None,
+        None,
+    );
 }
 
 #[test]

--- a/tests/commands/avocado/runtime/install.rs
+++ b/tests/commands/avocado/runtime/install.rs
@@ -1,0 +1,54 @@
+//! Tests for runtime install command.
+
+use crate::common;
+
+#[test]
+fn test_long_help() {
+    common::assert_cmd(&["runtime", "install", "--help"], None, None);
+}
+
+#[test]
+fn test_short_help() {
+    common::assert_cmd(&["runtime", "install", "-h"], None, None);
+}
+
+#[test]
+fn test_install_missing_config() {
+    common::refute_cmd(&["runtime", "install", "-C", "nonexistent.toml"], None, None);
+}
+
+#[test]
+fn test_install_with_verbose() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["runtime", "install", "--verbose"], None, None);
+}
+
+#[test]
+fn test_install_with_runtime_flag() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["runtime", "install", "-r", "test-runtime"], None, None);
+}
+
+#[test]
+fn test_install_with_force() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["runtime", "install", "--force"], None, None);
+}
+
+#[test]
+fn test_install_with_container_args() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["runtime", "install", "--container-arg", "--cap-add=SYS_ADMIN"], None, None);
+}
+
+#[test]
+fn test_install_with_dnf_args() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["runtime", "install", "--dnf-arg", "--nogpgcheck"], None, None);
+}
+
+#[test]
+fn test_install_all_runtimes() {
+    // Install for all runtimes (no -r flag)
+    common::refute_cmd(&["runtime", "install"], None, None);
+}

--- a/tests/commands/avocado/runtime/mod.rs
+++ b/tests/commands/avocado/runtime/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod build;
 pub mod deps;
+pub mod dnf;
 pub mod install;
 pub mod list;
 pub mod provision;

--- a/tests/commands/avocado/runtime/mod.rs
+++ b/tests/commands/avocado/runtime/mod.rs
@@ -1,6 +1,7 @@
 //! Tests for runtime command.
 
 pub mod build;
+pub mod clean;
 pub mod deps;
 pub mod dnf;
 pub mod install;

--- a/tests/commands/avocado/runtime/mod.rs
+++ b/tests/commands/avocado/runtime/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod build;
 pub mod deps;
+pub mod install;
 pub mod list;
 pub mod provision;
 

--- a/tests/commands/runtime/install.rs
+++ b/tests/commands/runtime/install.rs
@@ -1,0 +1,291 @@
+use std::fs;
+use tempfile::TempDir;
+
+use avocado_cli::commands::runtime::RuntimeInstallCommand;
+
+fn create_test_config_file(temp_dir: &TempDir, content: &str) -> String {
+    let config_path = temp_dir.path().join("avocado.toml");
+    fs::write(&config_path, content).unwrap();
+    config_path.to_string_lossy().to_string()
+}
+
+#[test]
+fn test_new() {
+    let cmd = RuntimeInstallCommand::new(
+        Some("test-runtime".to_string()),
+        "avocado.toml".to_string(),
+        false,
+        false,
+        Some("x86_64".to_string()),
+        None,
+        None,
+    );
+
+    assert_eq!(cmd.runtime, Some("test-runtime".to_string()));
+    assert_eq!(cmd.config_path, "avocado.toml");
+    assert!(!cmd.verbose);
+    assert!(!cmd.force);
+    assert_eq!(cmd.target, Some("x86_64".to_string()));
+}
+
+#[test]
+fn test_new_all_runtimes() {
+    let cmd = RuntimeInstallCommand::new(
+        None,
+        "avocado.toml".to_string(),
+        true,
+        true,
+        None,
+        Some(vec!["--arg1".to_string()]),
+        Some(vec!["--dnf-arg".to_string()]),
+    );
+
+    assert_eq!(cmd.runtime, None);
+    assert_eq!(cmd.config_path, "avocado.toml");
+    assert!(cmd.verbose);
+    assert!(cmd.force);
+    assert_eq!(cmd.target, None);
+    assert_eq!(cmd.container_args, Some(vec!["--arg1".to_string()]));
+    assert_eq!(cmd.dnf_args, Some(vec!["--dnf-arg".to_string()]));
+}
+
+#[tokio::test]
+async fn test_execute_no_runtime_section() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_content = r#"
+[sdk]
+image = "test-image"
+"#;
+    let config_path = create_test_config_file(&temp_dir, config_content);
+
+    let cmd = RuntimeInstallCommand::new(
+        Some("test-runtime".to_string()),
+        config_path,
+        false,
+        false,
+        Some("x86_64".to_string()),
+        None,
+        None,
+    );
+
+    // Should handle missing runtime section gracefully
+    let result = cmd.execute().await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_execute_runtime_not_found() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_content = r#"
+[sdk]
+image = "test-image"
+
+[runtime.other-runtime]
+target = "x86_64"
+"#;
+    let config_path = create_test_config_file(&temp_dir, config_content);
+
+    let cmd = RuntimeInstallCommand::new(
+        Some("test-runtime".to_string()),
+        config_path,
+        false,
+        false,
+        Some("x86_64".to_string()),
+        None,
+        None,
+    );
+
+    // Should handle missing specific runtime gracefully
+    let result = cmd.execute().await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_execute_no_sdk_config() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_content = r#"
+[runtime.test-runtime]
+target = "x86_64"
+
+[runtime.test-runtime.dependencies]
+gcc = "11.0"
+"#;
+    let config_path = create_test_config_file(&temp_dir, config_content);
+
+    let cmd = RuntimeInstallCommand::new(
+        Some("test-runtime".to_string()),
+        config_path,
+        false,
+        false,
+        Some("x86_64".to_string()),
+        None,
+        None,
+    );
+
+    // Should fail without SDK configuration
+    let result = cmd.execute().await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("No SDK configuration found"));
+}
+
+#[tokio::test]
+async fn test_execute_no_container_image() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_content = r#"
+[sdk]
+# Missing image field
+
+[runtime.test-runtime]
+target = "x86_64"
+
+[runtime.test-runtime.dependencies]
+gcc = "11.0"
+"#;
+    let config_path = create_test_config_file(&temp_dir, config_content);
+
+    let cmd = RuntimeInstallCommand::new(
+        Some("test-runtime".to_string()),
+        config_path,
+        false,
+        false,
+        Some("x86_64".to_string()),
+        None,
+        None,
+    );
+
+    // Should fail without container image
+    let result = cmd.execute().await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("No SDK container image specified"));
+}
+
+#[test]
+fn test_runtime_install_with_package_dependencies() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_content = r#"
+[sdk]
+image = "test-image"
+
+[runtime.test-runtime]
+target = "x86_64"
+
+[runtime.test-runtime.dependencies]
+gcc = "11.0"
+python3 = "*"
+curl = { version = "7.0" }
+app-ext = { ext = "my-extension" }
+
+[ext.my-extension]
+version = "2.0"
+sysext = true
+"#;
+    let config_path = create_test_config_file(&temp_dir, config_content);
+
+    let cmd = RuntimeInstallCommand::new(
+        Some("test-runtime".to_string()),
+        config_path,
+        false,
+        false,
+        Some("x86_64".to_string()),
+        None,
+        None,
+    );
+
+    // This would test the actual installation logic, but since we can't run containers in tests,
+    // we'll just verify the command was created correctly
+    assert_eq!(cmd.runtime, Some("test-runtime".to_string()));
+    assert_eq!(cmd.target, Some("x86_64".to_string()));
+}
+
+#[test]
+fn test_runtime_install_all_runtimes() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_content = r#"
+[sdk]
+image = "test-image"
+
+[runtime.runtime1]
+target = "x86_64"
+
+[runtime.runtime1.dependencies]
+gcc = "11.0"
+
+[runtime.runtime2]
+target = "aarch64"
+
+[runtime.runtime2.dependencies]
+python3 = "*"
+"#;
+    let config_path = create_test_config_file(&temp_dir, config_content);
+
+    let cmd = RuntimeInstallCommand::new(
+        None, // Install for all runtimes
+        config_path,
+        false,
+        false,
+        Some("x86_64".to_string()),
+        None,
+        None,
+    );
+
+    // This would install dependencies for both runtime1 and runtime2
+    assert_eq!(cmd.runtime, None);
+}
+
+#[test]
+fn test_runtime_install_no_dependencies() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_content = r#"
+[sdk]
+image = "test-image"
+
+[runtime.test-runtime]
+target = "x86_64"
+# No dependencies section
+"#;
+    let config_path = create_test_config_file(&temp_dir, config_content);
+
+    let cmd = RuntimeInstallCommand::new(
+        Some("test-runtime".to_string()),
+        config_path,
+        false,
+        false,
+        Some("x86_64".to_string()),
+        None,
+        None,
+    );
+
+    // Should handle runtime with no dependencies gracefully
+    assert_eq!(cmd.runtime, Some("test-runtime".to_string()));
+}
+
+#[test]
+fn test_runtime_install_with_container_and_dnf_args() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_content = r#"
+[sdk]
+image = "test-image"
+
+[runtime.test-runtime]
+target = "x86_64"
+
+[runtime.test-runtime.dependencies]
+gcc = "*"
+"#;
+    let config_path = create_test_config_file(&temp_dir, config_content);
+
+    let cmd = RuntimeInstallCommand::new(
+        Some("test-runtime".to_string()),
+        config_path,
+        true,
+        true,
+        Some("x86_64".to_string()),
+        Some(vec!["--cap-add=SYS_ADMIN".to_string()]),
+        Some(vec!["--nogpgcheck".to_string()]),
+    );
+
+    assert_eq!(cmd.container_args, Some(vec!["--cap-add=SYS_ADMIN".to_string()]));
+    assert_eq!(cmd.dnf_args, Some(vec!["--nogpgcheck".to_string()]));
+    assert!(cmd.verbose);
+    assert!(cmd.force);
+}


### PR DESCRIPTION
* Add runtime install to install deps for a runtime.
* Remove the special handling of `avocado-pkg-images` in runtime build
* Update the `avocado init` template to list required runtime deps
* Add `runtime dnf` similar to `ext dnf`
* Add `runtime clean`
* Fix issue with ext install internal config not leveraging installroot rpm cache and trying to install too much
* Update runtime built var part staging location to place it in the stone input path
* Add `avocado install` to easily install all deps for sdk / ext / runtime
* Add `avocado build` to build everything in order for a runtime
* Add `avocado provision --runtime` whicih calls through to runtime provision. 
* rename binary to `avocado`