### PR TITLE
Enable scriptlets on ext install

### DIFF
--- a/src/commands/ext/install.rs
+++ b/src/commands/ext/install.rs
@@ -369,9 +369,12 @@ impl ExtInstallCommand {
                 };
                 let command = format!(
                     r#"
+RPM_NO_CHROOT_FOR_SCRIPTS=1 \
+AVOCADO_EXT_INSTALLROOT={} \
+PATH=$AVOCADO_SDK_PREFIX/ext-rpm-config-scripts/bin:$PATH \
+RPM_CONFIGDIR=$AVOCADO_SDK_PREFIX/ext-rpm-config-scripts \
 RPM_ETCCONFIGDIR=$DNF_SDK_TARGET_PREFIX \
 $DNF_SDK_HOST \
-    $DNF_NO_SCRIPTS \
     $DNF_SDK_TARGET_REPO_CONF \
     --installroot={} \
     --disablerepo=${{AVOCADO_TARGET}}-target-ext \
@@ -380,6 +383,7 @@ $DNF_SDK_HOST \
     {} \
     {}
 "#,
+                    installroot,
                     installroot,
                     dnf_args_str,
                     yes,

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -662,10 +662,13 @@ impl InstallCommand {
                     };
                     let install_command = format!(
                         r#"
+RPM_NO_CHROOT_FOR_SCRIPTS=1 \
+AVOCADO_EXT_INSTALLROOT={} \
+PATH=$AVOCADO_SDK_PREFIX/ext-rpm-config-scripts/bin:$PATH \
+RPM_CONFIGDIR=$AVOCADO_SDK_PREFIX/ext-rpm-config-scripts \
 RPM_ETCCONFIGDIR=$DNF_SDK_TARGET_PREFIX \
 $DNF_SDK_HOST \
     $DNF_SDK_TARGET_REPO_CONF \
-    $DNF_NO_SCRIPTS \
     --installroot={} \
     --disablerepo=${{AVOCADO_TARGET}}-target-ext \
     {} \
@@ -673,6 +676,7 @@ $DNF_SDK_HOST \
     {} \
     {}
 "#,
+                        installroot,
                         installroot,
                         dnf_args_str,
                         yes,
@@ -691,8 +695,8 @@ $DNF_SDK_HOST \
                         target: target.to_string(),
                         command: install_command,
                         verbose: self.verbose,
-                        source_environment: false, // don't source environment (same as regular extensions)
-                        interactive: !self.force, // interactive if not forced (same as regular extensions)
+                        source_environment: false, // don't source environment
+                        interactive: !self.force,  // interactive if not forced
                         repo_url,
                         repo_release,
                         container_args: merged_container_args,
@@ -820,8 +824,8 @@ $DNF_SDK_HOST \
 RPM_CONFIGDIR=$AVOCADO_SDK_PREFIX/ext-rpm-config \
 RPM_ETCCONFIGDIR=$DNF_SDK_TARGET_PREFIX \
 $DNF_SDK_HOST \
-    $DNF_SDK_TARGET_REPO_CONF \
     $DNF_NO_SCRIPTS \
+    $DNF_SDK_TARGET_REPO_CONF \
     --setopt=persistdir={installroot}/var/lib/extension.d/ \
     --installroot={installroot} \
     --enablerepo=${{AVOCADO_TARGET}}-target-ext \


### PR DESCRIPTION
Execution of scriptlets was disabled when installing packages into extension sysroots since the extension sysroot did not contain host executables and `--installroot` was causing dnf to chroot into the sysroot therefore isolating scriptlet execution to whats available within the env. This was causing issues with packages using update alternatives to fail to write the final symlink. For example `i2cdetect` from `i2ctools` is installed as `i2cdetect.i2ctools`. The package would call `update-alternatives` in its scriptlets to create the `i2cdetect` symlink and point it to the version installed from i2ctools.

This PR fixes this by:
* Enables scriptlets for extension installs and runs scriptlets outside the chroot
* Configures RPM macros to point to SDK executables. 
* Created a shim for `update-alternatives` to prefix the paths with the non-chrooted prefix. 