### PR TITLE
Update avocado init configs with default ext version string

### DIFF
--- a/configs/advantech/icam-540.toml
+++ b/configs/advantech/icam-540.toml
@@ -24,6 +24,7 @@ avocado-bsp-icam-540 = { ext = "avocado-bsp-icam-540", config = "bsp/icam-540/av
 
 [ext.app]
 types = ["sysext", "confext"]
+version = "0.1.0"
 
 [ext.app.dependencies]
 i2c-tools = "*"
@@ -47,6 +48,7 @@ udev-hwdb = "*"
 
 [ext.config]
 types = ["confext"]
+version = "0.1.0"
 
 [ext.config.users.root]
 password = ""

--- a/configs/default.toml
+++ b/configs/default.toml
@@ -24,6 +24,7 @@ app = { ext = "app" }
 # Use or modify this to install dependencies and or include sdk compiled code
 [ext.app]
 types = ["sysext", "confext"]
+version = "0.1.0"
 
 # Install application dependencies
 [ext.app.dependencies]
@@ -35,6 +36,7 @@ types = ["sysext", "confext"]
 # or configure other system services
 [ext.config]
 types = ["confext"]
+version = "0.1.0"
 
 # NOT FOR PRODUCTION: Set root password to empty string
 [ext.config.users.root]

--- a/configs/nvidia/jetson-orin-nano-devkit.toml
+++ b/configs/nvidia/jetson-orin-nano-devkit.toml
@@ -25,6 +25,7 @@ avocado-img-tegraflash = "*"
 # Use or modify this to install dependencies and or include sdk compiled code
 [ext.app]
 types = ["sysext", "confext"]
+version = "0.1.0"
 
 # Install application dependencies
 [ext.app.dependencies]
@@ -36,6 +37,7 @@ types = ["sysext", "confext"]
 # or configure other system services
 [ext.config]
 types = ["confext"]
+version = "0.1.0"
 
 # NOT FOR PRODUCTION: Set root password to empty string
 [ext.config.users.root]

--- a/configs/qemu/qemuarm64.toml
+++ b/configs/qemu/qemuarm64.toml
@@ -24,6 +24,7 @@ app = { ext = "app" }
 # Use or modify this to install dependencies and or include sdk compiled code
 [ext.app]
 types = ["sysext", "confext"]
+version = "0.1.0"
 
 # Install application dependencies
 [ext.app.dependencies]
@@ -35,6 +36,7 @@ types = ["sysext", "confext"]
 # or configure other system services
 [ext.config]
 types = ["confext"]
+version = "0.1.0"
 
 # NOT FOR PRODUCTION: Set root password to empty string
 [ext.config.users.root]

--- a/configs/qemu/qemux86-64.toml
+++ b/configs/qemu/qemux86-64.toml
@@ -24,6 +24,7 @@ app = { ext = "app" }
 # Use or modify this to install dependencies and or include sdk compiled code
 [ext.app]
 types = ["sysext", "confext"]
+version = "0.1.0"
 
 # Install application dependencies
 [ext.app.dependencies]
@@ -35,6 +36,7 @@ types = ["sysext", "confext"]
 # or configure other system services
 [ext.config]
 types = ["confext"]
+version = "0.1.0"
 
 # NOT FOR PRODUCTION: Set root password to empty string
 [ext.config.users.root]

--- a/configs/raspberry-pi/raspberrypi-4-model-b.toml
+++ b/configs/raspberry-pi/raspberrypi-4-model-b.toml
@@ -24,6 +24,7 @@ app = { ext = "app" }
 # Use or modify this to install dependencies and or include sdk compiled code
 [ext.app]
 types = ["sysext", "confext"]
+version = "0.1.0"
 
 # Install application dependencies
 [ext.app.dependencies]
@@ -35,6 +36,7 @@ types = ["sysext", "confext"]
 # or configure other system services
 [ext.config]
 types = ["confext"]
+version = "0.1.0"
 
 # NOT FOR PRODUCTION: Set root password to empty string
 [ext.config.users.root]

--- a/configs/raspberry-pi/raspberrypi-5.toml
+++ b/configs/raspberry-pi/raspberrypi-5.toml
@@ -24,6 +24,7 @@ app = { ext = "app" }
 # Use or modify this to install dependencies and or include sdk compiled code
 [ext.app]
 types = ["sysext", "confext"]
+version = "0.1.0"
 
 # Install application dependencies
 [ext.app.dependencies]
@@ -35,6 +36,7 @@ types = ["sysext", "confext"]
 # or configure other system services
 [ext.config]
 types = ["confext"]
+version = "0.1.0"
 
 # NOT FOR PRODUCTION: Set root password to empty string
 [ext.config.users.root]

--- a/configs/seeed/reterminal-dm.toml
+++ b/configs/seeed/reterminal-dm.toml
@@ -24,6 +24,7 @@ app = { ext = "app" }
 # Use or modify this to install dependencies and or include sdk compiled code
 [ext.app]
 types = ["sysext", "confext"]
+version = "0.1.0"
 
 # Install application dependencies
 [ext.app.dependencies]
@@ -35,6 +36,7 @@ types = ["sysext", "confext"]
 # or configure other system services
 [ext.config]
 types = ["confext"]
+version = "0.1.0"
 
 # NOT FOR PRODUCTION: Set root password to empty string
 [ext.config.users.root]

--- a/configs/seeed/reterminal.toml
+++ b/configs/seeed/reterminal.toml
@@ -24,6 +24,7 @@ app = { ext = "app" }
 # Use or modify this to install dependencies and or include sdk compiled code
 [ext.app]
 types = ["sysext", "confext"]
+version = "0.1.0"
 
 # Install application dependencies
 [ext.app.dependencies]
@@ -35,6 +36,7 @@ types = ["sysext", "confext"]
 # or configure other system services
 [ext.config]
 types = ["confext"]
+version = "0.1.0"
 
 # NOT FOR PRODUCTION: Set root password to empty string
 [ext.config.users.root]


### PR DESCRIPTION
Recent commits require that all extensions define a version. Update `avocado init` template configuration files to include a default starting version of 0.1.0