### PR TITLE
Migrate state and add support for overlay src fragments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ coverage/
 
 # Avocado state directories
 _avocado/
+.avocado-state
 
 # Documentation build
 docs/_build/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "indicatif",
+ "libc",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -49,29 +49,51 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "avocado-cli"
@@ -90,7 +112,9 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-test",
  "toml",
+ "uuid",
 ]
 
 [[package]]
@@ -155,9 +179,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.42"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -165,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.42"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -177,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -272,7 +296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -414,9 +438,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heck"
@@ -705,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libredox"
@@ -847,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
@@ -1050,7 +1074,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1161,18 +1185,18 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -1220,9 +1244,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1376,6 +1400,30 @@ checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -1544,6 +1592,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,6 +1740,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1773,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,11 +1805,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1751,6 +1842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +1858,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1775,10 +1878,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1793,6 +1908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1924,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1817,6 +1944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1829,10 +1962,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.11"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ futures-util = "0.3.30"
 flate2 = "1.0.32"
 tar = "0.4.41"
 uuid = { version = "1.0", features = ["v4"] }
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ indicatif = "0.17.8"
 futures-util = "0.3.30"
 flate2 = "1.0.32"
 tar = "0.4.41"
+uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3.0"
+tokio-test = "0.4"

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -97,21 +97,22 @@ impl CleanCommand {
                 );
             }
 
-            volume_manager.remove_volume(&volume_state.volume_name).await.with_context(|| {
-                format!("Failed to remove volume: {}", volume_state.volume_name)
-            })?;
+            volume_manager
+                .remove_volume(&volume_state.volume_name)
+                .await
+                .with_context(|| {
+                    format!("Failed to remove volume: {}", volume_state.volume_name)
+                })?;
 
             print_success(
                 &format!("Removed docker volume: {}", volume_state.volume_name),
                 OutputLevel::Normal,
             );
-        } else {
-            if self.verbose {
-                print_info(
-                    "No volume state found, skipping volume cleanup.",
-                    OutputLevel::Normal,
-                );
-            }
+        } else if self.verbose {
+            print_info(
+                "No volume state found, skipping volume cleanup.",
+                OutputLevel::Normal,
+            );
         }
 
         Ok(())
@@ -131,10 +132,7 @@ impl CleanCommand {
                 OutputLevel::Normal,
             );
         } else if self.verbose {
-            print_info(
-                "No .avocado-state file found.",
-                OutputLevel::Normal,
-            );
+            print_info("No .avocado-state file found.", OutputLevel::Normal);
         }
 
         Ok(())

--- a/src/commands/ext/checkout.rs
+++ b/src/commands/ext/checkout.rs
@@ -1,0 +1,342 @@
+use anyhow::{Context, Result};
+use std::path::Path;
+use tokio::process::Command as AsyncCommand;
+
+use crate::utils::output::{print_error, print_info, print_success, OutputLevel};
+use crate::utils::volume::VolumeManager;
+
+pub struct ExtCheckoutCommand {
+    extension: String,
+    ext_path: String,
+    src_path: String,
+    config_path: String,
+    verbose: bool,
+    container_tool: String,
+}
+
+impl ExtCheckoutCommand {
+    pub fn new(
+        extension: String,
+        ext_path: String,
+        src_path: String,
+        config_path: String,
+        verbose: bool,
+        container_tool: String,
+    ) -> Self {
+        Self {
+            extension,
+            ext_path,
+            src_path,
+            config_path,
+            verbose,
+            container_tool,
+        }
+    }
+
+    pub async fn execute(&self) -> Result<()> {
+        let cwd = std::env::current_dir().context("Failed to get current directory")?;
+
+        // Get the volume state for this project
+        let volume_manager = VolumeManager::new(self.container_tool.clone(), self.verbose);
+        let volume_state = match volume_manager.get_or_create_volume(&cwd).await {
+            Ok(state) => state,
+            Err(_) => {
+                print_error(
+                    "No avocado volume found. Run an extension build first to create the volume.",
+                    OutputLevel::Normal,
+                );
+                return Ok(());
+            }
+        };
+
+        // Create a temporary container to access the volume
+        let temp_container_name = format!("avocado-checkout-{}", uuid::Uuid::new_v4());
+
+        if self.verbose {
+            print_info(
+                &format!("Creating temporary container: {}", temp_container_name),
+                OutputLevel::Normal,
+            );
+        }
+
+        // Get target from config to determine the extension sysroot path
+        let target = self.get_target_from_config(&cwd)?;
+        let ext_sysroot_path = format!("/opt/_avocado/{}/extensions/{}", target, self.extension);
+        let full_ext_path = if self.ext_path.starts_with('/') {
+            format!("{}{}", ext_sysroot_path, self.ext_path)
+        } else {
+            format!("{}/{}", ext_sysroot_path, self.ext_path)
+        };
+
+        if self.verbose {
+            print_info(
+                &format!("Extension sysroot path: {}", ext_sysroot_path),
+                OutputLevel::Normal,
+            );
+            print_info(
+                &format!("Full source path in volume: {}", full_ext_path),
+                OutputLevel::Normal,
+            );
+        }
+
+        // Check if the path exists in the volume using a temporary container
+        let path_exists = self.check_path_exists(&volume_state.volume_name, &full_ext_path).await?;
+
+        if !path_exists {
+            print_error(
+                &format!(
+                    "Path '{}' not found in extension '{}' sysroot. Available paths can be listed with 'avocado ext list'.",
+                    self.ext_path,
+                    self.extension
+                ),
+                OutputLevel::Normal,
+            );
+            return Ok(());
+        }
+
+        // Determine if the path is a file or directory
+        let is_directory = self.check_is_directory(&volume_state.volume_name, &full_ext_path).await?;
+
+        // Prepare the destination path
+        let dest_path = cwd.join(&self.src_path);
+
+        if self.verbose {
+            print_info(
+                &format!("Destination path: {}", dest_path.display()),
+                OutputLevel::Normal,
+            );
+        }
+
+        // Extract the files using docker cp
+        self.extract_files(&volume_state.volume_name, &full_ext_path, &dest_path, is_directory, &temp_container_name).await?;
+
+        // Fix ownership to match host user
+        self.fix_ownership(&dest_path).await?;
+
+        print_success(
+            &format!(
+                "Successfully checked out '{}' from extension '{}' to '{}'",
+                self.ext_path,
+                self.extension,
+                self.src_path
+            ),
+            OutputLevel::Normal,
+        );
+
+        Ok(())
+    }
+
+    fn get_target_from_config(&self, cwd: &Path) -> Result<String> {
+        let config_path = cwd.join(&self.config_path);
+        let config_content = std::fs::read_to_string(&config_path)
+            .with_context(|| format!("Failed to read config file: {}", config_path.display()))?;
+
+        let parsed: toml::Value = toml::from_str(&config_content)
+            .with_context(|| format!("Failed to parse config file: {}", config_path.display()))?;
+
+        // Get target from runtime configuration
+        let target = parsed
+            .get("runtime")
+            .and_then(|runtime| runtime.as_table())
+            .and_then(|runtime_table| {
+                if runtime_table.len() == 1 {
+                    runtime_table.values().next()
+                } else {
+                    runtime_table.get("default")
+                }
+            })
+            .and_then(|runtime| runtime.get("target"))
+            .and_then(|target| target.as_str())
+            .ok_or_else(|| anyhow::anyhow!("No target specified in runtime configuration"))?;
+
+        Ok(target.to_string())
+    }
+
+    async fn check_path_exists(&self, volume_name: &str, path: &str) -> Result<bool> {
+        // Create temporary container with volume mounted
+        let output = AsyncCommand::new(&self.container_tool)
+            .arg("run")
+            .arg("--rm")
+            .arg("-v")
+            .arg(format!("{}:/opt/_avocado:ro", volume_name))
+            .arg("alpine:latest")
+            .arg("test")
+            .arg("-e")
+            .arg(path)
+            .output()
+            .await
+            .context("Failed to check if path exists")?;
+
+        Ok(output.status.success())
+    }
+
+    async fn check_is_directory(&self, volume_name: &str, path: &str) -> Result<bool> {
+        let output = AsyncCommand::new(&self.container_tool)
+            .arg("run")
+            .arg("--rm")
+            .arg("-v")
+            .arg(format!("{}:/opt/_avocado:ro", volume_name))
+            .arg("alpine:latest")
+            .arg("test")
+            .arg("-d")
+            .arg(path)
+            .output()
+            .await
+            .context("Failed to check if path is directory")?;
+
+        Ok(output.status.success())
+    }
+
+    async fn extract_files(
+        &self,
+        volume_name: &str,
+        source_path: &str,
+        dest_path: &Path,
+        is_directory: bool,
+        _container_name: &str,
+    ) -> Result<()> {
+        // Create a temporary container to copy files from
+        let temp_container_id = self.create_temp_container(volume_name).await?;
+
+        // Ensure destination directory exists
+        if let Some(parent) = dest_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create destination directory: {}", parent.display()))?;
+        }
+
+        let docker_cp_source = format!("{}:{}", temp_container_id, source_path);
+
+        let docker_cp_dest = if is_directory {
+            // For directories, copy the directory itself to preserve hierarchy
+            // Docker cp will create the directory at the destination
+            if let Some(parent) = dest_path.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("Failed to create parent directory: {}", parent.display()))?;
+            }
+            dest_path.to_string_lossy().to_string()
+        } else {
+            // For files, preserve the directory hierarchy from the original ext-path
+            // Use the ext_path to maintain the directory structure
+            let ext_path_normalized = if self.ext_path.starts_with('/') {
+                &self.ext_path[1..] // Remove leading slash
+            } else {
+                &self.ext_path
+            };
+
+            let full_dest_path = dest_path.join(ext_path_normalized);
+
+            // Create parent directories
+            if let Some(parent) = full_dest_path.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("Failed to create parent directory: {}", parent.display()))?;
+            }
+
+            full_dest_path.to_string_lossy().to_string()
+        };
+
+        if self.verbose {
+            print_info(
+                &format!("Docker cp: {} -> {}", docker_cp_source, docker_cp_dest),
+                OutputLevel::Normal,
+            );
+        }
+
+        let output = AsyncCommand::new(&self.container_tool)
+            .arg("cp")
+            .arg(&docker_cp_source)
+            .arg(&docker_cp_dest)
+            .output()
+            .await
+            .context("Failed to execute docker cp")?;
+
+        // Clean up the temporary container
+        let _ = AsyncCommand::new(&self.container_tool)
+            .arg("rm")
+            .arg("-f")
+            .arg(&temp_container_id)
+            .output()
+            .await;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!("Docker cp failed: {}", stderr));
+        }
+
+        Ok(())
+    }
+
+    async fn create_temp_container(&self, volume_name: &str) -> Result<String> {
+        let output = AsyncCommand::new(&self.container_tool)
+            .arg("create")
+            .arg("-v")
+            .arg(format!("{}:/opt/_avocado:ro", volume_name))
+            .arg("alpine:latest")
+            .arg("true")
+            .output()
+            .await
+            .context("Failed to create temporary container")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!("Failed to create temporary container: {}", stderr));
+        }
+
+        let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Ok(container_id)
+    }
+
+    async fn fix_ownership(&self, path: &Path) -> Result<()> {
+        // Get current user ID and group ID
+        let uid = unsafe { libc::getuid() };
+        let gid = unsafe { libc::getgid() };
+
+        if self.verbose {
+            print_info(
+                &format!("Setting ownership to {}:{} for {}", uid, gid, path.display()),
+                OutputLevel::Normal,
+            );
+        }
+
+        // Use chown to fix ownership recursively
+        let output = AsyncCommand::new("chown")
+            .arg("-R")
+            .arg(format!("{}:{}", uid, gid))
+            .arg(path)
+            .output()
+            .await
+            .context("Failed to change file ownership")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if self.verbose {
+                print_info(
+                    &format!("Note: Could not change ownership (may not be needed): {}", stderr),
+                    OutputLevel::Normal,
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_checkout_command_creation() {
+        let cmd = ExtCheckoutCommand::new(
+            "test-ext".to_string(),
+            "/etc/config".to_string(),
+            "extracted/config".to_string(),
+            "avocado.toml".to_string(),
+            false,
+            "docker".to_string(),
+        );
+
+        assert_eq!(cmd.extension, "test-ext");
+        assert_eq!(cmd.ext_path, "/etc/config");
+        assert_eq!(cmd.src_path, "extracted/config");
+    }
+}

--- a/src/commands/ext/mod.rs
+++ b/src/commands/ext/mod.rs
@@ -1,4 +1,5 @@
 pub mod build;
+pub mod checkout;
 pub mod clean;
 pub mod deps;
 pub mod dnf;
@@ -7,6 +8,7 @@ pub mod install;
 pub mod list;
 
 pub use build::ExtBuildCommand;
+pub use checkout::ExtCheckoutCommand;
 pub use clean::ExtCleanCommand;
 pub use deps::ExtDepsCommand;
 pub use dnf::ExtDnfCommand;

--- a/src/commands/sdk/run.rs
+++ b/src/commands/sdk/run.rs
@@ -175,7 +175,9 @@ impl SdkRunCommand {
     ) -> Result<bool> {
         // Get or create docker volume for persistent state
         let volume_manager = VolumeManager::new(container_helper.container_tool.clone(), false);
-        let volume_state = volume_manager.get_or_create_volume(&container_helper.cwd).await?;
+        let volume_state = volume_manager
+            .get_or_create_volume(&container_helper.cwd)
+            .await?;
         // Build container command for detached mode
         let mut container_cmd = vec![
             container_helper.container_tool.clone(),
@@ -194,15 +196,9 @@ impl SdkRunCommand {
 
         // Volume mounts: docker volume for persistent state, bind mount for source
         container_cmd.push("-v".to_string());
-        container_cmd.push(format!(
-            "{}:/opt/src:rw",
-            container_helper.cwd.display()
-        ));
+        container_cmd.push(format!("{}:/opt/src:rw", container_helper.cwd.display()));
         container_cmd.push("-v".to_string());
-        container_cmd.push(format!(
-            "{}:/opt/_avocado:rw",
-            volume_state.volume_name
-        ));
+        container_cmd.push(format!("{}:/opt/_avocado:rw", volume_state.volume_name));
 
         // Add environment variables
         container_cmd.push("-e".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod utils;
 use commands::build::BuildCommand;
 use commands::clean::CleanCommand;
 use commands::ext::{
-    ExtBuildCommand, ExtCleanCommand, ExtDepsCommand, ExtDnfCommand, ExtImageCommand,
+    ExtBuildCommand, ExtCheckoutCommand, ExtCleanCommand, ExtDepsCommand, ExtDnfCommand, ExtImageCommand,
     ExtInstallCommand, ExtListCommand,
 };
 use commands::hitl::HitlServerCommand;
@@ -666,6 +666,25 @@ async fn main() -> Result<()> {
                 build_cmd.execute().await?;
                 Ok(())
             }
+            ExtCommands::Checkout {
+                config,
+                verbose,
+                extension,
+                ext_path,
+                src_path,
+                container_tool,
+            } => {
+                let checkout_cmd = ExtCheckoutCommand::new(
+                    extension,
+                    ext_path,
+                    src_path,
+                    config,
+                    verbose,
+                    container_tool,
+                );
+                checkout_cmd.execute().await?;
+                Ok(())
+            }
             ExtCommands::List { config } => {
                 let list_cmd = ExtListCommand::new(config);
                 list_cmd.execute()?;
@@ -955,6 +974,27 @@ enum ExtCommands {
         /// Additional arguments to pass to DNF commands
         #[arg(long = "dnf-arg", num_args = 1, allow_hyphen_values = true, action = clap::ArgAction::Append)]
         dnf_args: Option<Vec<String>>,
+    },
+    /// Check out files from extension sysroot to source directory
+    Checkout {
+        /// Path to avocado.toml configuration file
+        #[arg(short = 'C', long, default_value = "avocado.toml")]
+        config: String,
+        /// Enable verbose output
+        #[arg(short, long)]
+        verbose: bool,
+        /// Name of the extension to checkout from
+        #[arg(short = 'e', long = "extension", required = true)]
+        extension: String,
+        /// Path within the extension sysroot to checkout (e.g., /etc/config.json or /etc for directory)
+        #[arg(long = "ext-path", required = true)]
+        ext_path: String,
+        /// Destination path in source directory (relative to src root)
+        #[arg(long = "src-path", required = true)]
+        src_path: String,
+        /// Container tool to use (docker/podman)
+        #[arg(long, default_value = "docker")]
+        container_tool: String,
     },
     /// Create squashfs image from system extension
     Image {

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,10 +66,19 @@ enum Commands {
         #[command(subcommand)]
         command: HitlCommands,
     },
-    /// Clean the avocado project by removing the _avocado directory
+    /// Clean the avocado project by removing docker volumes and state files
     Clean {
         /// Directory to clean (defaults to current directory)
         directory: Option<String>,
+        /// Skip cleaning docker volumes (volumes are cleaned by default)
+        #[arg(long)]
+        skip_volumes: bool,
+        /// Container tool to use (docker/podman)
+        #[arg(long, default_value = "docker")]
+        container_tool: String,
+        /// Enable verbose output
+        #[arg(short, long)]
+        verbose: bool,
     },
     /// Install all components (SDK, extensions, and runtime dependencies)
     Install {
@@ -432,9 +441,9 @@ async fn main() -> Result<()> {
             init_cmd.execute()?;
             Ok(())
         }
-        Commands::Clean { directory } => {
-            let clean_cmd = CleanCommand::new(directory);
-            clean_cmd.execute()?;
+        Commands::Clean { directory, skip_volumes, container_tool, verbose } => {
+            let clean_cmd = CleanCommand::new(directory, !skip_volumes, Some(container_tool), verbose);
+            clean_cmd.execute().await?;
             Ok(())
         }
         Commands::Install {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ mod utils;
 use commands::build::BuildCommand;
 use commands::clean::CleanCommand;
 use commands::ext::{
-    ExtBuildCommand, ExtCheckoutCommand, ExtCleanCommand, ExtDepsCommand, ExtDnfCommand, ExtImageCommand,
-    ExtInstallCommand, ExtListCommand,
+    ExtBuildCommand, ExtCheckoutCommand, ExtCleanCommand, ExtDepsCommand, ExtDnfCommand,
+    ExtImageCommand, ExtInstallCommand, ExtListCommand,
 };
 use commands::hitl::HitlServerCommand;
 use commands::init::InitCommand;
@@ -441,8 +441,14 @@ async fn main() -> Result<()> {
             init_cmd.execute()?;
             Ok(())
         }
-        Commands::Clean { directory, skip_volumes, container_tool, verbose } => {
-            let clean_cmd = CleanCommand::new(directory, !skip_volumes, Some(container_tool), verbose);
+        Commands::Clean {
+            directory,
+            skip_volumes,
+            container_tool,
+            verbose,
+        } => {
+            let clean_cmd =
+                CleanCommand::new(directory, !skip_volumes, Some(container_tool), verbose);
             clean_cmd.execute().await?;
             Ok(())
         }

--- a/src/utils/container.rs
+++ b/src/utils/container.rs
@@ -237,7 +237,10 @@ impl SdkContainer {
     ) -> Result<bool> {
         if verbose {
             print_info(
-                &format!("Mounting source directory: {} -> /opt/src", self.cwd.display()),
+                &format!(
+                    "Mounting source directory: {} -> /opt/src",
+                    self.cwd.display()
+                ),
                 OutputLevel::Normal,
             );
             print_info(

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,3 +2,4 @@ pub mod config;
 pub mod container;
 pub mod output;
 pub mod target;
+pub mod volume;

--- a/src/utils/volume.rs
+++ b/src/utils/volume.rs
@@ -1,0 +1,233 @@
+//! Docker volume management utilities for Avocado CLI.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tokio::process::Command as AsyncCommand;
+use uuid::Uuid;
+
+use crate::utils::output::{print_info, OutputLevel};
+
+/// Volume state configuration stored in .avocado-state file
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct VolumeState {
+    /// The docker volume name
+    pub volume_name: String,
+    /// Original source path where avocado config was located
+    pub source_path: String,
+    /// Container tool being used (docker/podman)
+    pub container_tool: String,
+}
+
+impl VolumeState {
+    /// Create a new volume state with a generated UUID-based name
+    pub fn new(source_path: PathBuf, container_tool: String) -> Self {
+        let uuid = Uuid::new_v4();
+        let volume_name = format!("avo-{}", uuid);
+
+        Self {
+            volume_name,
+            source_path: source_path.to_string_lossy().to_string(),
+            container_tool,
+        }
+    }
+
+    /// Load volume state from .avocado-state file in the given directory
+    pub fn load_from_dir(dir_path: &Path) -> Result<Option<Self>> {
+        let state_file = dir_path.join(".avocado-state");
+
+        if !state_file.exists() {
+            return Ok(None);
+        }
+
+        let content = fs::read_to_string(&state_file)
+            .with_context(|| format!("Failed to read volume state file: {}", state_file.display()))?;
+
+        let state: VolumeState = serde_json::from_str(&content)
+            .with_context(|| "Failed to parse volume state file")?;
+
+        Ok(Some(state))
+    }
+
+    /// Save volume state to .avocado-state file in the given directory
+    pub fn save_to_dir(&self, dir_path: &Path) -> Result<()> {
+        let state_file = dir_path.join(".avocado-state");
+
+        let content = serde_json::to_string_pretty(self)
+            .with_context(|| "Failed to serialize volume state")?;
+
+        fs::write(&state_file, content)
+            .with_context(|| format!("Failed to write volume state file: {}", state_file.display()))?;
+
+        Ok(())
+    }
+}
+
+/// Docker volume manager for Avocado operations
+pub struct VolumeManager {
+    container_tool: String,
+    verbose: bool,
+}
+
+impl VolumeManager {
+    /// Create a new volume manager
+    pub fn new(container_tool: String, verbose: bool) -> Self {
+        Self {
+            container_tool,
+            verbose,
+        }
+    }
+
+    /// Get or create a docker volume for the given source directory
+    pub async fn get_or_create_volume(&self, source_dir: &Path) -> Result<VolumeState> {
+        // Try to load existing volume state
+        if let Some(existing_state) = VolumeState::load_from_dir(source_dir)? {
+            // Verify the volume still exists
+            if self.volume_exists(&existing_state.volume_name).await? {
+                if self.verbose {
+                    print_info(
+                        &format!("Using existing volume: {}", existing_state.volume_name),
+                        OutputLevel::Normal,
+                    );
+                }
+                return Ok(existing_state);
+            } else {
+                if self.verbose {
+                    print_info(
+                        &format!("Volume {} no longer exists, creating new one", existing_state.volume_name),
+                        OutputLevel::Normal,
+                    );
+                }
+            }
+        }
+
+        // Create new volume state
+        let state = VolumeState::new(source_dir.to_path_buf(), self.container_tool.clone());
+
+        // Create the docker volume with metadata
+        self.create_volume(&state).await?;
+
+        // Save state to file
+        state.save_to_dir(source_dir)?;
+
+        if self.verbose {
+            print_info(
+                &format!("Created new volume: {}", state.volume_name),
+                OutputLevel::Normal,
+            );
+        }
+
+        Ok(state)
+    }
+
+    /// Check if a docker volume exists
+    async fn volume_exists(&self, volume_name: &str) -> Result<bool> {
+        let output = AsyncCommand::new(&self.container_tool)
+            .args(&["volume", "inspect", volume_name])
+            .output()
+            .await
+            .with_context(|| "Failed to check if volume exists")?;
+
+        Ok(output.status.success())
+    }
+
+    /// Create a docker volume with metadata
+    async fn create_volume(&self, state: &VolumeState) -> Result<()> {
+        let mut cmd = AsyncCommand::new(&self.container_tool);
+        cmd.args(&["volume", "create"]);
+
+        // Add label with source path metadata
+        cmd.args(&[
+            "--label",
+            &format!("avocado.source_path={}", state.source_path)
+        ]);
+
+        cmd.arg(&state.volume_name);
+
+        let output = cmd.output().await
+            .with_context(|| "Failed to create docker volume")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Failed to create volume {}: {}", state.volume_name, stderr);
+        }
+
+        Ok(())
+    }
+
+    /// Remove a docker volume
+    pub async fn remove_volume(&self, volume_name: &str) -> Result<()> {
+        let output = AsyncCommand::new(&self.container_tool)
+            .args(&["volume", "rm", volume_name])
+            .output()
+            .await
+            .with_context(|| "Failed to remove docker volume")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Failed to remove volume {}: {}", volume_name, stderr);
+        }
+
+        Ok(())
+    }
+
+
+}
+
+/// Information about a docker volume
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct VolumeInfo {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "Driver")]
+    pub driver: String,
+    #[serde(rename = "Mountpoint")]
+    pub mountpoint: String,
+    #[serde(rename = "Labels")]
+    pub labels: Option<HashMap<String, String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_volume_state_creation() {
+        let temp_dir = TempDir::new().unwrap();
+        let source_path = temp_dir.path().to_path_buf();
+        let container_tool = "docker".to_string();
+
+        let state = VolumeState::new(source_path.clone(), container_tool.clone());
+
+        assert!(state.volume_name.starts_with("avo-"));
+        assert_eq!(state.source_path, source_path.to_string_lossy());
+        assert_eq!(state.container_tool, container_tool);
+    }
+
+    #[test]
+    fn test_volume_state_save_and_load() {
+        let temp_dir = TempDir::new().unwrap();
+        let source_path = temp_dir.path().to_path_buf();
+        let state = VolumeState::new(source_path.clone(), "docker".to_string());
+
+        // Save state
+        state.save_to_dir(temp_dir.path()).unwrap();
+
+        // Load state
+        let loaded_state = VolumeState::load_from_dir(temp_dir.path()).unwrap().unwrap();
+
+        assert_eq!(state.volume_name, loaded_state.volume_name);
+        assert_eq!(state.source_path, loaded_state.source_path);
+        assert_eq!(state.container_tool, loaded_state.container_tool);
+    }
+
+    #[test]
+    fn test_load_nonexistent_state() {
+        let temp_dir = TempDir::new().unwrap();
+        let result = VolumeState::load_from_dir(temp_dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/tests/fixtures/configs/with-overlay-merge.toml
+++ b/tests/fixtures/configs/with-overlay-merge.toml
@@ -1,0 +1,14 @@
+[sdk]
+image = "ghcr.io/avocado-framework/avocado-sdk:latest"
+
+[runtime.default]
+target = "x86_64-unknown-linux-gnu"
+
+[ext.peridio]
+types = ["sysext", "confext"]
+overlay = {dir = "peridio-overlay", mode = "merge"}
+
+# Also test backward compatibility
+[ext.legacy]
+types = ["sysext"]
+overlay = "legacy-overlay"

--- a/tests/fixtures/configs/with-overlay-opaque.toml
+++ b/tests/fixtures/configs/with-overlay-opaque.toml
@@ -1,0 +1,9 @@
+[sdk]
+image = "ghcr.io/avocado-framework/avocado-sdk:latest"
+
+[runtime.default]
+target = "x86_64-unknown-linux-gnu"
+
+[ext.peridio]
+types = ["sysext", "confext"]
+overlay = {dir = "peridio-overlay", mode = "opaque"}

--- a/tests/fixtures/configs/with-overlay.toml
+++ b/tests/fixtures/configs/with-overlay.toml
@@ -1,0 +1,12 @@
+[sdk]
+image = "ghcr.io/avocado-framework/avocado-sdk:latest"
+
+[runtime.default]
+target = "x86_64-unknown-linux-gnu"
+
+[ext.peridio]
+types = ["sysext", "confext"]
+overlay = "peridio"
+
+[ext.peridio.dependencies]
+curl = "*"


### PR DESCRIPTION
* move avocado state from `_avocado` bind mount to a docker volume. The state name gets stored in `.avocado-state`
* Add support for including src overlay directories for extensions. These can be defined in the config file as 
```
[ext.my-ext]
overlay = "my-ext-dir"
```

* Add extension checkout command to copy directory fragments and files down from extensions. This is super useful if you need to override configuration files and store them in your own source directory.