### PR TITLE
Updates in support of hardware in the loop 

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -57,6 +57,8 @@ impl BuildCommand {
         let content = std::fs::read_to_string(&self.config_path)?;
         let parsed: toml::Value = toml::from_str(&content)?;
 
+
+
         print_info(
             "Starting comprehensive build process...",
             OutputLevel::Normal,

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -57,8 +57,6 @@ impl BuildCommand {
         let content = std::fs::read_to_string(&self.config_path)?;
         let parsed: toml::Value = toml::from_str(&content)?;
 
-
-
         print_info(
             "Starting comprehensive build process...",
             OutputLevel::Normal,

--- a/src/commands/ext/build.rs
+++ b/src/commands/ext/build.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 
-
 use crate::utils::container::{RunConfig, SdkContainer};
 use crate::utils::output::{print_error, print_info, print_success, OutputLevel};
 use crate::utils::target::resolve_target;
@@ -40,7 +39,8 @@ impl ExtBuildCommand {
         let parsed: toml::Value = toml::from_str(&content)?;
 
         // Merge container args from config and CLI (similar to SDK commands)
-        let processed_container_args = config.merge_sdk_container_args(self.container_args.as_ref());
+        let processed_container_args =
+            config.merge_sdk_container_args(self.container_args.as_ref());
         // Get repo_url and repo_release from config
         let repo_url = config.get_sdk_repo_url();
         let repo_release = config.get_sdk_repo_release();

--- a/src/commands/ext/build.rs
+++ b/src/commands/ext/build.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use crate::utils::config::load_config;
+
 use crate::utils::container::{RunConfig, SdkContainer};
 use crate::utils::output::{print_error, print_info, print_success, OutputLevel};
 use crate::utils::target::resolve_target;
@@ -35,9 +35,12 @@ impl ExtBuildCommand {
 
     pub async fn execute(&self) -> Result<()> {
         // Load configuration and parse raw TOML
-        let config = load_config(&self.config_path)?;
+        let config = crate::utils::config::Config::load(&self.config_path)?;
         let content = std::fs::read_to_string(&self.config_path)?;
         let parsed: toml::Value = toml::from_str(&content)?;
+
+        // Merge container args from config and CLI (similar to SDK commands)
+        let processed_container_args = config.merge_sdk_container_args(self.container_args.as_ref());
         // Get repo_url and repo_release from config
         let repo_url = config.get_sdk_repo_url();
         let repo_release = config.get_sdk_repo_release();
@@ -151,6 +154,7 @@ impl ExtBuildCommand {
                         &sysext_scopes,
                         repo_url,
                         repo_release,
+                        &processed_container_args,
                     )
                     .await?
                 }
@@ -163,6 +167,7 @@ impl ExtBuildCommand {
                         &confext_scopes,
                         repo_url,
                         repo_release,
+                        &processed_container_args,
                     )
                     .await?
                 }
@@ -208,6 +213,7 @@ impl ExtBuildCommand {
         ext_scopes: &[String],
         repo_url: Option<&String>,
         repo_release: Option<&String>,
+        processed_container_args: &Option<Vec<String>>,
     ) -> Result<bool> {
         // Create the build script for sysext extension
         let build_script = self.create_sysext_build_script(ext_version, ext_scopes);
@@ -229,7 +235,7 @@ impl ExtBuildCommand {
             interactive: false,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: self.container_args.clone(),
+            container_args: processed_container_args.clone(),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };
@@ -255,6 +261,7 @@ impl ExtBuildCommand {
         ext_scopes: &[String],
         repo_url: Option<&String>,
         repo_release: Option<&String>,
+        processed_container_args: &Option<Vec<String>>,
     ) -> Result<bool> {
         // Create the build script for confext extension
         let build_script = self.create_confext_build_script(ext_version, ext_scopes);
@@ -276,7 +283,7 @@ impl ExtBuildCommand {
             interactive: false,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: self.container_args.clone(),
+            container_args: processed_container_args.clone(),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/ext/clean.rs
+++ b/src/commands/ext/clean.rs
@@ -128,7 +128,7 @@ impl ExtCleanCommand {
             verbose: self.verbose,
             source_environment: false, // don't source environment
             interactive: false,
-            container_args: self.container_args.clone(),
+            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/ext/clean.rs
+++ b/src/commands/ext/clean.rs
@@ -128,7 +128,9 @@ impl ExtCleanCommand {
             verbose: self.verbose,
             source_environment: false, // don't source environment
             interactive: false,
-            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
+            container_args: crate::utils::config::Config::process_container_args(
+                self.container_args.as_ref(),
+            ),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/ext/dnf.rs
+++ b/src/commands/ext/dnf.rs
@@ -50,8 +50,15 @@ impl ExtDnfCommand {
         let repo_url = config.get_sdk_repo_url();
         let repo_release = config.get_sdk_repo_release();
 
-        self.execute_dnf_command(&parsed, &container_image, &target, repo_url, repo_release, &merged_container_args)
-            .await
+        self.execute_dnf_command(
+            &parsed,
+            &container_image,
+            &target,
+            repo_url,
+            repo_release,
+            &merged_container_args,
+        )
+        .await
     }
 
     fn validate_extension_exists(&self, parsed: &toml::Value) -> Result<()> {
@@ -163,10 +170,7 @@ impl ExtDnfCommand {
         repo_release: Option<&String>,
         merged_container_args: &Option<Vec<String>>,
     ) -> Result<()> {
-        let check_cmd = format!(
-            "test -d $AVOCADO_EXT_SYSROOTS/{}",
-            self.extension
-        );
+        let check_cmd = format!("test -d $AVOCADO_EXT_SYSROOTS/{}", self.extension);
 
         let config = RunConfig {
             container_image: container_image.to_string(),

--- a/src/commands/ext/dnf.rs
+++ b/src/commands/ext/dnf.rs
@@ -170,7 +170,9 @@ impl ExtDnfCommand {
             interactive: false,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
+            container_args: crate::utils::config::Config::process_container_args(
+                self.container_args.as_ref(),
+            ),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };
@@ -213,7 +215,9 @@ impl ExtDnfCommand {
             interactive: false,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
+            container_args: crate::utils::config::Config::process_container_args(
+                self.container_args.as_ref(),
+            ),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };
@@ -265,7 +269,9 @@ impl ExtDnfCommand {
             interactive: true,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
+            container_args: crate::utils::config::Config::process_container_args(
+                self.container_args.as_ref(),
+            ),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/ext/dnf.rs
+++ b/src/commands/ext/dnf.rs
@@ -170,7 +170,7 @@ impl ExtDnfCommand {
             interactive: false,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: self.container_args.clone(),
+            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };
@@ -213,7 +213,7 @@ impl ExtDnfCommand {
             interactive: false,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: self.container_args.clone(),
+            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };
@@ -265,7 +265,7 @@ impl ExtDnfCommand {
             interactive: true,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: self.container_args.clone(),
+            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/ext/image.rs
+++ b/src/commands/ext/image.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 
-
 use crate::utils::container::{RunConfig, SdkContainer};
 use crate::utils::output::{print_error, print_info, print_success, OutputLevel};
 use crate::utils::target::resolve_target;
@@ -150,6 +149,7 @@ impl ExtImageCommand {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn create_image(
         &self,
         container_helper: &SdkContainer,

--- a/src/commands/ext/install.rs
+++ b/src/commands/ext/install.rs
@@ -42,6 +42,13 @@ impl ExtInstallCommand {
         let content = std::fs::read_to_string(&self.config_path)?;
         let parsed: toml::Value = toml::from_str(&content)?;
 
+        // Merge container args from config and CLI (similar to SDK commands)
+        let merged_container_args = config.merge_sdk_container_args(self.container_args.as_ref());
+
+
+
+
+
         // Get repo_url and repo_release from config
         let repo_url = config.get_sdk_repo_url();
         let repo_release = config.get_sdk_repo_release();
@@ -149,6 +156,7 @@ impl ExtInstallCommand {
                     &target,
                     repo_url,
                     repo_release,
+                    &merged_container_args,
                 )
                 .await?
             {
@@ -179,6 +187,7 @@ impl ExtInstallCommand {
         target: &str,
         repo_url: Option<&String>,
         repo_release: Option<&String>,
+        merged_container_args: &Option<Vec<String>>,
     ) -> Result<bool> {
         // Create the commands to check and set up the directory structure
         let check_command = format!("[ -d $AVOCADO_EXT_SYSROOTS/{extension} ]");
@@ -196,7 +205,7 @@ impl ExtInstallCommand {
             interactive: false,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: self.container_args.clone(),
+            container_args: merged_container_args.clone(),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };
@@ -213,7 +222,7 @@ impl ExtInstallCommand {
                 interactive: false,
                 repo_url: repo_url.cloned(),
                 repo_release: repo_release.cloned(),
-                container_args: self.container_args.clone(),
+                container_args: merged_container_args.clone(),
                 dnf_args: self.dnf_args.clone(),
                 ..Default::default()
             };
@@ -310,7 +319,7 @@ $DNF_SDK_HOST \
                     interactive: !self.force,  // interactive if not forced
                     repo_url: repo_url.cloned(),
                     repo_release: repo_release.cloned(),
-                    container_args: self.container_args.clone(),
+                    container_args: merged_container_args.clone(),
                     dnf_args: self.dnf_args.clone(),
                     ..Default::default()
                 };

--- a/src/commands/ext/install.rs
+++ b/src/commands/ext/install.rs
@@ -45,10 +45,6 @@ impl ExtInstallCommand {
         // Merge container args from config and CLI (similar to SDK commands)
         let merged_container_args = config.merge_sdk_container_args(self.container_args.as_ref());
 
-
-
-
-
         // Get repo_url and repo_release from config
         let repo_url = config.get_sdk_repo_url();
         let repo_release = config.get_sdk_repo_release();

--- a/src/commands/ext/install.rs
+++ b/src/commands/ext/install.rs
@@ -287,7 +287,6 @@ impl ExtInstallCommand {
                     r#"
 RPM_ETCCONFIGDIR=$DNF_SDK_TARGET_PREFIX \
 $DNF_SDK_HOST \
-    $DNF_SDK_HOST_OPTS \
     $DNF_SDK_TARGET_REPO_CONF \
     --installroot={} \
     {} \

--- a/src/commands/hitl/mod.rs
+++ b/src/commands/hitl/mod.rs
@@ -1,0 +1,3 @@
+pub mod server;
+
+pub use server::HitlServerCommand;

--- a/src/commands/hitl/server.rs
+++ b/src/commands/hitl/server.rs
@@ -1,0 +1,211 @@
+use crate::utils::config::Config;
+use crate::utils::container::{RunConfig, SdkContainer};
+use crate::utils::output::{print_debug, OutputLevel};
+use anyhow::Result;
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct HitlServerCommand {
+    /// Path to the avocado.toml configuration file
+    #[arg(short, long, default_value = "avocado.toml")]
+    pub config_path: String,
+
+    /// Extensions to create NFS exports for
+    #[arg(short, long = "extension")]
+    pub extensions: Vec<String>,
+
+    /// Additional container arguments
+    #[arg(long)]
+    pub container_args: Option<Vec<String>>,
+
+    /// Additional DNF arguments
+    #[arg(long)]
+    pub dnf_args: Option<Vec<String>>,
+
+    /// Target to build for
+    #[arg(short, long)]
+    pub target: Option<String>,
+
+    /// Enable verbose output
+    #[arg(short, long)]
+    pub verbose: bool,
+}
+
+impl HitlServerCommand {
+    pub async fn execute(&self) -> Result<()> {
+        let config = Config::load(&self.config_path)?;
+        let container_helper = SdkContainer::new().verbose(self.verbose);
+
+        // Determine target
+        let target = if let Some(ref target) = self.target {
+            target.clone()
+        } else if let Some(ref runtime_map) = config.runtime {
+            if let Some(first_runtime) = runtime_map.keys().next() {
+                if let Some(runtime_config) = runtime_map.get(first_runtime) {
+                    if let Some(ref target) = runtime_config.target {
+                        target.clone()
+                    } else {
+                        return Err(anyhow::anyhow!(
+                            "No target specified for runtime '{}'",
+                            first_runtime
+                        ));
+                    }
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "No target configuration found for runtime '{}'",
+                        first_runtime
+                    ));
+                }
+            } else {
+                return Err(anyhow::anyhow!("No runtime configurations found"));
+            }
+        } else {
+            return Err(anyhow::anyhow!(
+                "No target specified and no runtime configuration found"
+            ));
+        };
+
+        if self.verbose {
+            print_debug(&format!("Using target: {target}"), OutputLevel::Normal);
+        }
+
+        // Get SDK configuration
+        let (container_image, repo_url, repo_release) = if let Some(sdk_config) = &config.sdk {
+            let repo_url = sdk_config.repo_url.as_ref();
+            let repo_release = sdk_config.repo_release.as_ref();
+            let image = sdk_config
+                .image
+                .as_ref()
+                .unwrap_or(&"avocadolinux/sdk:latest".to_string())
+                .clone();
+            (image, repo_url, repo_release)
+        } else {
+            return Err(anyhow::anyhow!("No SDK configuration found in config file"));
+        };
+
+        if self.verbose {
+            print_debug(
+                &format!("Using SDK image: {container_image}"),
+                OutputLevel::Normal,
+            );
+        }
+
+        // Build container arguments with HITL-specific defaults
+        let mut container_args = vec![
+            "--net=host".to_string(),
+            "--cap-add".to_string(),
+            "DAC_READ_SEARCH".to_string(),
+            "--init".to_string(),
+        ];
+
+        // Add any additional container arguments
+        if let Some(ref additional_args) = self.container_args {
+            container_args.extend(additional_args.clone());
+        }
+
+        // Generate NFS export setup commands
+        let export_setup = self.generate_export_setup_commands(&target);
+
+        // Create the command to set up netconfig symlink, ganesha symlink, exports, and start HITL server
+        let setup_command = format!(
+            "if [ -f \"${{AVOCADO_SDK_PREFIX}}/environment-setup\" ]; then \
+             source \"${{AVOCADO_SDK_PREFIX}}/environment-setup\"; \
+             fi && \
+             ln -sf ${{AVOCADO_SDK_PREFIX}}/etc/netconfig /etc/netconfig && \
+             mkdir -p /tmp/hitl && \
+             ln -sf ${{AVOCADO_SDK_PREFIX}}/usr/var/lib/nfs/ganesha /tmp/hitl && \
+             {export_setup} \
+             exec avocado-hitl-server -c ${{AVOCADO_SDK_PREFIX}}/etc/avocado/hitl-nfs.conf"
+        );
+
+        if self.verbose {
+            print_debug("Starting HITL server container...", OutputLevel::Normal);
+            print_debug(
+                &format!("Container args: {container_args:?}"),
+                OutputLevel::Normal,
+            );
+            print_debug(
+                &format!("Setup command: {setup_command}"),
+                OutputLevel::Normal,
+            );
+        }
+
+        let config = RunConfig {
+            container_image,
+            target,
+            command: setup_command,
+            verbose: self.verbose,
+            source_environment: true,
+            interactive: true,
+            repo_url: repo_url.cloned(),
+            repo_release: repo_release.cloned(),
+            container_args: Some(container_args),
+            dnf_args: self.dnf_args.clone(),
+            ..Default::default()
+        };
+
+        container_helper.run_in_container(config).await?;
+
+        Ok(())
+    }
+
+    /// Generate shell commands to create NFS export configuration files
+    fn generate_export_setup_commands(&self, target: &str) -> String {
+        let mut commands = vec![
+            "mkdir -p ${AVOCADO_SDK_PREFIX}/etc/avocado/exports.d".to_string(),
+            "mkdir -p ${AVOCADO_SDK_PREFIX}/etc/avocado".to_string(),
+        ];
+
+        // Add/update the hitl-nfs.conf file with the exports.d directory directive
+        let exports_dir_line = format!("%dir /opt/_avocado/{target}/sdk/etc/avocado/exports.d");
+        let config_file = "${AVOCADO_SDK_PREFIX}/etc/avocado/hitl-nfs.conf".to_string();
+
+        // Check if the line exists, if not add it
+        let update_config_cmd = format!(
+            "touch {config_file} && \
+             if ! grep -q '^%dir /opt/_avocado/{target}/sdk/etc/avocado/exports.d$' {config_file}; then \
+               echo '{exports_dir_line}' >> {config_file}; \
+             fi"
+        );
+        commands.push(update_config_cmd);
+
+        if self.extensions.is_empty() {
+            return format!("{} &&", commands.join(" && "));
+        }
+
+        for (index, extension) in self.extensions.iter().enumerate() {
+            let export_id = index + 1;
+
+            // Expand the AVOCADO_PREFIX variable to its actual path
+            let extensions_path = format!("/opt/_avocado/{target}/extensions/{extension}");
+
+            let export_content = format!(
+                "EXPORT {{\n\
+                \x20\x20Export_Id = {export_id};\n\
+                \x20\x20Path = {extensions_path};\n\
+                \x20\x20Pseudo = /{extension};\n\
+                \x20\x20FSAL {{\n\
+                \x20\x20\x20\x20name = VFS;\n\
+                \x20\x20}}\n\
+                }}"
+            );
+
+            let export_file =
+                format!("${{AVOCADO_SDK_PREFIX}}/etc/avocado/exports.d/{extension}.conf");
+
+            // Create a command that writes the export content to the file using echo -e to avoid here-doc issues
+            let escaped_content = export_content.replace('\\', "\\\\").replace('"', "\\\"");
+            let write_command = format!("echo -e \"{escaped_content}\" > {export_file}");
+
+            commands.push(write_command);
+
+            if self.verbose {
+                commands.push(format!(
+                    "echo \"[DEBUG] Created NFS export for extension '{extension}' with Export_Id {export_id} at {extensions_path}\""
+                ));
+            }
+        }
+
+        format!("{} &&", commands.join(" && "))
+    }
+}

--- a/src/commands/hitl/server.rs
+++ b/src/commands/hitl/server.rs
@@ -101,9 +101,12 @@ impl HitlServerCommand {
             "--init".to_string(),
         ];
 
-        // Add any additional container arguments
+        // Add any additional container arguments with environment variable expansion
         if let Some(ref additional_args) = self.container_args {
-            container_args.extend(additional_args.clone());
+            let processed_args = Config::process_container_args(Some(additional_args));
+            if let Some(processed) = processed_args {
+                container_args.extend(processed);
+            }
         }
 
         // Generate NFS export setup commands

--- a/src/commands/hitl/server.rs
+++ b/src/commands/hitl/server.rs
@@ -254,7 +254,7 @@ mod tests {
         assert!(!commands.contains("NFS_Port ="));
     }
 
-        #[test]
+    #[test]
     fn test_generate_export_setup_commands_with_port() {
         let cmd = HitlServerCommand {
             config_path: "test.toml".to_string(),
@@ -289,7 +289,8 @@ mod tests {
 
         // Should include port update commands and debug message
         assert!(commands.contains("NFS_Port = 3049"));
-        assert!(commands.contains("[DEBUG] Updated NFS_Port to 3049 in NFS_Core_Param block in hitl-nfs.conf"));
+        assert!(commands
+            .contains("[DEBUG] Updated NFS_Port to 3049 in NFS_Core_Param block in hitl-nfs.conf"));
     }
 
     #[test]

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -52,7 +52,7 @@ impl InstallCommand {
 
     /// Execute the install command
     pub async fn execute(&self) -> Result<()> {
-                // Load the configuration to check what components exist
+        // Load the configuration to check what components exist
         let config = Config::load(&self.config_path)
             .with_context(|| format!("Failed to load config from {}", self.config_path))?;
 
@@ -103,10 +103,9 @@ impl InstallCommand {
                     self.container_args.clone(),
                     self.dnf_args.clone(),
                 );
-                ext_install_cmd
-                    .execute()
-                    .await
-                    .with_context(|| format!("Failed to install extension dependencies for '{extension}'"))?;
+                ext_install_cmd.execute().await.with_context(|| {
+                    format!("Failed to install extension dependencies for '{extension}'")
+                })?;
             }
         } else {
             print_info("No extension dependencies to install.", OutputLevel::Normal);
@@ -130,7 +129,7 @@ impl InstallCommand {
             self.verbose,
             self.force,
             self.target.clone(),
-            self.container_args.clone(),  // Pass original CLI args, let RuntimeInstallCommand merge with config
+            self.container_args.clone(), // Pass original CLI args, let RuntimeInstallCommand merge with config
             self.dnf_args.clone(),
         );
         runtime_install_cmd
@@ -172,7 +171,8 @@ impl InstallCommand {
                             .and_then(|d| d.as_table())
                         {
                             for (_dep_name, dep_spec) in dependencies {
-                                if let Some(ext_name) = dep_spec.get("ext").and_then(|v| v.as_str()) {
+                                if let Some(ext_name) = dep_spec.get("ext").and_then(|v| v.as_str())
+                                {
                                     required_extensions.insert(ext_name.to_string());
                                 }
                             }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -52,8 +52,8 @@ impl InstallCommand {
 
     /// Execute the install command
     pub async fn execute(&self) -> Result<()> {
-        // Load the configuration to check what components exist
-        let _config = Config::load(&self.config_path)
+                // Load the configuration to check what components exist
+        let config = Config::load(&self.config_path)
             .with_context(|| format!("Failed to load config from {}", self.config_path))?;
 
         print_info(
@@ -83,7 +83,7 @@ impl InstallCommand {
         );
 
         // Determine which extensions to install based on runtime dependencies
-        let extensions_to_install = self.find_required_extensions(&_config, &self.config_path)?;
+        let extensions_to_install = self.find_required_extensions(&config, &self.config_path)?;
 
         if !extensions_to_install.is_empty() {
             for extension in &extensions_to_install {
@@ -130,7 +130,7 @@ impl InstallCommand {
             self.verbose,
             self.force,
             self.target.clone(),
-            self.container_args.clone(),
+            self.container_args.clone(),  // Pass original CLI args, let RuntimeInstallCommand merge with config
             self.dnf_args.clone(),
         );
         runtime_install_cmd

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod build;
 pub mod clean;
 pub mod ext;
+pub mod hitl;
 pub mod init;
 pub mod install;
 pub mod provision;

--- a/src/commands/provision.rs
+++ b/src/commands/provision.rs
@@ -52,7 +52,7 @@ impl ProvisionCommand {
             self.verbose,
             self.force,
             self.target.clone(),
-            self.container_args.clone(),
+            crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
             self.dnf_args.clone(),
         );
 

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -42,7 +42,8 @@ impl RuntimeBuildCommand {
         let parsed: toml::Value = toml::from_str(&content)?;
 
         // Process container args with environment variable expansion
-        let processed_container_args = crate::utils::config::Config::process_container_args(self.container_args.as_ref());
+        let processed_container_args =
+            crate::utils::config::Config::process_container_args(self.container_args.as_ref());
 
         // Get repo_url and repo_release from config
         let repo_url = config.get_sdk_repo_url();

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -40,6 +40,10 @@ impl RuntimeBuildCommand {
         let config = load_config(&self.config_path)?;
         let content = std::fs::read_to_string(&self.config_path)?;
         let parsed: toml::Value = toml::from_str(&content)?;
+
+        // Process container args with environment variable expansion
+        let processed_container_args = crate::utils::config::Config::process_container_args(self.container_args.as_ref());
+
         // Get repo_url and repo_release from config
         let repo_url = config.get_sdk_repo_url();
         let repo_release = config.get_sdk_repo_release();
@@ -105,7 +109,7 @@ impl RuntimeBuildCommand {
             interactive: false,       // build script runs non-interactively
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: self.container_args.clone(),
+            container_args: processed_container_args.clone(),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/runtime/clean.rs
+++ b/src/commands/runtime/clean.rs
@@ -127,7 +127,9 @@ impl RuntimeCleanCommand {
             interactive: false,
             repo_url: None,
             repo_release: None,
-            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
+            container_args: crate::utils::config::Config::process_container_args(
+                self.container_args.as_ref(),
+            ),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/runtime/clean.rs
+++ b/src/commands/runtime/clean.rs
@@ -127,7 +127,7 @@ impl RuntimeCleanCommand {
             interactive: false,
             repo_url: None,
             repo_release: None,
-            container_args: self.container_args.clone(),
+            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/runtime/dnf.rs
+++ b/src/commands/runtime/dnf.rs
@@ -50,8 +50,15 @@ impl RuntimeDnfCommand {
         let repo_url = config.get_sdk_repo_url();
         let repo_release = config.get_sdk_repo_release();
 
-        self.execute_dnf_command(&parsed, &container_image, &target, repo_url, repo_release, &merged_container_args)
-            .await
+        self.execute_dnf_command(
+            &parsed,
+            &container_image,
+            &target,
+            repo_url,
+            repo_release,
+            &merged_container_args,
+        )
+        .await
     }
 
     fn validate_runtime_exists(&self, parsed: &toml::Value) -> Result<()> {

--- a/src/commands/runtime/dnf.rs
+++ b/src/commands/runtime/dnf.rs
@@ -164,7 +164,7 @@ impl RuntimeDnfCommand {
             interactive: false,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: self.container_args.clone(),
+            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };
@@ -206,7 +206,7 @@ impl RuntimeDnfCommand {
             interactive: false,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: self.container_args.clone(),
+            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };
@@ -255,7 +255,7 @@ impl RuntimeDnfCommand {
             interactive: true,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: self.container_args.clone(),
+            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/runtime/dnf.rs
+++ b/src/commands/runtime/dnf.rs
@@ -164,7 +164,9 @@ impl RuntimeDnfCommand {
             interactive: false,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
+            container_args: crate::utils::config::Config::process_container_args(
+                self.container_args.as_ref(),
+            ),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };
@@ -206,7 +208,9 @@ impl RuntimeDnfCommand {
             interactive: false,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
+            container_args: crate::utils::config::Config::process_container_args(
+                self.container_args.as_ref(),
+            ),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };
@@ -255,7 +259,9 @@ impl RuntimeDnfCommand {
             interactive: true,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
+            container_args: crate::utils::config::Config::process_container_args(
+                self.container_args.as_ref(),
+            ),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/runtime/install.rs
+++ b/src/commands/runtime/install.rs
@@ -293,10 +293,9 @@ impl RuntimeInstallCommand {
                 };
 
                 let dnf_command = format!(
-                    r#"RPM_CONFIGDIR="$AVOCADO_SDK_PREFIX/usr/lib/rpm" \
+                    r#"\
 RPM_ETCCONFIGDIR="$DNF_SDK_TARGET_PREFIX" \
 $DNF_SDK_HOST \
-    $DNF_SDK_HOST_OPTS \
     $DNF_SDK_TARGET_REPO_CONF \
     --installroot={installroot_path} \
     {} \

--- a/src/commands/runtime/install.rs
+++ b/src/commands/runtime/install.rs
@@ -42,6 +42,9 @@ impl RuntimeInstallCommand {
         let content = std::fs::read_to_string(&self.config_path)?;
         let parsed: toml::Value = toml::from_str(&content)?;
 
+        // Merge container args from config and CLI (similar to SDK commands)
+        let merged_container_args = config.merge_sdk_container_args(self.container_args.as_ref());
+
         // Get repo_url and repo_release from config
         let repo_url = config.get_sdk_repo_url();
         let repo_release = config.get_sdk_repo_release();
@@ -122,6 +125,7 @@ impl RuntimeInstallCommand {
                     container_image,
                     repo_url,
                     repo_release,
+                    &merged_container_args,
                 )
                 .await?;
 
@@ -154,6 +158,7 @@ impl RuntimeInstallCommand {
         container_image: &str,
         repo_url: Option<&String>,
         repo_release: Option<&String>,
+        merged_container_args: &Option<Vec<String>>,
     ) -> Result<bool> {
         // Get runtime configuration
         let runtime_config = config["runtime"][runtime].clone();
@@ -189,7 +194,7 @@ impl RuntimeInstallCommand {
             interactive: false,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: self.container_args.clone(),
+            container_args: merged_container_args.clone(),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };
@@ -206,7 +211,7 @@ impl RuntimeInstallCommand {
                 interactive: false,
                 repo_url: repo_url.cloned(),
                 repo_release: repo_release.cloned(),
-                container_args: self.container_args.clone(),
+                container_args: merged_container_args.clone(),
                 dnf_args: self.dnf_args.clone(),
                 ..Default::default()
             };
@@ -319,7 +324,7 @@ $DNF_SDK_HOST \
                     interactive: !self.force,
                     repo_url: repo_url.cloned(),
                     repo_release: repo_release.cloned(),
-                    container_args: self.container_args.clone(),
+                    container_args: merged_container_args.clone(),
                     dnf_args: self.dnf_args.clone(),
                     ..Default::default()
                 };

--- a/src/commands/runtime/provision.rs
+++ b/src/commands/runtime/provision.rs
@@ -99,7 +99,7 @@ impl RuntimeProvisionCommand {
             verbose: self.verbose,
             source_environment: true,
             interactive: !self.force,
-            container_args: self.container_args.clone(),
+            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/runtime/provision.rs
+++ b/src/commands/runtime/provision.rs
@@ -99,7 +99,9 @@ impl RuntimeProvisionCommand {
             verbose: self.verbose,
             source_environment: true,
             interactive: !self.force,
-            container_args: crate::utils::config::Config::process_container_args(self.container_args.as_ref()),
+            container_args: crate::utils::config::Config::process_container_args(
+                self.container_args.as_ref(),
+            ),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/sdk/clean.rs
+++ b/src/commands/sdk/clean.rs
@@ -47,6 +47,9 @@ impl SdkCleanCommand {
         let config = Config::load(&self.config_path)
             .with_context(|| format!("Failed to load config from {}", self.config_path))?;
 
+        // Merge container args from config with CLI args
+        let merged_container_args = config.merge_sdk_container_args(self.container_args.as_ref());
+
         // Get the SDK image from configuration
         let container_image = config.get_sdk_image().ok_or_else(|| {
             anyhow::anyhow!("No container image specified in config under 'sdk.image'")
@@ -86,7 +89,7 @@ impl SdkCleanCommand {
             interactive: false,
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: self.container_args.clone(),
+            container_args: merged_container_args.clone(),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/sdk/compile.rs
+++ b/src/commands/sdk/compile.rs
@@ -58,6 +58,9 @@ impl SdkCompileCommand {
         let config = Config::load(&self.config_path)
             .with_context(|| format!("Failed to load config from {}", self.config_path))?;
 
+        // Merge container args from config with CLI args
+        let merged_container_args = config.merge_sdk_container_args(self.container_args.as_ref());
+
         // Get compile sections from config
         let compile_sections = self.get_compile_sections_from_config(&config);
 
@@ -153,7 +156,7 @@ impl SdkCompileCommand {
                 interactive: false,
                 repo_url: repo_url.cloned(),
                 repo_release: repo_release.cloned(),
-                container_args: self.container_args.clone(),
+                container_args: merged_container_args.clone(),
                 dnf_args: self.dnf_args.clone(),
                 ..Default::default()
             };

--- a/src/commands/sdk/dnf.rs
+++ b/src/commands/sdk/dnf.rs
@@ -62,6 +62,9 @@ impl SdkDnfCommand {
         let repo_url = config.get_sdk_repo_url();
         let repo_release = config.get_sdk_repo_release();
 
+        // Merge container args from config with CLI args
+        let merged_container_args = config.merge_sdk_container_args(self.container_args.as_ref());
+
         // Resolve target with proper precedence
         let config_target = config.get_target();
         let target = resolve_target(self.target.as_deref(), config_target.as_deref())
@@ -94,6 +97,7 @@ impl SdkDnfCommand {
                 &command,
                 repo_url,
                 repo_release,
+                merged_container_args.as_ref(),
             )
             .await?;
 
@@ -117,6 +121,7 @@ impl SdkDnfCommand {
         command: &str,
         repo_url: Option<&String>,
         repo_release: Option<&String>,
+        container_args: Option<&Vec<String>>,
     ) -> Result<bool> {
         // Use the container helper's method with repo URL and release support
         let config = RunConfig {
@@ -128,7 +133,7 @@ impl SdkDnfCommand {
             interactive: true,        // allow user input for DNF prompts
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: self.container_args.clone(),
+            container_args: container_args.map(|v| v.clone()),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/sdk/dnf.rs
+++ b/src/commands/sdk/dnf.rs
@@ -113,6 +113,7 @@ impl SdkDnfCommand {
     }
 
     /// Run DNF command using container with entrypoint
+    #[allow(clippy::too_many_arguments)]
     async fn run_dnf_command(
         &self,
         container_helper: &SdkContainer,
@@ -133,7 +134,7 @@ impl SdkDnfCommand {
             interactive: true,        // allow user input for DNF prompts
             repo_url: repo_url.cloned(),
             repo_release: repo_release.cloned(),
-            container_args: container_args.map(|v| v.clone()),
+            container_args: container_args.cloned(),
             dnf_args: self.dnf_args.clone(),
             ..Default::default()
         };

--- a/src/commands/sdk/install.rs
+++ b/src/commands/sdk/install.rs
@@ -52,6 +52,9 @@ impl SdkInstallCommand {
         let config = Config::load(&self.config_path)
             .with_context(|| format!("Failed to load config from {}", self.config_path))?;
 
+        // Merge container args from config with CLI args
+        let merged_container_args = config.merge_sdk_container_args(self.container_args.as_ref());
+
         // Read the config file content for extension parsing
         let config_content = std::fs::read_to_string(&self.config_path)
             .with_context(|| format!("Failed to read config file {}", self.config_path))?;
@@ -145,7 +148,7 @@ $DNF_SDK_HOST \
                 interactive: !self.force,
                 repo_url: repo_url.cloned(),
                 repo_release: repo_release.cloned(),
-                container_args: self.container_args.clone(),
+                container_args: merged_container_args.clone(),
                 dnf_args: self.dnf_args.clone(),
                 ..Default::default()
             };
@@ -213,7 +216,7 @@ $DNF_SDK_HOST \
                         interactive: !self.force,
                         repo_url: repo_url.cloned(),
                         repo_release: repo_release.cloned(),
-                        container_args: self.container_args.clone(),
+                        container_args: merged_container_args.clone(),
                         dnf_args: self.dnf_args.clone(),
                         ..Default::default()
                     };

--- a/src/commands/sdk/run.rs
+++ b/src/commands/sdk/run.rs
@@ -191,7 +191,7 @@ impl SdkRunCommand {
         // Add volume mounts
         container_cmd.push("-v".to_string());
         container_cmd.push(format!(
-            "{}:/opt/_avocado/src:ro",
+            "{}:/opt/_avocado/src:rw",
             container_helper.cwd.display()
         ));
         container_cmd.push("-v".to_string());

--- a/src/commands/sdk/run.rs
+++ b/src/commands/sdk/run.rs
@@ -90,6 +90,9 @@ impl SdkRunCommand {
         let repo_url = config.get_sdk_repo_url();
         let repo_release = config.get_sdk_repo_release();
 
+        // Merge container args from config with CLI args
+        let merged_container_args = config.merge_sdk_container_args(self.container_args.as_ref());
+
         // Get the SDK image from configuration
         let container_image = config.get_sdk_image().ok_or_else(|| {
             anyhow::anyhow!("No container image specified in config under 'sdk.image'")
@@ -148,7 +151,7 @@ impl SdkRunCommand {
                 interactive: false,        // not interactive
                 repo_url: repo_url.cloned(),
                 repo_release: repo_release.cloned(),
-                container_args: self.container_args.clone(),
+                container_args: merged_container_args.clone(),
                 ..Default::default()
             };
             container_helper.run_in_container(config).await?

--- a/src/main.rs
+++ b/src/main.rs
@@ -662,6 +662,7 @@ async fn main() -> Result<()> {
                 dnf_args,
                 target,
                 verbose,
+                port,
             } => {
                 let hitl_cmd = HitlServerCommand {
                     config_path,
@@ -670,6 +671,7 @@ async fn main() -> Result<()> {
                     dnf_args,
                     target: target.or(cli.target),
                     verbose,
+                    port,
                 };
                 hitl_cmd.execute().await?;
                 Ok(())
@@ -917,5 +919,8 @@ enum HitlCommands {
         /// Enable verbose output
         #[arg(short, long)]
         verbose: bool,
+        /// NFS port number to use
+        #[arg(short, long)]
+        port: Option<u16>,
     },
 }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -99,7 +99,7 @@ impl Config {
         self.sdk.as_ref()?.container_args.as_ref()
     }
 
-            /// Expand environment variables in a string
+    /// Expand environment variables in a string
     pub fn expand_env_vars(input: &str) -> String {
         let mut result = input.to_string();
 
@@ -149,11 +149,14 @@ impl Config {
     /// This is a universal function that can be used by any command
     pub fn process_container_args(args: Option<&Vec<String>>) -> Option<Vec<String>> {
         args.map(|args_vec| {
-            args_vec.iter().map(|arg| Self::expand_env_vars(arg)).collect()
+            args_vec
+                .iter()
+                .map(|arg| Self::expand_env_vars(arg))
+                .collect()
         })
     }
 
-        /// Merge SDK container args from config with CLI args, expanding environment variables
+    /// Merge SDK container args from config with CLI args, expanding environment variables
     /// Returns a new Vec containing config args first, then CLI args
     pub fn merge_sdk_container_args(&self, cli_args: Option<&Vec<String>>) -> Option<Vec<String>> {
         let config_args = self.get_sdk_container_args();
@@ -375,7 +378,7 @@ container_args = ["--network=$USER-avocado", "--privileged"]
         assert_eq!(args[1], "--privileged");
     }
 
-        #[test]
+    #[test]
     fn test_merge_sdk_container_args() {
         let config_content = r#"
 [sdk]
@@ -398,7 +401,7 @@ container_args = ["--network=host", "--privileged"]
         assert_eq!(merged_args[3], "--rm");
     }
 
-        #[test]
+    #[test]
     fn test_merge_sdk_container_args_config_only() {
         let config_content = r#"
 [sdk]
@@ -436,7 +439,7 @@ image = "avocadolinux/sdk:apollo-edge"
         assert_eq!(merged_args[0], "--cap-add=SYS_ADMIN");
     }
 
-        #[test]
+    #[test]
     fn test_merge_sdk_container_args_none() {
         let config_content = r#"
 [sdk]
@@ -482,7 +485,7 @@ image = "avocadolinux/sdk:apollo-edge"
         std::env::remove_var("TEST_NETWORK");
     }
 
-        #[test]
+    #[test]
     fn test_merge_sdk_container_args_with_env_expansion() {
         // Set up test environment variable
         std::env::set_var("TEST_USER", "myuser");

--- a/src/utils/container.rs
+++ b/src/utils/container.rs
@@ -194,7 +194,7 @@ impl SdkContainer {
 
         // Default volume mounts
         container_cmd.push("-v".to_string());
-        container_cmd.push(format!("{}:/opt/_avocado/src:ro", self.cwd.display()));
+        container_cmd.push(format!("{}:/opt/_avocado/src:rw", self.cwd.display()));
         container_cmd.push("-v".to_string());
         container_cmd.push(format!("{}/_avocado:/opt/_avocado:rw", self.cwd.display()));
 

--- a/tests/commands/avocado/hitl/mod.rs
+++ b/tests/commands/avocado/hitl/mod.rs
@@ -1,0 +1,1 @@
+pub mod server;

--- a/tests/commands/avocado/hitl/server.rs
+++ b/tests/commands/avocado/hitl/server.rs
@@ -1,0 +1,76 @@
+//! Tests for hitl server command.
+
+use crate::common;
+
+#[test]
+fn test_long_help() {
+    common::assert_cmd(&["hitl", "server", "--help"], None, None);
+}
+
+#[test]
+fn test_short_help() {
+    common::assert_cmd(&["hitl", "server", "-h"], None, None);
+}
+
+#[test]
+fn test_server_missing_config() {
+    common::refute_cmd(&["hitl", "server", "-C", "nonexistent.toml"], None, None);
+}
+
+#[test]
+fn test_server_with_verbose() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["hitl", "server", "--verbose"], None, None);
+}
+
+#[test]
+fn test_server_with_target() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["hitl", "server", "-t", "qemux86-64"], None, None);
+}
+
+#[test]
+fn test_server_with_container_args() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(
+        &[
+            "hitl",
+            "server",
+            "--container-arg",
+            "--privileged",
+            "--container-arg",
+            "--device=/dev/kvm",
+        ],
+        None,
+        None,
+    );
+}
+
+#[test]
+fn test_server_with_dnf_args() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["hitl", "server", "--dnf-arg", "--assumeyes"], None, None);
+}
+
+#[test]
+fn test_server_with_extension() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(&["hitl", "server", "-e", "avocado-dev"], None, None);
+}
+
+#[test]
+fn test_server_with_multiple_extensions() {
+    // This will fail with a real config but tests argument parsing
+    common::refute_cmd(
+        &[
+            "hitl",
+            "server",
+            "--extension",
+            "avocado-dev",
+            "--extension",
+            "foo",
+        ],
+        None,
+        None,
+    );
+}

--- a/tests/commands/avocado/mod.rs
+++ b/tests/commands/avocado/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod clean;
 pub mod ext;
+pub mod hitl;
 pub mod init;
 pub mod runtime;
 pub mod sdk;


### PR DESCRIPTION
* adds `hitl server` for starting hardware in the loop server
* update build to no longer link extensions into the runtime, let `avocadoctl` do it
* Update source dir to read/write
* Allow container-args to be configured in the avocado config under `[sdk]`