### PR TITLE
Config updates

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -3,7 +3,11 @@
 use anyhow::{Context, Result};
 use std::collections::HashSet;
 
-use crate::commands::{ext::{ExtBuildCommand, ExtImageCommand}, runtime::RuntimeBuildCommand, sdk::SdkCompileCommand};
+use crate::commands::{
+    ext::{ExtBuildCommand, ExtImageCommand},
+    runtime::RuntimeBuildCommand,
+    sdk::SdkCompileCommand,
+};
 use crate::utils::{
     config::Config,
     output::{print_info, print_success, OutputLevel},
@@ -149,10 +153,9 @@ impl BuildCommand {
                     self.container_args.clone(),
                     self.dnf_args.clone(),
                 );
-                ext_image_cmd
-                    .execute()
-                    .await
-                    .with_context(|| format!("Failed to create image for extension '{extension}'"))?;
+                ext_image_cmd.execute().await.with_context(|| {
+                    format!("Failed to create image for extension '{extension}'")
+                })?;
             }
         } else {
             print_info("No extension images to create.", OutputLevel::Normal);

--- a/src/commands/ext/build.rs
+++ b/src/commands/ext/build.rs
@@ -50,22 +50,12 @@ impl ExtBuildCommand {
                 anyhow::anyhow!("Extension '{}' not found in configuration.", self.extension)
             })?;
 
-        // Get extension types (sysext, confext) from boolean flags
-        let mut ext_types = Vec::new();
-        if ext_config
-            .get("sysext")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false)
-        {
-            ext_types.push("sysext");
-        }
-        if ext_config
-            .get("confext")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false)
-        {
-            ext_types.push("confext");
-        }
+        // Get extension types from the types array
+        let ext_types = ext_config
+            .get("types")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+            .unwrap_or_default();
 
         let ext_scopes = ext_config
             .get("scopes")
@@ -102,7 +92,7 @@ impl ExtBuildCommand {
 
         if ext_types.is_empty() {
             return Err(anyhow::anyhow!(
-                "Extension '{}' has sysext=false and confext=false. At least one must be true to build.",
+                "Extension '{}' has no types specified. The 'types' array must contain at least one of: 'sysext', 'confext'.",
                 self.extension
             ));
         }

--- a/src/commands/ext/image.rs
+++ b/src/commands/ext/image.rs
@@ -50,26 +50,16 @@ impl ExtImageCommand {
                 anyhow::anyhow!("Extension '{}' not found in configuration.", self.extension)
             })?;
 
-        // Get extension types (sysext, confext) from boolean flags
-        let mut ext_types = Vec::new();
-        if ext_config
-            .get("sysext")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false)
-        {
-            ext_types.push("sysext");
-        }
-        if ext_config
-            .get("confext")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false)
-        {
-            ext_types.push("confext");
-        }
+        // Get extension types from the types array
+        let ext_types = ext_config
+            .get("types")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+            .unwrap_or_default();
 
         if ext_types.is_empty() {
             return Err(anyhow::anyhow!(
-                "Extension '{}' has sysext=false and confext=false. At least one must be true to create image.",
+                "Extension '{}' has no types specified. The 'types' array must contain at least one of: 'sysext', 'confext'.",
                 self.extension
             ));
         }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -73,8 +73,7 @@ image = "avocadolinux/sdk:apollo-edge"
 nativesdk-qemu-system-x86-64 = "*"
 
 [ext.avocado-dev]
-sysext = true
-confext = true
+types = ["sysext", "confext"]
 
 [ext.avocado-dev.dependencies]
 avocado-hitl = "*"
@@ -134,8 +133,7 @@ mod tests {
         assert!(content.contains("image = \"avocadolinux/sdk:apollo-edge\""));
         assert!(content.contains("nativesdk-qemu-system-x86-64 = \"*\""));
         assert!(content.contains("[ext.avocado-dev]"));
-        assert!(content.contains("sysext = true"));
-        assert!(content.contains("confext = true"));
+        assert!(content.contains("types = [\"sysext\", \"confext\"]"));
         assert!(content.contains("avocado-hitl = \"*\""));
         assert!(content.contains("nativesdk-avocado-hitl = \"*\""));
     }

--- a/src/commands/runtime/deps.rs
+++ b/src/commands/runtime/deps.rs
@@ -160,8 +160,7 @@ app-ext = { ext = "my-extension" }
 
 [ext.my-extension]
 version = "2.0"
-sysext = true
-confext = false
+types = ["sysext"]
 "#
     }
 

--- a/src/commands/runtime/install.rs
+++ b/src/commands/runtime/install.rs
@@ -540,7 +540,7 @@ app-ext = { ext = "my-extension" }
 
 [ext.my-extension]
 version = "2.0"
-sysext = true
+types = ["sysext"]
 "#;
         let config_path = create_test_config_file(&temp_dir, config_content);
 

--- a/src/commands/sdk/deps.rs
+++ b/src/commands/sdk/deps.rs
@@ -384,15 +384,13 @@ image = "test-image"
 cmake = "*"
 
 [ext.avocado-dev]
-sysext = true
-confext = true
+types = ["sysext", "confext"]
 
 [ext.avocado-dev.sdk.dependencies]
 nativesdk-avocado-hitl = "*"
 
 [ext.avocado-dev1]
-sysext = true
-confext = true
+types = ["sysext", "confext"]
 
 [ext.avocado-dev1.sdk.dependencies]
 nativesdk-avocado-hitl = "*"

--- a/src/commands/sdk/run.rs
+++ b/src/commands/sdk/run.rs
@@ -133,6 +133,7 @@ impl SdkRunCommand {
                 &container_helper,
                 container_image,
                 &target,
+                &command,
                 repo_url,
                 repo_release,
             )
@@ -235,15 +236,16 @@ impl SdkRunCommand {
         container_helper: &SdkContainer,
         container_image: &str,
         target: &str,
+        command: &str,
         repo_url: Option<&String>,
         repo_release: Option<&String>,
     ) -> Result<bool> {
         let config = RunConfig {
             container_image: container_image.to_string(),
             target: target.to_string(),
-            command: "bash".to_string(),
+            command: command.to_string(),
             verbose: self.verbose,
-            source_environment: false,
+            source_environment: self.env,
             interactive: true,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
@@ -286,6 +288,28 @@ mod tests {
             Some(vec!["echo".to_string(), "test".to_string()])
         );
         assert_eq!(cmd.target, Some("test-target".to_string()));
+    }
+
+    #[test]
+    fn test_interactive_with_env_and_command() {
+        let cmd = SdkRunCommand::new(
+            "config.toml".to_string(),
+            None,
+            false, // detach
+            false, // rm
+            true,  // interactive
+            false, // verbose
+            true,  // env
+            Some(vec!["ls".to_string(), "-la".to_string()]),
+            Some("test-target".to_string()),
+            None,
+            None,
+        );
+
+        // Verify that the command struct stores the values correctly
+        assert!(cmd.interactive);
+        assert!(cmd.env);
+        assert_eq!(cmd.command, Some(vec!["ls".to_string(), "-la".to_string()]));
     }
 
     #[tokio::test]

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -222,15 +222,14 @@ dependencies = { gcc = "*" }
 image = "avocadolinux/sdk:apollo-edge"
 
 [ext.avocado-dev]
-sysext = true
-confext = true
+types = ["sysext", "confext"]
 
 [ext.avocado-dev.sdk.dependencies]
 nativesdk-avocado-hitl = "*"
 nativesdk-something-else = "1.2.3"
 
 [ext.another-ext]
-sysext = true
+types = ["sysext"]
 
 [ext.another-ext.sdk.dependencies]
 nativesdk-tool = "*"

--- a/tests/fixtures/configs/complex.toml
+++ b/tests/fixtures/configs/complex.toml
@@ -7,13 +7,11 @@ target = "aarch64-unknown-linux-gnu"
 board = "raspberry-pi-4"
 
 [ext.web-server]
-sysext = true
-confext = true
+types = ["sysext", "confext"]
 packages = ["nginx", "certbot", "curl"]
 
 [ext.config-only]
-sysext = false
-confext = true
+types = ["confext"]
 
 [ext.config-only.files]
 "etc/app/config.yaml" = """
@@ -30,6 +28,5 @@ Type=simple
 ExecStart=/usr/bin/myapp"""
 
 [ext.monitoring]
-sysext = true
-confext = false
+types = ["sysext"]
 packages = ["prometheus", "grafana", "node-exporter"]

--- a/tests/fixtures/configs/with-confext.toml
+++ b/tests/fixtures/configs/with-confext.toml
@@ -5,8 +5,7 @@ image = "ghcr.io/avocado-framework/avocado-sdk:latest"
 target = "x86_64-unknown-linux-gnu"
 
 [ext.test-confext]
-sysext = false
-confext = true
+types = ["confext"]
 
 [ext.test-confext.files]
 "etc/app.conf" = """

--- a/tests/fixtures/configs/with-sysext.toml
+++ b/tests/fixtures/configs/with-sysext.toml
@@ -5,6 +5,5 @@ image = "ghcr.io/avocado-framework/avocado-sdk:latest"
 target = "x86_64-unknown-linux-gnu"
 
 [ext.test-sysext]
-sysext = true
-confext = false
+types = ["sysext"]
 packages = ["curl", "wget"]


### PR DESCRIPTION
* Change `[ext.<name>]` `{sysext|confext} = BOOL` to `types: [{syseext|confext}]`
* Add support for overriding extension types in runtime dep include
* Fixed issue with running sdk commands interactive in the environment with a custom command
* add `AVOCADO_ON_MERGE=depmod` to sysext extension release metadata files when the sysext contains kernel modules. 