### PR TITLE
Release avocado-cli 0.29.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocado-cli"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.29.0"
+version = "0.29.1"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -1514,9 +1514,38 @@ echo "Copying required extension images to runtime-specific directory..."
 {update_authority_section}
 {docker_section}
 
+VAR_IMAGE="$OUTPUT_DIR/avocado-image-var-$TARGET_ARCH.btrfs"
+VAR_INPUT_SIZE=$(du -sb "$VAR_DIR" 2>/dev/null | awk '{{print $1}}')
+VAR_INPUT_MB=$(( VAR_INPUT_SIZE / 1048576 ))
+echo "Building var image (${{VAR_INPUT_MB}}MB source)..."
+
+# Background progress reporter — prints size and estimated % every 5s
+(
+    while [ ! -f "$VAR_IMAGE" ]; do sleep 1; done
+    while kill -0 $$ 2>/dev/null; do
+        CUR=$(stat -c%s "$VAR_IMAGE" 2>/dev/null || echo 0)
+        CUR_MB=$(( CUR / 1048576 ))
+        if [ "$VAR_INPUT_SIZE" -gt 0 ] 2>/dev/null; then
+            PCT=$(( CUR * 100 / VAR_INPUT_SIZE ))
+            [ "$PCT" -gt 99 ] && PCT=99
+            printf "\r  var image: %dMB written (~%d%%)" "$CUR_MB" "$PCT"
+        else
+            printf "\r  var image: %dMB written" "$CUR_MB"
+        fi
+        sleep 5
+    done
+) &
+_PROGRESS_PID=$!
+
 mkfs.btrfs -r "$VAR_DIR" \
     --subvol rw:lib/avocado \
-    -f "$OUTPUT_DIR/avocado-image-var-$TARGET_ARCH.btrfs"
+    -f "$VAR_IMAGE"
+
+kill $_PROGRESS_PID 2>/dev/null; wait $_PROGRESS_PID 2>/dev/null || true
+FINAL_SIZE=$(stat -c%s "$VAR_IMAGE" 2>/dev/null || echo 0)
+FINAL_MB=$(( FINAL_SIZE / 1048576 ))
+echo ""
+echo "Built var image: ${{FINAL_MB}}MB"
 
 # Build OS bundle (.aos) — needs rootfs + initramfs + kernel + var (all built above)
 STONE_MANIFEST="${{AVOCADO_STONE_MANIFEST:-$AVOCADO_SDK_PREFIX/stone/stone-$TARGET_ARCH.json}}"

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -1393,16 +1393,16 @@ esac
 
 # The SDK container may have the host's /sys bind-mounted (-v /sys:/sys),
 # and --privileged gives write access even without that flag.
-# Overmount /sys/fs/cgroup with a private hierarchy so the inner dockerd
-# cannot write into the host's cgroup tree.  When we umount afterwards
-# the host hierarchy is restored untouched.
+# Make the /sys/fs/cgroup mount private so the inner dockerd's mount
+# events do not propagate to the host.  A bind+private mount preserves
+# the existing cgroup controllers (required by dockerd) while isolating
+# mount propagation.
 _AVOCADO_CGROUP_PRIVATE=0
-if mount -t cgroup2 cgroup2 /sys/fs/cgroup 2>/dev/null; then
-    _AVOCADO_CGROUP_PRIVATE=1
-elif mount -t tmpfs tmpfs /sys/fs/cgroup 2>/dev/null; then
+if mount --bind /sys/fs/cgroup /sys/fs/cgroup 2>/dev/null \
+   && mount --make-private /sys/fs/cgroup 2>/dev/null; then
     _AVOCADO_CGROUP_PRIVATE=1
 else
-    echo "WARNING: Could not overmount /sys/fs/cgroup — inner dockerd may leave stale cgroup entries on the host."
+    echo "WARNING: Could not make /sys/fs/cgroup private — inner dockerd may leave stale cgroup entries on the host."
 fi
 
 # When the SDK container uses --network=host the inner dockerd shares the


### PR DESCRIPTION
## Summary
- **fix:** fake systemctl line parsing (e252032)
- **fix:** Use bind+private mount for cgroups to preserve controllers — the previous cgroup2/tmpfs overmount removed existing controllers needed by dockerd inside the SDK container
- **feat:** Add progress indicator for var image build — prints size and estimated percentage every 5 seconds during `mkfs.btrfs`
- Bump version to 0.29.1

## Test plan
- [ ] Verify runtime build completes successfully inside an SDK container with `--privileged`
- [ ] Confirm cgroup controllers are preserved and inner dockerd starts correctly
- [ ] Observe progress output during var image creation for large builds
- [ ] Verify fake systemctl line parsing works correctly