### PR TITLE
Prebuilt Extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocado-cli"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.7.4"
+version = "0.8.0"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]

--- a/examples/ext-install-example.sh
+++ b/examples/ext-install-example.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Example install script demonstrating the use of AVOCADO_BUILD_EXT_SYSROOT
+# This script runs after SDK compilation and installs compiled code into the extension
+
+set -e
+
+echo "Installing compiled application into extension..."
+
+# The AVOCADO_BUILD_EXT_SYSROOT environment variable is automatically set
+# to the fully expanded path of the extension sysroot that has this dependency
+echo "Extension sysroot: $AVOCADO_BUILD_EXT_SYSROOT"
+
+# Example: Get application name from environment or use default
+APP_NAME=${APP_NAME:-"my-app"}
+INSTALL_PATH=${INSTALL_PATH:-"/opt/$APP_NAME"}
+
+# Check if compiled artifacts exist
+COMPILED_DIR="$AVOCADO_SDK_PREFIX/compiled/$APP_NAME"
+if [ ! -d "$COMPILED_DIR" ]; then
+    echo "Error: Compiled application not found at $COMPILED_DIR"
+    exit 1
+fi
+
+# Create installation directory in the extension sysroot
+FULL_INSTALL_PATH="$AVOCADO_BUILD_EXT_SYSROOT$INSTALL_PATH"
+mkdir -p "$FULL_INSTALL_PATH"
+
+# Copy compiled artifacts to the extension sysroot
+echo "Copying compiled artifacts to $FULL_INSTALL_PATH"
+cp -r "$COMPILED_DIR"/* "$FULL_INSTALL_PATH/"
+
+# Make binaries executable
+find "$FULL_INSTALL_PATH" -type f -name "$APP_NAME" -exec chmod +x {} \; 2>/dev/null || true
+
+# Create systemd service file in the extension sysroot
+mkdir -p "$AVOCADO_BUILD_EXT_SYSROOT/usr/lib/systemd/system"
+cat > "$AVOCADO_BUILD_EXT_SYSROOT/usr/lib/systemd/system/$APP_NAME.service" << EOF
+[Unit]
+Description=$APP_NAME Application
+After=network.target
+
+[Service]
+Type=exec
+ExecStart=$INSTALL_PATH/$APP_NAME
+Restart=always
+RestartSec=5
+User=$APP_NAME
+Group=$APP_NAME
+WorkingDirectory=$INSTALL_PATH
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Create system user via sysusers.d in the extension sysroot
+mkdir -p "$AVOCADO_BUILD_EXT_SYSROOT/usr/lib/sysusers.d"
+cat > "$AVOCADO_BUILD_EXT_SYSROOT/usr/lib/sysusers.d/$APP_NAME.conf" << EOF
+u $APP_NAME - "$APP_NAME Application User" /var/lib/$APP_NAME /bin/false
+EOF
+
+# Create application directories in the extension sysroot
+mkdir -p "$AVOCADO_BUILD_EXT_SYSROOT/var/lib/$APP_NAME"
+mkdir -p "$AVOCADO_BUILD_EXT_SYSROOT/var/log/$APP_NAME"
+
+echo "Installation completed successfully!"
+echo "Application installed to: $INSTALL_PATH"
+echo "Service file: /usr/lib/systemd/system/$APP_NAME.service"
+echo "System user: $APP_NAME"

--- a/examples/sysroot-example.toml
+++ b/examples/sysroot-example.toml
@@ -1,0 +1,29 @@
+# Example configuration showing how install scripts can use AVOCADO_BUILD_EXT_SYSROOT
+
+default_target = "qemux86-64"
+src_dir = "examples"
+
+[runtime.default]
+target = "qemux86-64"
+
+[sdk]
+image = "docker.io/avocadolinux/sdk:dev"
+
+# SDK compile section
+[sdk.compile.my-app]
+compile = "ext-compile.sh"
+
+[sdk.compile.my-app.dependencies]
+build-essential = "*"
+
+# Extension that uses compile dependency with install script
+[ext.my-extension]
+types = ["sysext"]
+
+[ext.my-extension.dependencies]
+# The install script will have access to AVOCADO_BUILD_EXT_SYSROOT
+# which points to $AVOCADO_EXT_SYSROOTS/my-extension
+my-app = { compile = "my-app", install = "ext-install-example.sh" }
+
+# Regular dependencies work as before
+some-package = "1.0.0"

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -250,11 +250,15 @@ impl BuildCommand {
                     ExtensionDependency::Versioned { name, version } => {
                         if self.verbose {
                             print_info(
-                                &format!("Skipping image creation for versioned extension '{name}' version '{version}' (installed via DNF)"),
+                                &format!("Creating image for versioned extension '{name}' version '{version}'"),
                                 OutputLevel::Normal,
                             );
                         }
-                        // Versioned extensions are installed via DNF and don't need image creation
+
+                        // Create image for versioned extension from its sysroot
+                        self.create_versioned_extension_image(name, &target).await.with_context(|| {
+                            format!("Failed to create image for versioned extension '{name}' version '{version}'")
+                        })?;
                     }
                 }
             }

--- a/src/commands/ext/build.rs
+++ b/src/commands/ext/build.rs
@@ -1282,7 +1282,9 @@ echo "Set proper permissions on authentication files""#,
             );
 
             compile_command.execute().await.with_context(|| {
-                format!("Failed to compile SDK section '{compile_section}' for dependency '{dep_name}'")
+                format!(
+                    "Failed to compile SDK section '{compile_section}' for dependency '{dep_name}'"
+                )
             })?;
 
             // Then, run the install script
@@ -1295,7 +1297,9 @@ echo "Set proper permissions on authentication files""#,
 
             if self.verbose {
                 print_info(
-                    &format!("Running install script for dependency '{dep_name}': {install_script}"),
+                    &format!(
+                        "Running install script for dependency '{dep_name}': {install_script}"
+                    ),
                     OutputLevel::Normal,
                 );
             }

--- a/src/commands/ext/deps.rs
+++ b/src/commands/ext/deps.rs
@@ -160,7 +160,18 @@ impl ExtDepsCommand {
 
         // Try extension reference
         if let Some(toml::Value::String(ext_name)) = spec_map.get("ext") {
-            return self.resolve_extension_dependency(config, ext_name);
+            // Check if this is a versioned extension (has vsn field)
+            if let Some(toml::Value::String(version)) = spec_map.get("vsn") {
+                return vec![("ext".to_string(), ext_name.clone(), version.clone())];
+            }
+            // Check if this is an external extension (has config field)
+            else if spec_map.get("config").is_some() {
+                // For external extensions, we don't have a local version, so use "*"
+                return vec![("ext".to_string(), ext_name.clone(), "*".to_string())];
+            } else {
+                // Local extension - resolve from local config
+                return self.resolve_extension_dependency(config, ext_name);
+            }
         }
 
         // Try compile reference

--- a/src/commands/ext/package.rs
+++ b/src/commands/ext/package.rs
@@ -402,9 +402,7 @@ rm -rf "$TMPDIR"
         }
 
         // RPM is now created in the container at $AVOCADO_PREFIX/output/extensions/{rpm_filename}
-        let container_rpm_path = format!(
-            "/opt/_avocado/{target}/output/extensions/{rpm_filename}"
-        );
+        let container_rpm_path = format!("/opt/_avocado/{target}/output/extensions/{rpm_filename}");
 
         // If --out is specified, copy the RPM to the host
         if let Some(output_dir) = &self.output_dir {
@@ -733,9 +731,7 @@ rm -rf "$TMPDIR"
         }
 
         // RPM is now created in the container at $AVOCADO_PREFIX/output/extensions/{rpm_filename}
-        let container_rpm_path = format!(
-            "/opt/_avocado/{target}/output/extensions/{rpm_filename}"
-        );
+        let container_rpm_path = format!("/opt/_avocado/{target}/output/extensions/{rpm_filename}");
 
         // If --out is specified, copy the RPM to the host
         if let Some(output_dir) = &self.output_dir {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -814,6 +814,7 @@ RPM_ETCCONFIGDIR=$DNF_SDK_TARGET_PREFIX \
 $DNF_SDK_HOST \
     $DNF_SDK_TARGET_REPO_CONF \
     $DNF_NO_SCRIPTS \
+    --setopt=persistdir={installroot}/var/lib/extensions/ \
     --installroot={installroot} \
     {dnf_args_str} \
     install \

--- a/src/commands/runtime/install.rs
+++ b/src/commands/runtime/install.rs
@@ -236,11 +236,20 @@ impl RuntimeInstallCommand {
             let mut packages = Vec::new();
             for (package_name, version_spec) in deps_map {
                 // Skip extension dependencies (identified by 'ext' key)
+                // Note: Extension dependencies are handled by the main install command,
+                // not by individual runtime install
                 if let toml::Value::Table(spec_map) = version_spec {
                     if spec_map.contains_key("ext") {
                         if self.verbose {
+                            let dep_type = if spec_map.contains_key("vsn") {
+                                "versioned extension"
+                            } else if spec_map.contains_key("config") {
+                                "external extension"
+                            } else {
+                                "local extension"
+                            };
                             print_debug(
-                                &format!("Skipping extension dependency '{package_name}' (will be handled by runtime build)"),
+                                &format!("Skipping {dep_type} dependency '{package_name}' (handled by main install command)"),
                                 OutputLevel::Normal,
                             );
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1276,9 +1276,9 @@ enum ExtCommands {
         /// Name of the extension to package
         #[arg(short = 'e', long = "extension", required = true)]
         extension: String,
-        /// Target architecture (e.g., x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu)
-        #[arg(short = 't', long = "target", required = true)]
-        target: String,
+        /// Target architecture
+        #[arg(short, long)]
+        target: Option<String>,
         /// Output directory on host for the RPM package (relative or absolute path). If not specified, RPM stays in container at $AVOCADO_PREFIX/output/extensions
         #[arg(long = "out-dir")]
         output_dir: Option<String>,


### PR DESCRIPTION
* ext package will now also package sdk deps into a <ext package>-sdk package of arch all_avocadosdk.
* add install script execution support for sdk.compile block deps of extensions
* add support for installing prebuilt extensions from the repo using `{ vsn = "<vsn>" }`