### PR TITLE
set AVOCADO_SDK_TARGET in the container runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocado-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]

--- a/src/commands/runtime/deploy.rs
+++ b/src/commands/runtime/deploy.rs
@@ -92,6 +92,7 @@ impl RuntimeDeployCommand {
         // Build environment variables for the deploy process
         let mut env_vars = HashMap::new();
         env_vars.insert("AVOCADO_TARGET".to_string(), target_arch.clone());
+        env_vars.insert("AVOCADO_SDK_TARGET".to_string(), target_arch.clone());
         env_vars.insert("AVOCADO_RUNTIME".to_string(), self.runtime_name.clone());
         env_vars.insert("AVOCADO_DEPLOY_MACHINE".to_string(), self.device.clone());
 
@@ -268,11 +269,16 @@ mod tests {
         let target_arch = "x86_64";
         let mut env_vars = HashMap::new();
         env_vars.insert("AVOCADO_TARGET".to_string(), target_arch.to_string());
+        env_vars.insert("AVOCADO_SDK_TARGET".to_string(), target_arch.to_string());
         env_vars.insert("AVOCADO_RUNTIME".to_string(), cmd.runtime_name.clone());
         env_vars.insert("AVOCADO_DEPLOY_MACHINE".to_string(), cmd.device.clone());
 
         // Verify all expected environment variables are present
         assert_eq!(env_vars.get("AVOCADO_TARGET"), Some(&"x86_64".to_string()));
+        assert_eq!(
+            env_vars.get("AVOCADO_SDK_TARGET"),
+            Some(&"x86_64".to_string())
+        );
         assert_eq!(
             env_vars.get("AVOCADO_RUNTIME"),
             Some(&"my-runtime".to_string())
@@ -281,6 +287,6 @@ mod tests {
             env_vars.get("AVOCADO_DEPLOY_MACHINE"),
             Some(&"192.168.1.10".to_string())
         );
-        assert_eq!(env_vars.len(), 3); // Ensure no extra variables
+        assert_eq!(env_vars.len(), 4); // Ensure no extra variables
     }
 }

--- a/src/commands/sdk/run.rs
+++ b/src/commands/sdk/run.rs
@@ -227,6 +227,8 @@ impl SdkRunCommand {
         // Add environment variables
         container_cmd.push("-e".to_string());
         container_cmd.push(format!("AVOCADO_TARGET={}", config.target));
+        container_cmd.push("-e".to_string());
+        container_cmd.push(format!("AVOCADO_SDK_TARGET={}", config.target));
 
         // Add merged container args
         if let Some(args) = &config.container_args {

--- a/src/utils/container.rs
+++ b/src/utils/container.rs
@@ -233,6 +233,8 @@ impl SdkContainer {
         // Add environment variables
         container_cmd.push("-e".to_string());
         container_cmd.push(format!("AVOCADO_TARGET={target}"));
+        container_cmd.push("-e".to_string());
+        container_cmd.push(format!("AVOCADO_SDK_TARGET={target}"));
 
         for (key, value) in env_vars {
             container_cmd.push("-e".to_string());


### PR DESCRIPTION
fixes issues with booting qemu scripts until upstream is update with `AVOCADO_SDK_TARGET` -> `AVOCADO_TARGET`