### PR TITLE
Release 0.34.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,19 @@ jobs:
             suffix: .exe
 
     steps:
-      - name: install aws-lc-rs build pre-reqs for windows
-        if: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
+      - name: Install build pre-reqs (Windows)
+        if: ${{ runner.os == 'Windows' }}
         run: |
-          choco install nasm -y
+          choco install nasm cmake -y
           echo "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install cmake (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        run: brew install cmake
+
+      - name: Install cmake (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        run: sudo apt-get update && sudo apt-get install -y cmake
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -24,6 +24,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
+      - name: Install cmake
+        run: sudo apt-get update && sudo apt-get install -y cmake
+
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocado-cli"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]


### PR DESCRIPTION
## Summary
- Bump avocado-cli version from 0.33.0 to 0.34.0 in Cargo.toml and Cargo.lock

## Test plan
- [ ] Verify `avocado --version` reports 0.34.0
- [ ] CI passes