### PR TITLE
Identify exact prebuilt extension names and version

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -870,8 +870,16 @@ $DNF_SDK_HOST \
             ));
         }
 
+        let version_msg = if version == "*" {
+            "latest version".to_string()
+        } else {
+            format!("version '{version}'")
+        };
+
         print_info(
-            &format!("Successfully installed versioned extension '{extension_name}' version '{version}'."),
+            &format!(
+                "Successfully installed versioned extension '{extension_name}' {version_msg}."
+            ),
             crate::utils::output::OutputLevel::Normal,
         );
 


### PR DESCRIPTION
The extensions enabled for a runtime are available from within `avocado provision` scripts via the `AVOCADO_EXT_LIST` variable. When extensions are pre-built and installed via the extension package repos, the names of the extension built image files should be resolved with `<extname>-<version>.raw` instead of splatting with `*`. This was causing issues with provisioning scripts resolving rhe exact raw images.

```
WARNING: Extension image not found: /opt/_avocado/jetson-orin-nano-devkit/output/extensions/avocado-ext-sshd-dev-*.raw
```

This PR resolves pre-built extension versions from the RPM database instead of using splat. 