### PR TITLE
update provision to support --out

### DIFF
--- a/src/commands/provision.rs
+++ b/src/commands/provision.rs
@@ -21,6 +21,8 @@ pub struct ProvisionConfig {
     pub provision_profile: Option<String>,
     /// Environment variables to pass to the provision process
     pub env_vars: Option<HashMap<String, String>>,
+    /// Output path relative to src_dir for provisioning artifacts
+    pub out: Option<String>,
     /// Additional arguments to pass to the container runtime
     pub container_args: Option<Vec<String>>,
     /// Additional arguments to pass to DNF commands
@@ -58,6 +60,7 @@ impl ProvisionCommand {
                 target: self.config.target.clone(),
                 provision_profile: self.config.provision_profile.clone(),
                 env_vars: self.config.env_vars.clone(),
+                out: self.config.out.clone(),
                 container_args: merged_container_args,
                 dnf_args: self.config.dnf_args.clone(),
             },
@@ -84,6 +87,7 @@ mod tests {
             target: Some("x86_64".to_string()),
             provision_profile: None,
             env_vars: Some(env_vars.clone()),
+            out: None,
             container_args: Some(vec!["--privileged".to_string()]),
             dnf_args: Some(vec!["--nogpgcheck".to_string()]),
         };
@@ -95,6 +99,7 @@ mod tests {
         assert!(!cmd.config.force);
         assert_eq!(cmd.config.target, Some("x86_64".to_string()));
         assert_eq!(cmd.config.env_vars, Some(env_vars));
+        assert_eq!(cmd.config.out, None);
         assert_eq!(
             cmd.config.container_args,
             Some(vec!["--privileged".to_string()])
@@ -112,6 +117,7 @@ mod tests {
             target: None,
             provision_profile: None,
             env_vars: None,
+            out: None,
             container_args: None,
             dnf_args: None,
         };
@@ -123,6 +129,7 @@ mod tests {
         assert!(cmd.config.force);
         assert_eq!(cmd.config.target, None);
         assert_eq!(cmd.config.env_vars, None);
+        assert_eq!(cmd.config.out, None);
         assert_eq!(cmd.config.container_args, None);
         assert_eq!(cmd.config.dnf_args, None);
     }
@@ -143,6 +150,7 @@ mod tests {
             target: None,
             provision_profile: Some("production".to_string()),
             env_vars: Some(expected_env.clone()),
+            out: None,
             container_args: None,
             dnf_args: None,
         };
@@ -150,5 +158,25 @@ mod tests {
 
         assert_eq!(cmd.config.runtime, "my-runtime");
         assert_eq!(cmd.config.env_vars, Some(expected_env));
+    }
+
+    #[test]
+    fn test_new_with_out_path() {
+        let config = ProvisionConfig {
+            runtime: "test-runtime".to_string(),
+            config_path: "avocado.toml".to_string(),
+            verbose: false,
+            force: false,
+            target: None,
+            provision_profile: None,
+            env_vars: None,
+            out: Some("output".to_string()),
+            container_args: None,
+            dnf_args: None,
+        };
+        let cmd = ProvisionCommand::new(config);
+
+        assert_eq!(cmd.config.runtime, "test-runtime");
+        assert_eq!(cmd.config.out, Some("output".to_string()));
     }
 }

--- a/src/commands/runtime/provision.rs
+++ b/src/commands/runtime/provision.rs
@@ -15,6 +15,7 @@ pub struct RuntimeProvisionConfig {
     pub target: Option<String>,
     pub provision_profile: Option<String>,
     pub env_vars: Option<HashMap<String, String>>,
+    pub out: Option<String>,
     pub container_args: Option<Vec<String>>,
     pub dnf_args: Option<Vec<String>>,
 }
@@ -93,6 +94,15 @@ impl RuntimeProvisionCommand {
                 resolved_extensions.join(" "),
             );
         }
+
+        // Set AVOCADO_PROVISION_OUT if --out is specified
+        if let Some(out_path) = &self.config.out {
+            // Construct the absolute path from the container's perspective
+            // The src_dir is mounted at /opt/src in the container
+            let container_out_path = format!("/opt/src/{}", out_path);
+            env_vars.insert("AVOCADO_PROVISION_OUT".to_string(), container_out_path);
+        }
+
         let env_vars = if env_vars.is_empty() {
             None
         } else {
@@ -340,6 +350,7 @@ mod tests {
             target: Some("x86_64".to_string()),
             provision_profile: None,
             env_vars: None,
+            out: None,
             container_args: None,
             dnf_args: None,
         };
@@ -351,6 +362,7 @@ mod tests {
         assert!(!cmd.config.force);
         assert_eq!(cmd.config.target, Some("x86_64".to_string()));
         assert_eq!(cmd.config.env_vars, None);
+        assert_eq!(cmd.config.out, None);
     }
 
     #[test]
@@ -363,6 +375,7 @@ mod tests {
             target: Some("x86_64".to_string()),
             provision_profile: None,
             env_vars: None,
+            out: None,
             container_args: None,
             dnf_args: None,
         };
@@ -404,6 +417,7 @@ ext_two = { ext = "beta-ext", vsn = "2.0.0" }
             target: Some("x86_64".to_string()),
             provision_profile: None,
             env_vars: None,
+            out: None,
             container_args: None,
             dnf_args: None,
         };
@@ -444,6 +458,7 @@ ext_two = { ext = "beta-ext", vsn = "2.0.0" }
             target: Some("x86_64".to_string()),
             provision_profile: None,
             env_vars: None,
+            out: None,
             container_args: container_args.clone(),
             dnf_args: dnf_args.clone(),
         };
@@ -455,6 +470,7 @@ ext_two = { ext = "beta-ext", vsn = "2.0.0" }
         assert!(!cmd.config.force);
         assert_eq!(cmd.config.target, Some("x86_64".to_string()));
         assert_eq!(cmd.config.env_vars, None);
+        assert_eq!(cmd.config.out, None);
         assert_eq!(cmd.config.container_args, container_args);
         assert_eq!(cmd.config.dnf_args, dnf_args);
     }
@@ -476,6 +492,7 @@ ext_two = { ext = "beta-ext", vsn = "2.0.0" }
             target: Some("x86_64".to_string()),
             provision_profile: None,
             env_vars: Some(env_vars.clone()),
+            out: None,
             container_args: None,
             dnf_args: None,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,9 @@ enum Commands {
         /// Environment variables to pass to the provision process
         #[arg(long = "env", num_args = 1, action = clap::ArgAction::Append)]
         env: Option<Vec<String>>,
+        /// Output path relative to src_dir for provisioning artifacts
+        #[arg(long = "out")]
+        out: Option<String>,
         /// Additional arguments to pass to the container runtime
         #[arg(long = "container-arg", num_args = 1, allow_hyphen_values = true, action = clap::ArgAction::Append)]
         container_args: Option<Vec<String>>,
@@ -438,6 +441,9 @@ enum RuntimeCommands {
         /// Environment variables to pass to the provision process
         #[arg(long = "env", num_args = 1, action = clap::ArgAction::Append)]
         env: Option<Vec<String>>,
+        /// Output path relative to src_dir for provisioning artifacts
+        #[arg(long = "out")]
+        out: Option<String>,
         /// Additional arguments to pass to the container runtime
         #[arg(long = "container-arg", num_args = 1, allow_hyphen_values = true, action = clap::ArgAction::Append)]
         container_args: Option<Vec<String>>,
@@ -673,6 +679,7 @@ async fn main() -> Result<()> {
             target,
             provision_profile,
             env,
+            out,
             container_args,
             dnf_args,
         } => {
@@ -685,6 +692,7 @@ async fn main() -> Result<()> {
                     target: target.or(cli.target),
                     provision_profile: provision_profile.clone(),
                     env_vars: build_env_vars(provision_profile.as_ref(), env.as_ref()),
+                    out,
                     container_args,
                     dnf_args,
                 });
@@ -762,6 +770,7 @@ async fn main() -> Result<()> {
                 target,
                 provision_profile,
                 env,
+                out,
                 container_args,
                 dnf_args,
             } => {
@@ -774,6 +783,7 @@ async fn main() -> Result<()> {
                         target: target.or(cli.target),
                         provision_profile: provision_profile.clone(),
                         env_vars: build_env_vars(provision_profile.as_ref(), env.as_ref()),
+                        out,
                         container_args,
                         dnf_args,
                     },


### PR DESCRIPTION
Adds `avocado provision --out <path>` where the path is relative to the `src_dir`. When this is set, a provisioning script will receive it in the script via `AVOCADO_PROVISION_OUT=<abs_path>` where the path is translated to an absolute path in the container to the loaction of the mounted src dir. 