### PR TITLE
User management

### DIFF
--- a/docs/users-and-groups.md
+++ b/docs/users-and-groups.md
@@ -1,0 +1,170 @@
+# User and Group Management in Avocado Extensions
+
+Avocado supports comprehensive user and group management in extensions using a flexible TOML configuration syntax.
+
+## Mixed Syntax Approach (Recommended)
+
+You can use two approaches depending on complexity:
+
+### Simple Users/Groups: Inline Syntax
+For users or groups with minimal configuration, use inline table syntax:
+
+```toml
+[ext.my-extension.users]
+root = { password = "" }
+guest = { password = "*" }
+
+[ext.my-extension.groups]
+users = { gid = 1000 }
+staff = { gid = 20 }
+```
+
+### Complex Users/Groups: Table Syntax
+For users or groups with many attributes, use separate table sections:
+
+```toml
+[ext.my-extension.users]
+# Simple users still use inline syntax
+root = { password = "" }
+
+# Complex users use table syntax for better readability
+[ext.my-extension.users.alice]
+password = "$6$salt$hash"
+uid = 1001
+gid = 1001
+gecos = "Alice Smith,Engineering,Room 123,555-1234,555-5678"
+home = "/home/alice"
+shell = "/bin/zsh"
+groups = ["users", "developers", "sudo"]
+
+[ext.my-extension.users.nginx]
+password = "*"          # No login allowed
+uid = 33
+gid = 33
+gecos = "nginx web server"
+home = "/var/www"
+shell = "/usr/sbin/nologin"
+system = true           # Mark as system user
+```
+
+## Comprehensive User Attributes
+
+All user attributes are optional with reasonable defaults:
+
+### Core Attributes
+- `password`: Password hash, `""` for no password, `"*"` for no login (default: `"*"`)
+- `uid`: User ID (default: auto-increment from 1000)
+- `gid`: Primary group ID (default: same as UID)
+- `gecos`: Full name and contact info (default: username)
+- `home`: Home directory (default: `/home/{username}`)
+- `shell`: Login shell (default: `/bin/sh`)
+- `groups`: Additional group memberships (default: user's own group)
+- `system`: Mark as system user (default: false)
+
+### Password Aging (Shadow File)
+- `last_change`: Days since epoch when password was last changed (default: 19000)
+- `min_days`: Minimum days between password changes (default: 0)
+- `max_days`: Maximum days before password expires (default: 99999)
+- `warn_days`: Days before expiration to warn user (default: 7)
+- `inactive_days`: Days after expiration before account is disabled (default: empty)
+- `expire_date`: Days since epoch when account expires (default: empty)
+- `disabled`: Mark account as disabled (default: false)
+
+## Comprehensive Group Attributes
+
+All group attributes are optional with reasonable defaults:
+
+### Core Attributes
+- `gid`: Group ID (default: auto-increment from 1000)
+- `members`: List of usernames to add to group (default: empty)
+- `system`: Mark as system group (default: false)
+- `password`: Group password for `newgrp` command (default: empty)
+- `admins`: List of group administrators (default: empty)
+
+## Complete Example
+
+```toml
+[ext.web-stack]
+types = ["sysext", "confext"]
+packages = ["nginx", "postgresql", "redis"]
+
+[ext.web-stack.users]
+# Simple users use inline syntax
+root = { password = "" }
+guest = { password = "*" }
+
+# Complex application user
+[ext.web-stack.users.webapp]
+password = "$6$salt$hash"
+uid = 1001
+gecos = "Web Application User"
+home = "/opt/webapp"
+shell = "/bin/bash"
+groups = ["webapp", "users"]
+# Password expires every 90 days
+max_days = 90
+warn_days = 7
+
+# Database service user
+[ext.web-stack.users.postgres]
+password = "*"
+uid = 26
+gid = 26
+gecos = "PostgreSQL Server"
+home = "/var/lib/pgsql"
+shell = "/usr/sbin/nologin"
+system = true
+groups = ["postgres"]
+
+# Web server user
+[ext.web-stack.users.nginx]
+password = "*"
+uid = 33
+gid = 33
+gecos = "nginx web server"
+home = "/var/www"
+shell = "/usr/sbin/nologin"
+system = true
+
+[ext.web-stack.groups]
+# Simple groups use inline syntax
+users = { gid = 1000 }
+
+# Application group with members
+[ext.web-stack.groups.webapp]
+gid = 1001
+members = ["webapp"]
+
+# System service groups
+[ext.web-stack.groups.postgres]
+gid = 26
+system = true
+
+[ext.web-stack.groups.nginx]
+gid = 33
+system = true
+```
+
+## Security Features
+
+- **Password Warnings**: Empty passwords trigger build-time warnings
+- **Default Security**: Users without passwords default to `"*"` (no login)
+- **Proper Permissions**: Files get correct ownership and permissions automatically
+- **System Users**: Special handling for service accounts
+- **Password Aging**: Full support for account expiration and password policies
+
+## File Management
+
+The system automatically:
+1. Copies `/etc/passwd`, `/etc/shadow`, and `/etc/group` from rootfs
+2. Creates missing users and groups
+3. Updates existing entries as needed
+4. Sets proper file permissions (644 for passwd/group, 640 for shadow)
+5. Handles group membership correctly
+
+## TOML Syntax Notes
+
+- **Inline tables** must be on a single line: `user = { password = "hash", uid = 1001 }`
+- **Separate tables** allow multiline formatting: `[ext.name.users.username]`
+- **Mix both approaches** for optimal readability
+- **All fields are optional** with sensible defaults

--- a/examples/comprehensive-users-example.toml
+++ b/examples/comprehensive-users-example.toml
@@ -1,0 +1,104 @@
+[sdk]
+image = "ghcr.io/avocado-framework/avocado-sdk:latest"
+
+[runtime.default]
+target = "x86_64-unknown-linux-gnu"
+
+[ext.avocado-dev]
+types = ["sysext", "confext"]
+packages = ["vim", "curl", "nginx", "postgresql"]
+
+# Mixed approach for users: inline for simple, table syntax for complex
+[ext.avocado-dev.users]
+# Simple users with minimal configuration use inline syntax
+root = { password = "" }
+guest = { password = "*" }  # No login allowed
+
+# Complex user with full passwd attributes
+[ext.avocado-dev.users.alice]
+password = "$6$salt$hash"
+uid = 1001
+gid = 1001
+gecos = "Alice Smith,Engineering,Room 123,555-1234,555-5678"
+home = "/home/alice"
+shell = "/bin/zsh"
+groups = ["users", "developers", "sudo"]
+
+# User with comprehensive shadow attributes for password aging
+[ext.avocado-dev.users.bob]
+password = "$6$anothersalt$anotherhash"
+uid = 1002
+gecos = "Bob Johnson,DevOps Team"
+home = "/home/bob"
+shell = "/bin/bash"
+groups = ["users", "admins"]
+# Shadow file attributes for strict password policy
+last_change = 19000     # Days since epoch when password was last changed
+min_days = 7            # Minimum days between password changes
+max_days = 90           # Maximum days before password expires
+warn_days = 7           # Days before expiration to warn user
+inactive_days = 14      # Days after expiration before account is disabled
+expire_date = 20000     # Days since epoch when account expires
+
+# System service user with specific configuration
+[ext.avocado-dev.users.nginx]
+password = "*"          # No login allowed
+uid = 33
+gid = 33
+gecos = "nginx web server"
+home = "/var/www"
+shell = "/usr/sbin/nologin"
+system = true           # Mark as system user
+
+# Database service user
+[ext.avocado-dev.users.postgres]
+password = "!"          # Locked password
+uid = 26
+gid = 26
+gecos = "PostgreSQL Server"
+home = "/var/lib/pgsql"
+shell = "/bin/bash"
+system = true
+groups = ["postgres"]
+
+# Locked/disabled user account
+[ext.avocado-dev.users.temp]
+password = "!"
+uid = 1099
+disabled = true         # Account disabled
+gecos = "Temporary disabled account"
+groups = ["users"]
+
+# Groups with mixed syntax
+[ext.avocado-dev.groups]
+# Simple groups use inline syntax
+users = { gid = 1000 }
+sudo = { gid = 27 }
+
+# Complex group with members and password
+[ext.avocado-dev.groups.developers]
+gid = 2000
+members = ["alice", "bob"]
+system = false
+
+# System group with administrative access
+[ext.avocado-dev.groups.admins]
+gid = 2001
+system = true
+members = ["bob"]
+
+# Group with password for newgrp command
+[ext.avocado-dev.groups.secure]
+gid = 3000
+password = "$6$groupsalt$grouphash"  # Group password for newgrp
+admins = ["alice", "bob"]            # Group administrators
+members = ["alice"]
+
+# Service-specific groups
+[ext.avocado-dev.groups.nginx]
+gid = 33
+system = true
+
+[ext.avocado-dev.groups.postgres]
+gid = 26
+system = true

--- a/src/commands/ext/build.rs
+++ b/src/commands/ext/build.rs
@@ -96,6 +96,10 @@ impl ExtBuildCommand {
             })
             .unwrap_or_default();
 
+        // Get users and groups configuration
+        let users_config = ext_config.get("users").and_then(|v| v.as_table());
+        let groups_config = ext_config.get("groups").and_then(|v| v.as_table());
+
         // Validate that confext is present if enable_services is used
         if !enable_services.is_empty() && !ext_types.contains(&"confext") {
             print_error(
@@ -236,6 +240,8 @@ impl ExtBuildCommand {
                         repo_release,
                         &processed_container_args,
                         &modprobe_modules,
+                        users_config,
+                        groups_config,
                     )
                     .await?
                 }
@@ -251,6 +257,8 @@ impl ExtBuildCommand {
                         repo_release,
                         &processed_container_args,
                         &enable_services,
+                        users_config,
+                        groups_config,
                     )
                     .await?
                 }
@@ -299,6 +307,8 @@ impl ExtBuildCommand {
         repo_release: Option<&String>,
         processed_container_args: &Option<Vec<String>>,
         modprobe_modules: &[String],
+        users_config: Option<&toml::value::Table>,
+        groups_config: Option<&toml::value::Table>,
     ) -> Result<bool> {
         // Create the build script for sysext extension
         let build_script = self.create_sysext_build_script(
@@ -306,6 +316,8 @@ impl ExtBuildCommand {
             ext_scopes,
             overlay_config,
             modprobe_modules,
+            users_config,
+            groups_config,
         );
 
         // Execute the build script in the SDK container
@@ -354,6 +366,8 @@ impl ExtBuildCommand {
         repo_release: Option<&String>,
         processed_container_args: &Option<Vec<String>>,
         enable_services: &[String],
+        users_config: Option<&toml::value::Table>,
+        groups_config: Option<&toml::value::Table>,
     ) -> Result<bool> {
         // Create the build script for confext extension
         let build_script = self.create_confext_build_script(
@@ -361,6 +375,8 @@ impl ExtBuildCommand {
             ext_scopes,
             overlay_config,
             enable_services,
+            users_config,
+            groups_config,
         );
 
         // Execute the build script in the SDK container
@@ -402,6 +418,8 @@ impl ExtBuildCommand {
         ext_scopes: &[String],
         overlay_config: Option<&OverlayConfig>,
         modprobe_modules: &[String],
+        users_config: Option<&toml::value::Table>,
+        groups_config: Option<&toml::value::Table>,
     ) -> String {
         let overlay_section = if let Some(overlay_config) = overlay_config {
             match overlay_config.mode {
@@ -460,10 +478,12 @@ fi
 
         let modprobe_list = modprobe_modules.join(" ");
 
+        let users_section = self.create_users_script_section(users_config, groups_config);
+
         format!(
             r#"
 set -e
-{}
+{}{}
 release_dir="$AVOCADO_EXT_SYSROOTS/{}/usr/lib/extension-release.d"
 release_file="$release_dir/extension-release.{}"
 modules_dir="$AVOCADO_EXT_SYSROOTS/{}/usr/lib/modules"
@@ -495,6 +515,7 @@ if [ -n "{}" ]; then
 fi
 "#,
             overlay_section,
+            users_section,
             self.extension,
             self.extension,
             self.extension,
@@ -515,6 +536,8 @@ fi
         ext_scopes: &[String],
         overlay_config: Option<&OverlayConfig>,
         enable_services: &[String],
+        users_config: Option<&toml::value::Table>,
+        groups_config: Option<&toml::value::Table>,
     ) -> String {
         let overlay_section = if let Some(overlay_config) = overlay_config {
             match overlay_config.mode {
@@ -605,10 +628,12 @@ fi"#,
             String::new()
         };
 
+        let users_section = self.create_users_script_section(users_config, groups_config);
+
         format!(
             r#"
 set -e
-{}
+{}{}
 release_dir="$AVOCADO_EXT_SYSROOTS/{}/etc/extension-release.d"
 release_file="$release_dir/extension-release.{}"
 
@@ -626,6 +651,7 @@ fi
 {}
 "#,
             overlay_section,
+            users_section,
             self.extension,
             self.extension,
             ext_scopes.join(" "),
@@ -633,6 +659,443 @@ fi
             self.extension,
             service_linking_section
         )
+    }
+
+    /// Creates a script section for handling user and group configuration
+    /// This will copy passwd/shadow/group files and create/modify users and groups
+    fn create_users_script_section(
+        &self,
+        users_config: Option<&toml::value::Table>,
+        groups_config: Option<&toml::value::Table>,
+    ) -> String {
+        // If neither users nor groups are configured, return empty string
+        if users_config.is_none() && groups_config.is_none() {
+            return String::new();
+        }
+
+        let mut script_lines = Vec::new();
+        let mut has_valid_users = false;
+        script_lines.push("\n# Copy and manage user authentication files".to_string());
+
+        // Copy authentication files from rootfs
+        script_lines.push(format!(
+            r#"
+# Copy authentication files from rootfs to extension
+echo "Copying /etc/passwd, /etc/shadow, and /etc/group from rootfs to extension"
+mkdir -p "$AVOCADO_EXT_SYSROOTS/{}/etc"
+cp "$AVOCADO_PREFIX/rootfs/etc/passwd" "$AVOCADO_EXT_SYSROOTS/{}/etc/passwd"
+cp "$AVOCADO_PREFIX/rootfs/etc/shadow" "$AVOCADO_EXT_SYSROOTS/{}/etc/shadow"
+cp "$AVOCADO_PREFIX/rootfs/etc/group" "$AVOCADO_EXT_SYSROOTS/{}/etc/group"
+"#,
+            self.extension, self.extension, self.extension, self.extension
+        ));
+
+        // Auto-incrementing counters for uid/gid starting at 1000
+        script_lines.push(
+            "# Auto-incrementing counters for uid/gid\nCURRENT_UID=1000\nCURRENT_GID=1000\n"
+                .to_string(),
+        );
+
+        // Process groups first (they might be referenced by users)
+        if let Some(groups) = groups_config {
+            script_lines.push("\n# Create groups".to_string());
+
+            for (groupname, group_config) in groups {
+                if let Some(group_table) = group_config.as_table() {
+                    // Parse comprehensive group configuration with defaults
+                    let gid = if let Some(gid_value) = group_table.get("gid") {
+                        if let Some(gid_num) = gid_value.as_integer() {
+                            gid_num.to_string()
+                        } else {
+                            "$CURRENT_GID".to_string()
+                        }
+                    } else {
+                        "$CURRENT_GID".to_string()
+                    };
+
+                    let system_group = group_table
+                        .get("system")
+                        .and_then(|s| s.as_bool())
+                        .unwrap_or(false);
+
+                    let password = group_table
+                        .get("password")
+                        .and_then(|p| p.as_str())
+                        .unwrap_or(""); // Default: no group password
+
+                    let members = if let Some(members_value) = group_table.get("members") {
+                        if let Some(members_array) = members_value.as_array() {
+                            members_array
+                                .iter()
+                                .filter_map(|m| m.as_str())
+                                .collect::<Vec<_>>()
+                                .join(",")
+                        } else {
+                            "".to_string()
+                        }
+                    } else {
+                        "".to_string()
+                    };
+
+                    let _admins = if let Some(admins_value) = group_table.get("admins") {
+                        if let Some(admins_array) = admins_value.as_array() {
+                            admins_array
+                                .iter()
+                                .filter_map(|a| a.as_str())
+                                .collect::<Vec<_>>()
+                        } else {
+                            vec![]
+                        }
+                    } else {
+                        vec![]
+                    };
+
+                    // Escape password for potential gshadow entry
+                    let _escaped_group_password = password.replace("/", "\\/").replace("&", "\\&");
+
+                    let system_type = if system_group { " (system group)" } else { "" };
+                    let password_note = if !password.is_empty() {
+                        " with password"
+                    } else {
+                        ""
+                    };
+                    let members_msg = if !members.is_empty() {
+                        format!(" and members: {members}")
+                    } else {
+                        "".to_string()
+                    };
+                    let password_config = if !password.is_empty() {
+                        format!("\n# Set group password for '{groupname}'\necho \"Note: Group password configured for '{groupname}'\"")
+                    } else {
+                        "".to_string()
+                    };
+
+                    script_lines.push(format!(
+                        r#"
+# Create group '{}'{}
+echo "Creating group '{}'"{}
+if ! grep -q "^{}:" "$AVOCADO_EXT_SYSROOTS/{}/etc/group"; then
+    echo "{}:x:{}:{}" >> "$AVOCADO_EXT_SYSROOTS/{}/etc/group"
+    echo "Group '{}' created with GID {}{}"
+    if [ "{}" = "$CURRENT_GID" ]; then
+        CURRENT_GID=$((CURRENT_GID + 1))
+    fi
+else
+    echo "Group '{}' already exists, updating members"
+    # Update members if specified
+    if [ -n "{}" ]; then
+        sed -i "s|^{}:x:{}:.*$|{}:x:{}:{}|" "$AVOCADO_EXT_SYSROOTS/{}/etc/group"
+        echo "Updated members for group '{}'"
+    fi
+fi{}"#,
+                        groupname,
+                        system_type,
+                        groupname,
+                        password_note,
+                        groupname,
+                        self.extension,
+                        groupname,
+                        gid,
+                        members,
+                        self.extension,
+                        groupname,
+                        gid,
+                        members_msg,
+                        gid,
+                        groupname,
+                        members,
+                        groupname,
+                        gid,
+                        groupname,
+                        gid,
+                        members,
+                        self.extension,
+                        groupname,
+                        password_config
+                    ));
+                } else {
+                    // Simple group with just GID auto-assignment
+                    script_lines.push(format!(
+                        r#"
+# Create group '{}'
+echo "Creating group '{}'"
+if ! grep -q "^{}:" "$AVOCADO_EXT_SYSROOTS/{}/etc/group"; then
+    echo "{}:x:$CURRENT_GID:" >> "$AVOCADO_EXT_SYSROOTS/{}/etc/group"
+    echo "Group '{}' created with GID $CURRENT_GID"
+    CURRENT_GID=$((CURRENT_GID + 1))
+else
+    echo "Group '{}' already exists"
+fi"#,
+                        groupname,
+                        groupname,
+                        groupname,
+                        self.extension,
+                        groupname,
+                        self.extension,
+                        groupname,
+                        groupname
+                    ));
+                }
+            }
+        }
+
+        // Process users
+        if let Some(users) = users_config {
+            let mut user_script_lines = Vec::new();
+
+            for (username, user_config) in users {
+                if let Some(user_table) = user_config.as_table() {
+                    // Check if user has password field - if not, create with disabled login
+                    let password = user_table
+                        .get("password")
+                        .and_then(|p| p.as_str())
+                        .unwrap_or("*"); // Default to no login allowed
+
+                    has_valid_users = true;
+
+                    // Parse comprehensive user configuration with defaults
+                    let uid = if let Some(uid_value) = user_table.get("uid") {
+                        if let Some(uid_num) = uid_value.as_integer() {
+                            uid_num.to_string()
+                        } else {
+                            "$CURRENT_UID".to_string()
+                        }
+                    } else {
+                        "$CURRENT_UID".to_string()
+                    };
+
+                    let gid = if let Some(gid_value) = user_table.get("gid") {
+                        if let Some(gid_num) = gid_value.as_integer() {
+                            gid_num.to_string()
+                        } else {
+                            "$CURRENT_UID".to_string() // Default to same as UID for user private groups
+                        }
+                    } else {
+                        "$CURRENT_UID".to_string()
+                    };
+
+                    let gecos = user_table
+                        .get("gecos")
+                        .and_then(|g| g.as_str())
+                        .unwrap_or(username); // Default to username
+
+                    let default_home = format!("/home/{username}");
+                    let home = user_table
+                        .get("home")
+                        .and_then(|h| h.as_str())
+                        .unwrap_or(&default_home); // Default to /home/username
+
+                    let shell = user_table
+                        .get("shell")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("/bin/sh"); // Default shell
+
+                    let groups = if let Some(groups_value) = user_table.get("groups") {
+                        if let Some(groups_array) = groups_value.as_array() {
+                            groups_array
+                                .iter()
+                                .filter_map(|g| g.as_str())
+                                .map(|s| s.to_string())
+                                .collect::<Vec<_>>()
+                        } else {
+                            vec![username.clone()] // Default to user's own group
+                        }
+                    } else {
+                        vec![username.clone()] // Default to user's own group
+                    };
+
+                    let _primary_group = groups.first().unwrap_or(username);
+
+                    // Shadow file attributes with defaults
+                    let last_change = user_table
+                        .get("last_change")
+                        .and_then(|l| l.as_integer())
+                        .unwrap_or(19000); // Default to a reasonable epoch day
+
+                    let min_days = user_table
+                        .get("min_days")
+                        .and_then(|m| m.as_integer())
+                        .unwrap_or(0); // Default: no minimum
+
+                    let max_days = user_table
+                        .get("max_days")
+                        .and_then(|m| m.as_integer())
+                        .unwrap_or(99999); // Default: no maximum
+
+                    let warn_days = user_table
+                        .get("warn_days")
+                        .and_then(|w| w.as_integer())
+                        .unwrap_or(7); // Default: warn 7 days before
+
+                    let inactive_days = user_table
+                        .get("inactive_days")
+                        .and_then(|i| i.as_integer())
+                        .map(|i| i.to_string())
+                        .unwrap_or_else(|| "".to_string()); // Default: no inactive period
+
+                    let expire_date = user_table
+                        .get("expire_date")
+                        .and_then(|e| e.as_integer())
+                        .map(|e| e.to_string())
+                        .unwrap_or_else(|| "".to_string()); // Default: no expiration
+
+                    let disabled = user_table
+                        .get("disabled")
+                        .and_then(|d| d.as_bool())
+                        .unwrap_or(false);
+
+                    let system_user = user_table
+                        .get("system")
+                        .and_then(|s| s.as_bool())
+                        .unwrap_or(false);
+
+                    // Escape special characters in password for sed
+                    // Note: We use | as sed delimiter to avoid conflicts with / in passwords
+                    // We only need to escape characters that have special meaning in sed replacement strings
+                    let escaped_password = password
+                        .replace("\\", "\\\\") // Escape backslashes first
+                        .replace("&", "\\&") // Escape ampersands (sed replacement reference)
+                        .replace("$", "\\$"); // Escape dollar signs (sed end-of-line anchor)
+
+                    let warning_message = if password.is_empty() {
+                        format!("\necho \"[WARNING] User '{username}' will be able to login with NO PASSWORD\"")
+                    } else {
+                        String::new()
+                    };
+
+                    // Create user in passwd file
+                    user_script_lines.push(format!(
+                        r#"
+# Create user '{}'
+echo "Creating user '{}'{}"{}
+if ! grep -q "^{}:" "$AVOCADO_EXT_SYSROOTS/{}/etc/passwd"; then
+    # Add user to passwd file with comprehensive attributes
+    echo "{}:x:{}:{}:{}:{}:{}" >> "$AVOCADO_EXT_SYSROOTS/{}/etc/passwd"
+    echo "User '{}' created with UID {}, GID {}, home '{}', shell '{}'"
+
+    if [ "{}" = "$CURRENT_UID" ]; then
+        CURRENT_UID=$((CURRENT_UID + 1))
+    fi
+else
+    echo "User '{}' already exists, updating attributes"
+fi"#,
+                        username,
+                        username,
+                        if system_user { " (system user)" } else { "" },
+                        warning_message,
+                        username,
+                        self.extension,
+                        username,
+                        uid,
+                        gid,
+                        gecos,
+                        home,
+                        shell,
+                        self.extension,
+                        username,
+                        uid,
+                        gid,
+                        home,
+                        shell,
+                        uid,
+                        username
+                    ));
+
+                    // Create/update user in shadow file with comprehensive attributes
+                    user_script_lines.push(format!(
+                        r#"
+# Set password and shadow attributes for user '{}'
+echo "Setting password and aging policy for user '{}'"
+if grep -q "^{}:" "$AVOCADO_EXT_SYSROOTS/{}/etc/shadow"; then
+    # Update existing user's shadow entry completely
+    sed -i "s|^{}:.*$|{}:{}:{}:{}:{}:{}:{}:{}:|" "$AVOCADO_EXT_SYSROOTS/{}/etc/shadow"
+    echo "Updated shadow entry for existing user '{}'"
+else
+    # Add new user to shadow file with full attributes
+    echo "{}:{}:{}:{}:{}:{}:{}:{}:" >> "$AVOCADO_EXT_SYSROOTS/{}/etc/shadow"
+    echo "Added new user '{}' to shadow file"
+fi{}"#,
+                        username,
+                        username,
+                        username,
+                        self.extension,
+                        username,
+                        username,
+                        escaped_password,
+                        last_change,
+                        min_days,
+                        max_days,
+                        warn_days,
+                        inactive_days,
+                        expire_date,
+                        self.extension,
+                        username,
+                        username,
+                        escaped_password,
+                        last_change,
+                        min_days,
+                        max_days,
+                        warn_days,
+                        inactive_days,
+                        expire_date,
+                        self.extension,
+                        username,
+                        if disabled {
+                            "\necho \"Note: User account is marked as disabled\""
+                        } else {
+                            ""
+                        }
+                    ));
+
+                    // Add user to additional groups if specified
+                    if groups.len() > 1 {
+                        user_script_lines.push(format!(
+                            r#"
+# Add user '{username}' to additional groups"#
+                        ));
+
+                        for group in &groups[1..] {
+                            // Skip primary group
+                            user_script_lines.push(format!(
+                                r#"
+if grep -q "^{}:" "$AVOCADO_EXT_SYSROOTS/{}/etc/group"; then
+    # Add user to group if not already present
+    if ! grep "^{}:" "$AVOCADO_EXT_SYSROOTS/{}/etc/group" | grep -q "{}"; then
+        sed -i "s|^{}:\([^:]*\):\([^:]*\):\(.*\)$|{}:\1:\2:\3,{}|" "$AVOCADO_EXT_SYSROOTS/{}/etc/group"
+        echo "Added user '{}' to group '{}'"
+    fi
+else
+    echo "Warning: Group '{}' not found, cannot add user '{}'"
+fi"#,
+                                group, self.extension, group, self.extension, username, group, group, username, self.extension, username, group, group, username
+                            ));
+                        }
+                    }
+                }
+            }
+
+            // Add user scripts to main script if there are valid users
+            if has_valid_users {
+                script_lines.push("\n# Create and configure users".to_string());
+                script_lines.extend(user_script_lines);
+            }
+        }
+
+        // Set proper permissions only if we processed any users or groups
+        if groups_config.is_some() || has_valid_users {
+            script_lines.push(format!(
+                r#"
+# Set proper ownership and permissions for authentication files
+chown root:root "$AVOCADO_EXT_SYSROOTS/{}/etc/passwd" "$AVOCADO_EXT_SYSROOTS/{}/etc/shadow" "$AVOCADO_EXT_SYSROOTS/{}/etc/group"
+chmod 644 "$AVOCADO_EXT_SYSROOTS/{}/etc/passwd"
+chmod 640 "$AVOCADO_EXT_SYSROOTS/{}/etc/shadow"
+chmod 644 "$AVOCADO_EXT_SYSROOTS/{}/etc/group"
+echo "Set proper permissions on authentication files""#,
+                self.extension, self.extension, self.extension, self.extension, self.extension, self.extension
+            ));
+        }
+
+        script_lines.join("")
     }
 }
 
@@ -651,7 +1114,8 @@ mod tests {
             dnf_args: None,
         };
 
-        let script = cmd.create_sysext_build_script("1.0", &["system".to_string()], None, &[]);
+        let script =
+            cmd.create_sysext_build_script("1.0", &["system".to_string()], None, &[], None, None);
 
         // Print the actual script for debugging
         // println!("Generated sysext build script:\n{}", script);
@@ -692,7 +1156,8 @@ mod tests {
             dnf_args: None,
         };
 
-        let script = cmd.create_confext_build_script("1.0", &["system".to_string()], None, &[]);
+        let script =
+            cmd.create_confext_build_script("1.0", &["system".to_string()], None, &[], None, None);
 
         assert!(script
             .contains("release_dir=\"$AVOCADO_EXT_SYSROOTS/test-ext/etc/extension-release.d\""));
@@ -730,6 +1195,8 @@ mod tests {
             &["system".to_string(), "portable".to_string()],
             None,
             &[],
+            None,
+            None,
         );
 
         assert!(script.contains("echo \"SYSEXT_SCOPE=system portable\" >> \"$release_file\""));
@@ -752,6 +1219,8 @@ mod tests {
             &["system".to_string(), "portable".to_string()],
             None,
             &[],
+            None,
+            None,
         );
 
         assert!(script.contains("echo \"CONFEXT_SCOPE=system portable\" >> \"$release_file\""));
@@ -770,8 +1239,14 @@ mod tests {
         };
 
         let enable_services = vec!["peridiod.service".to_string(), "test.service".to_string()];
-        let script =
-            cmd.create_confext_build_script("1.0", &["system".to_string()], None, &enable_services);
+        let script = cmd.create_confext_build_script(
+            "1.0",
+            &["system".to_string()],
+            None,
+            &enable_services,
+            None,
+            None,
+        );
 
         // Check that service linking commands are present
         assert!(script.contains("# Link service file for peridiod.service"));
@@ -795,7 +1270,8 @@ mod tests {
             dnf_args: None,
         };
 
-        let script = cmd.create_sysext_build_script("1.0", &["system".to_string()], None, &[]);
+        let script =
+            cmd.create_sysext_build_script("1.0", &["system".to_string()], None, &[], None, None);
 
         // Verify the find command looks for common kernel module extensions
         assert!(script.contains("-name \"*.ko\""));
@@ -826,6 +1302,8 @@ mod tests {
             &["system".to_string()],
             Some(&overlay_config),
             &[],
+            None,
+            None,
         );
 
         // Verify overlay merging commands are present
@@ -860,6 +1338,8 @@ mod tests {
             &["system".to_string()],
             Some(&overlay_config),
             &[],
+            None,
+            None,
         );
 
         // Verify overlay merging commands are present
@@ -894,6 +1374,8 @@ mod tests {
             &["system".to_string()],
             Some(&overlay_config),
             &[],
+            None,
+            None,
         );
 
         // Verify overlay opaque mode commands are present
@@ -930,6 +1412,8 @@ mod tests {
             &["system".to_string()],
             Some(&overlay_config),
             &[],
+            None,
+            None,
         );
 
         // Verify overlay opaque mode commands are present
@@ -958,9 +1442,9 @@ mod tests {
         };
 
         let script_sysext =
-            cmd.create_sysext_build_script("1.0", &["system".to_string()], None, &[]);
+            cmd.create_sysext_build_script("1.0", &["system".to_string()], None, &[], None, None);
         let script_confext =
-            cmd.create_confext_build_script("1.0", &["system".to_string()], None, &[]);
+            cmd.create_confext_build_script("1.0", &["system".to_string()], None, &[], None, None);
 
         // Verify no overlay merging commands are present
         assert!(!script_sysext.contains("Merge overlay directory"));
@@ -983,8 +1467,14 @@ mod tests {
         };
 
         let modprobe_modules = vec!["nfs".to_string(), "ext4".to_string()];
-        let script =
-            cmd.create_sysext_build_script("1.0", &["system".to_string()], None, &modprobe_modules);
+        let script = cmd.create_sysext_build_script(
+            "1.0",
+            &["system".to_string()],
+            None,
+            &modprobe_modules,
+            None,
+            None,
+        );
 
         // Verify AVOCADO_MODPROBE is added with correct modules
         assert!(script.contains("if [ -n \"nfs ext4\" ]; then"));
@@ -1003,7 +1493,8 @@ mod tests {
             dnf_args: None,
         };
 
-        let script = cmd.create_sysext_build_script("1.0", &["system".to_string()], None, &[]);
+        let script =
+            cmd.create_sysext_build_script("1.0", &["system".to_string()], None, &[], None, None);
 
         // Verify sysusers.d detection logic is present
         assert!(script.contains(
@@ -1029,7 +1520,8 @@ mod tests {
             dnf_args: None,
         };
 
-        let script = cmd.create_confext_build_script("1.0", &["system".to_string()], None, &[]);
+        let script =
+            cmd.create_confext_build_script("1.0", &["system".to_string()], None, &[], None, None);
 
         // Verify sysusers.d detection logic is present for confext
         assert!(script.contains(
@@ -1052,7 +1544,8 @@ mod tests {
             dnf_args: None,
         };
 
-        let script = cmd.create_sysext_build_script("1.0", &["system".to_string()], None, &[]);
+        let script =
+            cmd.create_sysext_build_script("1.0", &["system".to_string()], None, &[], None, None);
 
         // Verify both kernel modules and sysusers.d are handled correctly with separate lines
         assert!(script.contains("echo \"AVOCADO_ON_MERGE=\\\"depmod\\\"\" >> \"$release_file\""));
@@ -1073,10 +1566,531 @@ mod tests {
             dnf_args: None,
         };
 
-        let script = cmd.create_sysext_build_script("1.0", &["system".to_string()], None, &[]);
+        let script =
+            cmd.create_sysext_build_script("1.0", &["system".to_string()], None, &[], None, None);
 
         // Verify AVOCADO_MODPROBE section exists but with empty check
         assert!(script.contains("if [ -n \"\" ]; then"));
         assert!(script.contains("AVOCADO_MODPROBE="));
+    }
+
+    #[test]
+    fn test_create_users_script_section_with_empty_password_user() {
+        let cmd = ExtBuildCommand {
+            extension: "avocado-dev".to_string(),
+            config_path: "avocado.toml".to_string(),
+            verbose: false,
+            target: None,
+            container_args: None,
+            dnf_args: None,
+        };
+
+        // Create users config matching the example in the user request
+        let mut users_config = toml::value::Table::new();
+        let mut root_user = toml::value::Table::new();
+        root_user.insert("password".to_string(), toml::Value::String("".to_string()));
+        users_config.insert("root".to_string(), toml::Value::Table(root_user));
+
+        let script = cmd.create_users_script_section(Some(&users_config), None);
+
+        // Verify the users script section contains the expected commands
+        assert!(script.contains("# Copy and manage user authentication files"));
+        assert!(script
+            .contains("Copying /etc/passwd, /etc/shadow, and /etc/group from rootfs to extension"));
+        assert!(script.contains("mkdir -p \"$AVOCADO_EXT_SYSROOTS/avocado-dev/etc\""));
+        assert!(script.contains("cp \"$AVOCADO_PREFIX/rootfs/etc/passwd\" \"$AVOCADO_EXT_SYSROOTS/avocado-dev/etc/passwd\""));
+        assert!(script.contains("cp \"$AVOCADO_PREFIX/rootfs/etc/shadow\" \"$AVOCADO_EXT_SYSROOTS/avocado-dev/etc/shadow\""));
+        assert!(script.contains("cp \"$AVOCADO_PREFIX/rootfs/etc/group\" \"$AVOCADO_EXT_SYSROOTS/avocado-dev/etc/group\""));
+        assert!(script.contains("Creating user 'root'"));
+        assert!(script.contains("[WARNING] User 'root' will be able to login with NO PASSWORD"));
+        assert!(script.contains("Setting password and aging policy for user 'root'"));
+        assert!(script.contains("chown root:root"));
+        assert!(script.contains("chmod 644"));
+        assert!(script.contains("chmod 640"));
+    }
+
+    #[test]
+    fn test_create_users_script_section_without_users() {
+        let cmd = ExtBuildCommand {
+            extension: "test-ext".to_string(),
+            config_path: "avocado.toml".to_string(),
+            verbose: false,
+            target: None,
+            container_args: None,
+            dnf_args: None,
+        };
+
+        let script = cmd.create_users_script_section(None, None);
+
+        // Should return empty string when no users config is provided
+        assert_eq!(script, "");
+    }
+
+    #[test]
+    fn test_create_users_script_section_with_non_empty_password_user() {
+        let cmd = ExtBuildCommand {
+            extension: "test-ext".to_string(),
+            config_path: "avocado.toml".to_string(),
+            verbose: false,
+            target: None,
+            container_args: None,
+            dnf_args: None,
+        };
+
+        // Create users config with a user that has a non-empty password
+        let mut users_config = toml::value::Table::new();
+        let mut user = toml::value::Table::new();
+        user.insert(
+            "password".to_string(),
+            toml::Value::String("$6$salt$hashedpassword".to_string()),
+        );
+        users_config.insert("testuser".to_string(), toml::Value::Table(user));
+
+        let script = cmd.create_users_script_section(Some(&users_config), None);
+
+        // Should now generate script for any password value
+        assert!(script.contains("# Copy and manage user authentication files"));
+        assert!(script.contains("Creating user 'testuser'"));
+        assert!(script.contains("Setting password and aging policy for user 'testuser'"));
+        assert!(script.contains("testuser:\\$6\\$salt\\$hashedpassword:"));
+        // Should NOT contain warning for hashed passwords
+        assert!(
+            !script.contains("[WARNING] User 'testuser' will be able to login with NO PASSWORD")
+        );
+    }
+
+    #[test]
+    fn test_create_users_script_section_with_invalid_password_type() {
+        let cmd = ExtBuildCommand {
+            extension: "test-ext".to_string(),
+            config_path: "avocado.toml".to_string(),
+            verbose: false,
+            target: None,
+            container_args: None,
+            dnf_args: None,
+        };
+
+        // Create users config with a user that has a non-string password
+        let mut users_config = toml::value::Table::new();
+        let mut user = toml::value::Table::new();
+        user.insert("password".to_string(), toml::Value::Integer(123));
+        users_config.insert("testuser".to_string(), toml::Value::Table(user));
+
+        let script = cmd.create_users_script_section(Some(&users_config), None);
+
+        // Should still create the basic structure and the user with default password
+        assert!(script.contains("# Copy and manage user authentication files"));
+        // Should create the user with default password "*" (no login allowed)
+        assert!(script.contains("Creating user 'testuser'"));
+        assert!(script.contains("testuser:*:19000:0:99999:7:::"));
+    }
+
+    #[test]
+    fn test_sysext_build_script_with_users() {
+        let cmd = ExtBuildCommand {
+            extension: "avocado-dev".to_string(),
+            config_path: "avocado.toml".to_string(),
+            verbose: false,
+            target: None,
+            container_args: None,
+            dnf_args: None,
+        };
+
+        // Create users config matching the example in the user request
+        let mut users_config = toml::value::Table::new();
+        let mut root_user = toml::value::Table::new();
+        root_user.insert("password".to_string(), toml::Value::String("".to_string()));
+        users_config.insert("root".to_string(), toml::Value::Table(root_user));
+
+        let script = cmd.create_sysext_build_script(
+            "1.0",
+            &["system".to_string()],
+            None,
+            &[],
+            Some(&users_config),
+            None,
+        );
+
+        // Verify the complete build script includes users functionality
+        assert!(script.contains("set -e"));
+        assert!(script.contains("# Copy and manage user authentication files"));
+        assert!(script.contains("mkdir -p \"$AVOCADO_EXT_SYSROOTS/avocado-dev/etc\""));
+        assert!(script.contains("cp \"$AVOCADO_PREFIX/rootfs/etc/passwd\" \"$AVOCADO_EXT_SYSROOTS/avocado-dev/etc/passwd\""));
+        assert!(script.contains("cp \"$AVOCADO_PREFIX/rootfs/etc/shadow\" \"$AVOCADO_EXT_SYSROOTS/avocado-dev/etc/shadow\""));
+        assert!(script.contains("cp \"$AVOCADO_PREFIX/rootfs/etc/group\" \"$AVOCADO_EXT_SYSROOTS/avocado-dev/etc/group\""));
+        assert!(script.contains("Creating user 'root'"));
+        assert!(script.contains("[WARNING] User 'root' will be able to login with NO PASSWORD"));
+        assert!(script.contains(
+            "release_dir=\"$AVOCADO_EXT_SYSROOTS/avocado-dev/usr/lib/extension-release.d\""
+        ));
+        assert!(script.contains("echo \"ID=_any\" > \"$release_file\""));
+        assert!(script.contains("echo \"SYSEXT_SCOPE=system\" >> \"$release_file\""));
+    }
+
+    #[test]
+    fn test_confext_build_script_with_users() {
+        let cmd = ExtBuildCommand {
+            extension: "avocado-dev".to_string(),
+            config_path: "avocado.toml".to_string(),
+            verbose: false,
+            target: None,
+            container_args: None,
+            dnf_args: None,
+        };
+
+        // Create users config matching the example in the user request
+        let mut users_config = toml::value::Table::new();
+        let mut root_user = toml::value::Table::new();
+        root_user.insert("password".to_string(), toml::Value::String("".to_string()));
+        users_config.insert("root".to_string(), toml::Value::Table(root_user));
+
+        let script = cmd.create_confext_build_script(
+            "1.0",
+            &["system".to_string()],
+            None,
+            &[],
+            Some(&users_config),
+            None,
+        );
+
+        // Verify the complete build script includes users functionality
+        assert!(script.contains("set -e"));
+        assert!(script.contains("# Copy and manage user authentication files"));
+        assert!(script.contains("mkdir -p \"$AVOCADO_EXT_SYSROOTS/avocado-dev/etc\""));
+        assert!(script.contains("cp \"$AVOCADO_PREFIX/rootfs/etc/passwd\" \"$AVOCADO_EXT_SYSROOTS/avocado-dev/etc/passwd\""));
+        assert!(script.contains("cp \"$AVOCADO_PREFIX/rootfs/etc/shadow\" \"$AVOCADO_EXT_SYSROOTS/avocado-dev/etc/shadow\""));
+        assert!(script.contains("cp \"$AVOCADO_PREFIX/rootfs/etc/group\" \"$AVOCADO_EXT_SYSROOTS/avocado-dev/etc/group\""));
+        assert!(script.contains("Creating user 'root'"));
+        assert!(script
+            .contains("release_dir=\"$AVOCADO_EXT_SYSROOTS/avocado-dev/etc/extension-release.d\""));
+        assert!(script.contains("echo \"ID=_any\" > \"$release_file\""));
+        assert!(script.contains("echo \"CONFEXT_SCOPE=system\" >> \"$release_file\""));
+    }
+
+    #[test]
+    fn test_warning_for_empty_password() {
+        let cmd = ExtBuildCommand {
+            extension: "warning-test".to_string(),
+            config_path: "avocado.toml".to_string(),
+            verbose: false,
+            target: None,
+            container_args: None,
+            dnf_args: None,
+        };
+
+        // Test empty password - should show warning
+        let mut empty_users_config = toml::value::Table::new();
+        let mut empty_user = toml::value::Table::new();
+        empty_user.insert("password".to_string(), toml::Value::String("".to_string()));
+        empty_users_config.insert("testuser".to_string(), toml::Value::Table(empty_user));
+
+        let empty_script = cmd.create_users_script_section(Some(&empty_users_config), None);
+        assert!(empty_script
+            .contains("[WARNING] User 'testuser' will be able to login with NO PASSWORD"));
+
+        // Test hashed password - should NOT show warning
+        let mut hashed_users_config = toml::value::Table::new();
+        let mut hashed_user = toml::value::Table::new();
+        hashed_user.insert(
+            "password".to_string(),
+            toml::Value::String("$6$salt$hash".to_string()),
+        );
+        hashed_users_config.insert("testuser".to_string(), toml::Value::Table(hashed_user));
+
+        let hashed_script = cmd.create_users_script_section(Some(&hashed_users_config), None);
+        assert!(!hashed_script
+            .contains("[WARNING] User 'testuser' will be able to login with NO PASSWORD"));
+        // Should contain escaped password
+        assert!(hashed_script.contains("testuser:\\$6\\$salt\\$hash:"));
+    }
+
+    #[test]
+    fn test_full_users_and_groups_functionality() {
+        let cmd = ExtBuildCommand {
+            extension: "test-ext".to_string(),
+            config_path: "avocado.toml".to_string(),
+            verbose: false,
+            target: None,
+            container_args: None,
+            dnf_args: None,
+        };
+
+        // Create comprehensive groups config
+        let mut groups_config = toml::value::Table::new();
+        let mut avocado_group = toml::value::Table::new();
+        avocado_group.insert("gid".to_string(), toml::Value::Integer(1000));
+        groups_config.insert("avocado".to_string(), toml::Value::Table(avocado_group));
+
+        // Create comprehensive users config
+        let mut users_config = toml::value::Table::new();
+
+        // Root user with empty password
+        let mut root_user = toml::value::Table::new();
+        root_user.insert("password".to_string(), toml::Value::String("".to_string()));
+        users_config.insert("root".to_string(), toml::Value::Table(root_user));
+
+        // Avocado user with UID, groups, and hashed password
+        let mut avocado_user = toml::value::Table::new();
+        avocado_user.insert("uid".to_string(), toml::Value::Integer(1000));
+        avocado_user.insert(
+            "groups".to_string(),
+            toml::Value::Array(vec![toml::Value::String("avocado".to_string())]),
+        );
+        avocado_user.insert(
+            "password".to_string(),
+            toml::Value::String("$6$salt$hash".to_string()),
+        );
+        users_config.insert("avocado".to_string(), toml::Value::Table(avocado_user));
+
+        let script = cmd.create_users_script_section(Some(&users_config), Some(&groups_config));
+
+        // Test group creation
+        assert!(script.contains("# Create groups"));
+        assert!(script.contains("Creating group 'avocado'"));
+        assert!(script.contains("avocado:x:1000:"));
+        assert!(script.contains("Group 'avocado' created with GID 1000"));
+
+        // Test user creation
+        assert!(script.contains("# Create and configure users"));
+        assert!(script.contains("Creating user 'root'"));
+        assert!(script.contains("Creating user 'avocado'"));
+
+        // Test UID handling
+        assert!(script.contains("avocado:x:1000:"));
+
+        // Test password warnings and settings
+        assert!(script.contains("[WARNING] User 'root' will be able to login with NO PASSWORD"));
+        assert!(!script.contains("[WARNING] User 'avocado'"));
+        assert!(script.contains("avocado:\\$6\\$salt\\$hash:"));
+
+        // Test file permissions
+        assert!(script.contains("chown root:root"));
+        assert!(script.contains("chmod 644"));
+        assert!(script.contains("chmod 640"));
+    }
+
+    #[test]
+    fn test_comprehensive_users_and_groups_schema() {
+        let cmd = ExtBuildCommand {
+            extension: "test-ext".to_string(),
+            config_path: "avocado.toml".to_string(),
+            verbose: false,
+            target: None,
+            container_args: None,
+            dnf_args: None,
+        };
+
+        // Create comprehensive users configuration using mixed approach
+        let mut users_table = toml::value::Table::new();
+
+        // Simple users use inline-style tables (represented as TOML tables in tests)
+        let mut root_table = toml::value::Table::new();
+        root_table.insert("password".to_string(), toml::Value::String("".to_string()));
+        users_table.insert("root".to_string(), toml::Value::Table(root_table));
+
+        // Complex users would use table syntax in real TOML (but represented as nested tables in tests)
+        let mut alice_table = toml::value::Table::new();
+        alice_table.insert(
+            "password".to_string(),
+            toml::Value::String("$6$salt$hash".to_string()),
+        );
+        alice_table.insert("uid".to_string(), toml::Value::Integer(1001));
+        alice_table.insert(
+            "gecos".to_string(),
+            toml::Value::String("Alice Developer".to_string()),
+        );
+        alice_table.insert(
+            "shell".to_string(),
+            toml::Value::String("/bin/zsh".to_string()),
+        );
+        alice_table.insert(
+            "groups".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("users".to_string()),
+                toml::Value::String("developers".to_string()),
+            ]),
+        );
+        users_table.insert("alice".to_string(), toml::Value::Table(alice_table));
+
+        // User with comprehensive passwd attributes
+        let mut bob_table = toml::value::Table::new();
+        bob_table.insert(
+            "password".to_string(),
+            toml::Value::String("$6$anothersalt$anotherhash".to_string()),
+        );
+        bob_table.insert("uid".to_string(), toml::Value::Integer(1002));
+        bob_table.insert("gid".to_string(), toml::Value::Integer(1002));
+        bob_table.insert(
+            "gecos".to_string(),
+            toml::Value::String("Bob Smith,DevOps,Room 123,555-1234,555-5678".to_string()),
+        );
+        bob_table.insert(
+            "home".to_string(),
+            toml::Value::String("/home/bob".to_string()),
+        );
+        bob_table.insert(
+            "shell".to_string(),
+            toml::Value::String("/bin/bash".to_string()),
+        );
+        bob_table.insert(
+            "groups".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("users".to_string()),
+                toml::Value::String("admins".to_string()),
+            ]),
+        );
+        users_table.insert("bob".to_string(), toml::Value::Table(bob_table));
+
+        // User with comprehensive shadow attributes for password aging
+        let mut charlie_table = toml::value::Table::new();
+        charlie_table.insert(
+            "password".to_string(),
+            toml::Value::String("$6$salt3$hash3".to_string()),
+        );
+        charlie_table.insert("uid".to_string(), toml::Value::Integer(1003));
+        charlie_table.insert(
+            "gecos".to_string(),
+            toml::Value::String("Charlie Security".to_string()),
+        );
+        charlie_table.insert("last_change".to_string(), toml::Value::Integer(19000));
+        charlie_table.insert("min_days".to_string(), toml::Value::Integer(7));
+        charlie_table.insert("max_days".to_string(), toml::Value::Integer(90));
+        charlie_table.insert("warn_days".to_string(), toml::Value::Integer(7));
+        charlie_table.insert("inactive_days".to_string(), toml::Value::Integer(14));
+        charlie_table.insert("expire_date".to_string(), toml::Value::Integer(20000));
+        charlie_table.insert(
+            "groups".to_string(),
+            toml::Value::Array(vec![toml::Value::String("users".to_string())]),
+        );
+        users_table.insert("charlie".to_string(), toml::Value::Table(charlie_table));
+
+        // System service user
+        let mut nginx_table = toml::value::Table::new();
+        nginx_table.insert("password".to_string(), toml::Value::String("*".to_string()));
+        nginx_table.insert("uid".to_string(), toml::Value::Integer(33));
+        nginx_table.insert("gid".to_string(), toml::Value::Integer(33));
+        nginx_table.insert(
+            "gecos".to_string(),
+            toml::Value::String("nginx web server".to_string()),
+        );
+        nginx_table.insert(
+            "home".to_string(),
+            toml::Value::String("/var/www".to_string()),
+        );
+        nginx_table.insert(
+            "shell".to_string(),
+            toml::Value::String("/usr/sbin/nologin".to_string()),
+        );
+        nginx_table.insert("system".to_string(), toml::Value::Boolean(true));
+        users_table.insert("nginx".to_string(), toml::Value::Table(nginx_table));
+
+        // Create comprehensive groups configuration
+        let mut groups_table = toml::value::Table::new();
+
+        // Basic group
+        let mut users_group_table = toml::value::Table::new();
+        users_group_table.insert("gid".to_string(), toml::Value::Integer(1000));
+        groups_table.insert("users".to_string(), toml::Value::Table(users_group_table));
+
+        // Group with members
+        let mut developers_group_table = toml::value::Table::new();
+        developers_group_table.insert("gid".to_string(), toml::Value::Integer(2000));
+        developers_group_table.insert(
+            "members".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("alice".to_string()),
+                toml::Value::String("bob".to_string()),
+            ]),
+        );
+        groups_table.insert(
+            "developers".to_string(),
+            toml::Value::Table(developers_group_table),
+        );
+
+        // System group
+        let mut admins_group_table = toml::value::Table::new();
+        admins_group_table.insert("gid".to_string(), toml::Value::Integer(27));
+        admins_group_table.insert("system".to_string(), toml::Value::Boolean(true));
+        admins_group_table.insert(
+            "members".to_string(),
+            toml::Value::Array(vec![toml::Value::String("bob".to_string())]),
+        );
+        groups_table.insert("admins".to_string(), toml::Value::Table(admins_group_table));
+
+        let script = cmd.create_users_script_section(Some(&users_table), Some(&groups_table));
+
+        // Verify the script contains expected basic setup
+        assert!(script.contains("mkdir -p \"$AVOCADO_EXT_SYSROOTS/test-ext/etc\""));
+        assert!(script.contains("cp \"$AVOCADO_PREFIX/rootfs/etc/passwd\""));
+        assert!(script.contains("cp \"$AVOCADO_PREFIX/rootfs/etc/shadow\""));
+        assert!(script.contains("cp \"$AVOCADO_PREFIX/rootfs/etc/group\""));
+
+        // Check group creation with various attributes
+        assert!(script.contains("# Create groups"));
+        assert!(script.contains("Creating group 'users'"));
+        assert!(script.contains("users:x:1000:"));
+        assert!(script.contains("Creating group 'developers'"));
+        assert!(script.contains("developers:x:2000:alice,bob"));
+        assert!(script.contains("Creating group 'admins'"));
+        assert!(script.contains("(system group)"));
+        assert!(script.contains("admins:x:27:bob"));
+
+        // Check user creation with comprehensive attributes
+        assert!(script.contains("# Create and configure users"));
+        assert!(script.contains("Creating user 'root'"));
+        assert!(script.contains("[WARNING] User 'root' will be able to login with NO PASSWORD"));
+        assert!(script.contains("root:x:$CURRENT_UID:$CURRENT_UID:root:/home/root:/bin/sh"));
+
+        assert!(script.contains("Creating user 'alice'"));
+        assert!(script.contains("alice:x:1001:$CURRENT_UID:Alice Developer:/home/alice:/bin/zsh"));
+
+        assert!(script.contains("Creating user 'bob'"));
+        assert!(script.contains(
+            "bob:x:1002:1002:Bob Smith,DevOps,Room 123,555-1234,555-5678:/home/bob:/bin/bash"
+        ));
+
+        assert!(script.contains("Creating user 'nginx' (system user)"));
+        assert!(script.contains("nginx:x:33:33:nginx web server:/var/www:/usr/sbin/nologin"));
+
+        // Check shadow file updates with comprehensive attributes (escaped for sed)
+        assert!(script.contains("root::19000:0:99999:7:::"));
+        assert!(script.contains("alice:\\$6\\$salt\\$hash:19000:0:99999:7:::"));
+        assert!(script.contains("bob:\\$6\\$anothersalt\\$anotherhash:19000:0:99999:7:::"));
+        assert!(script.contains("charlie:\\$6\\$salt3\\$hash3:19000:7:90:7:14:20000:"));
+        assert!(script.contains("nginx:*:19000:0:99999:7:::"));
+
+        // Check group membership
+        assert!(script.contains("Add user 'alice' to additional groups"));
+        assert!(script.contains("Add user 'bob' to additional groups"));
+
+        // Check permissions
+        assert!(script.contains("chmod 644 \"$AVOCADO_EXT_SYSROOTS/test-ext/etc/passwd\""));
+        assert!(script.contains("chmod 640 \"$AVOCADO_EXT_SYSROOTS/test-ext/etc/shadow\""));
+        assert!(script.contains("chmod 644 \"$AVOCADO_EXT_SYSROOTS/test-ext/etc/group\""));
+    }
+
+    #[test]
+    fn test_minimal_user_defaults() {
+        let cmd = ExtBuildCommand {
+            extension: "test-ext".to_string(),
+            config_path: "avocado.toml".to_string(),
+            verbose: false,
+            target: None,
+            container_args: None,
+            dnf_args: None,
+        };
+
+        // Test user with just name (no fields at all)
+        let mut users_table = toml::value::Table::new();
+        let empty_table = toml::value::Table::new();
+        users_table.insert("testuser".to_string(), toml::Value::Table(empty_table));
+
+        let script = cmd.create_users_script_section(Some(&users_table), None);
+
+        // Should use all defaults
+        assert!(
+            script.contains("testuser:x:$CURRENT_UID:$CURRENT_UID:testuser:/home/testuser:/bin/sh")
+        );
+        assert!(script.contains("testuser:*:19000:0:99999:7:::")); // Default password "*" (no login)
     }
 }

--- a/tests/fixtures/configs/with-users.toml
+++ b/tests/fixtures/configs/with-users.toml
@@ -1,0 +1,25 @@
+[sdk]
+image = "ghcr.io/avocado-framework/avocado-sdk:latest"
+
+[runtime.default]
+target = "x86_64-unknown-linux-gnu"
+
+[ext.avocado-dev]
+types = ["sysext", "confext"]
+packages = ["vim", "curl"]
+
+[ext.avocado-dev.users]
+# Simple users can use inline syntax
+root = { password = "" }
+
+# Complex users can use table syntax for better readability
+[ext.avocado-dev.users.avocado]
+uid = 1000
+groups = ["avocado"]
+password = "$6$9YieAo4LtYEIqB6K$og/ykbnIiXP21yc6WHAVKkkIMNE5jaho8Ijj6zFo0UlOxWGpH9xrduFc0P9UYBtQXz2LrJjx7DK7/XAObLoqh0"
+gecos = "Avocado service user"
+home = "/home/avocado"
+shell = "/bin/bash"
+
+[ext.avocado-dev.groups]
+avocado = { gid = 1000 }


### PR DESCRIPTION
Add support for managing real user accounts. Service accounts will be handled by `systemd-sysusers` however, real accounts need to modify or control the user account files in `etc`. Primarily `shadow` `passwd` `group` and `gshadow`. This PR adds an interface for designating a single extension in the config to manage users. 

For development purposes, we support setting accounts with no passwords. Here is an example on how to enable root with no password. For the remainder of the text, we will assume you are doing your user management in an `my-app` extension. We support two ways to declare and organize user and group information in the config. 

Inline syntax:
```
[ext.my-app.users]
root = {password = ""}
```

Table syntax
```
[ext.my-app.users.root]
password = ""
```

The longer form is useful is you want control over a lot of keys for that user since the config file format is TOML and TOML objects do not support multiline breaks 🙄

Here is an example of all the settings supported on users:
```
[ext.my-app.users.appuser]
password = "$6$salt$hash"
uid = 1001
gecos = "Application User"
home = "/opt/appuser"
shell = "/bin/sh"
groups = ["appuser"]
max_days = 90
warn_days = 7
```

This comprehensively covers whats would normally be accomplished via `useradd` / `usermod`. More comprehensive documentation will ensure to illustrate the options, their choices, and the defaults. For example, you can omit all uid / gid's and the system will automatically increment starting at 1000. 

Groups are similar:
Inline syntax
```
[ext.my-ext.groups]
appuser = { gid = 1000 }
```

Table syntax
```
[ext.my-ext.groups.appuser]
gid = 1000
members = ["appuser"]
```

During ext build, the rootfs databases will be copied into the ext sysroot and updated to include the user / group modifications.