### PR TITLE
Add config option for weak deps Default enabled

### DIFF
--- a/src/commands/ext/install.rs
+++ b/src/commands/ext/install.rs
@@ -163,6 +163,7 @@ impl ExtInstallCommand {
                     repo_url.as_ref(),
                     repo_release.as_ref(),
                     &merged_container_args,
+                    config.get_sdk_disable_weak_dependencies(),
                 )
                 .await?
             {
@@ -194,6 +195,7 @@ impl ExtInstallCommand {
         repo_url: Option<&String>,
         repo_release: Option<&String>,
         merged_container_args: &Option<Vec<String>>,
+        disable_weak_dependencies: bool,
     ) -> Result<bool> {
         // Create the commands to check and set up the directory structure
         let check_command = format!("[ -d $AVOCADO_EXT_SYSROOTS/{extension} ]");
@@ -400,6 +402,7 @@ $DNF_SDK_HOST \
                     repo_release: repo_release.cloned(),
                     container_args: merged_container_args.clone(),
                     dnf_args: self.dnf_args.clone(),
+                    disable_weak_dependencies,
                     ..Default::default()
                 };
                 let install_success = container_helper.run_in_container(run_config).await?;

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -554,6 +554,7 @@ impl InstallCommand {
             repo_release: repo_release.clone(),
             container_args: merged_container_args.clone(),
             dnf_args: self.dnf_args.clone(),
+            disable_weak_dependencies: config.get_sdk_disable_weak_dependencies(),
             ..Default::default()
         };
         let sysroot_exists = container_helper.run_in_container(run_config).await?;
@@ -574,6 +575,7 @@ impl InstallCommand {
                 repo_release: repo_release.clone(),
                 container_args: merged_container_args.clone(),
                 dnf_args: self.dnf_args.clone(),
+                disable_weak_dependencies: config.get_sdk_disable_weak_dependencies(),
                 ..Default::default()
             };
             let success = container_helper.run_in_container(run_config).await?;
@@ -695,6 +697,7 @@ $DNF_SDK_HOST \
                         repo_release,
                         container_args: merged_container_args,
                         dnf_args: self.dnf_args.clone(),
+                        disable_weak_dependencies: config.get_sdk_disable_weak_dependencies(),
                         ..Default::default()
                     };
 
@@ -756,6 +759,7 @@ $DNF_SDK_HOST \
             repo_release: repo_release.clone(),
             container_args: merged_container_args.clone(),
             dnf_args: self.dnf_args.clone(),
+            disable_weak_dependencies: config.get_sdk_disable_weak_dependencies(),
             ..Default::default()
         };
         let sysroot_exists = container_helper.run_in_container(run_config).await?;
@@ -775,6 +779,7 @@ $DNF_SDK_HOST \
                 repo_release: repo_release.clone(),
                 container_args: merged_container_args.clone(),
                 dnf_args: self.dnf_args.clone(),
+                disable_weak_dependencies: config.get_sdk_disable_weak_dependencies(),
                 ..Default::default()
             };
             let success = container_helper.run_in_container(run_config).await?;
@@ -808,6 +813,8 @@ $DNF_SDK_HOST \
             String::new()
         };
 
+        // Always disable weak dependencies for versioned extensions since they're pre-built
+        // and need to be installed exactly as specified without pulling in recommends
         let install_command = format!(
             r#"
 RPM_CONFIGDIR=$AVOCADO_SDK_PREFIX/ext-rpm-config \
@@ -844,6 +851,7 @@ $DNF_SDK_HOST \
             repo_release,
             container_args: merged_container_args,
             dnf_args: self.dnf_args.clone(),
+            disable_weak_dependencies: config.get_sdk_disable_weak_dependencies(),
             ..Default::default()
         };
 

--- a/src/commands/runtime/install.rs
+++ b/src/commands/runtime/install.rs
@@ -337,6 +337,7 @@ $DNF_SDK_HOST \
                     repo_release: repo_release.cloned(),
                     container_args: merged_container_args.clone(),
                     dnf_args: self.dnf_args.clone(),
+                    disable_weak_dependencies: config.get_sdk_disable_weak_dependencies(),
                     ..Default::default()
                 };
                 let success = container_helper.run_in_container(run_config).await?;

--- a/src/commands/sdk/install.rs
+++ b/src/commands/sdk/install.rs
@@ -139,7 +139,7 @@ $DNF_SDK_HOST \
             );
 
             // Use the container helper's run_in_container method
-            let config = RunConfig {
+            let run_config = RunConfig {
                 container_image: container_image.to_string(),
                 target: target.clone(),
                 command,
@@ -150,9 +150,10 @@ $DNF_SDK_HOST \
                 repo_release: repo_release.clone(),
                 container_args: merged_container_args.clone(),
                 dnf_args: self.dnf_args.clone(),
+                disable_weak_dependencies: config.get_sdk_disable_weak_dependencies(),
                 ..Default::default()
             };
-            let install_success = container_helper.run_in_container(config).await?;
+            let install_success = container_helper.run_in_container(run_config).await?;
 
             if install_success {
                 print_success("Installed SDK dependencies.", OutputLevel::Normal);
@@ -208,7 +209,7 @@ $DNF_SDK_HOST \
                     );
 
                     // Use the container helper's run_in_container method with target-dev installroot
-                    let config = RunConfig {
+                    let run_config = RunConfig {
                         container_image: container_image.to_string(),
                         target: target.clone(),
                         command,
@@ -219,9 +220,10 @@ $DNF_SDK_HOST \
                         repo_release: repo_release.clone(),
                         container_args: merged_container_args.clone(),
                         dnf_args: self.dnf_args.clone(),
+                        disable_weak_dependencies: config.get_sdk_disable_weak_dependencies(),
                         ..Default::default()
                     };
-                    let install_success = container_helper.run_in_container(config).await?;
+                    let install_success = container_helper.run_in_container(run_config).await?;
 
                     if !install_success {
                         return Err(anyhow::anyhow!(

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -44,6 +44,7 @@ pub struct SdkConfig {
     pub repo_url: Option<String>,
     pub repo_release: Option<String>,
     pub container_args: Option<Vec<String>>,
+    pub disable_weak_dependencies: Option<bool>,
 }
 
 /// Compile configuration for SDK
@@ -328,6 +329,15 @@ impl Config {
     /// Get the SDK container args from configuration
     pub fn get_sdk_container_args(&self) -> Option<&Vec<String>> {
         self.sdk.as_ref()?.container_args.as_ref()
+    }
+
+    /// Get the disable_weak_dependencies setting from SDK configuration
+    /// Returns the configured value or false (enable weak deps) if not set
+    pub fn get_sdk_disable_weak_dependencies(&self) -> bool {
+        self.sdk
+            .as_ref()
+            .and_then(|sdk| sdk.disable_weak_dependencies)
+            .unwrap_or(false) // Default to false (enable weak dependencies)
     }
 
     /// Get provision profile configuration


### PR DESCRIPTION
Disable weak deps when installing versioned extensions. Weak deps were disabled to prevent versioned extensions from being mis identified as weak deps of other packages. This problem was fixed in two ways. First, we disable the extensions repo when installing pakages into other extensions. Second, when generating PBE packages, we disable rpm's clever scanning to eliminate a PBE from having any external deps or declaring that it is the provider of anything in its contents. Weak deps are convenient, now that we fixed weak deps problems with PBE's  re enable them and add an [sdk] config option to `disable_weak_dependencies = true` if users want to disable them