### PR TITLE
update gh actions for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         run: strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
 
       - name: Upload binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset_name }}
           path: target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
@@ -135,7 +135,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v5
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Addressing this CI error:

```
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.
```

Bumped to using `actions/upload-artifact@v4` and `actions/download-artifact@v5`. We already uniquely name and path our assets, then download everything, so I don't think we need to adjust anything else.

Refs:
- https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new
- https://github.com/actions/download-artifact?tab=readme-ov-file#v5---whats-new