### PR TITLE
Add avocado connect clean command

### DIFF
--- a/src/commands/connect/clean.rs
+++ b/src/commands/connect/clean.rs
@@ -25,7 +25,10 @@ impl ConnectCleanCommand {
         // 1. Remove connect: section from avocado.yaml
         match config_edit::remove_connect_fields(config_path) {
             Ok(true) => {
-                print_success("Removed connect section from avocado.yaml.", OutputLevel::Normal);
+                print_success(
+                    "Removed connect section from avocado.yaml.",
+                    OutputLevel::Normal,
+                );
                 any_changes = true;
             }
             Ok(false) => {

--- a/src/commands/connect/clean.rs
+++ b/src/commands/connect/clean.rs
@@ -1,0 +1,98 @@
+use anyhow::{Context, Result};
+use std::path::Path;
+
+use crate::utils::config_edit;
+use crate::utils::output::{print_info, print_success, print_warning, OutputLevel};
+
+pub struct ConnectCleanCommand {
+    pub runtime: String,
+    pub config_path: String,
+}
+
+impl ConnectCleanCommand {
+    pub fn execute(&self) -> Result<()> {
+        let config_path = Path::new(&self.config_path);
+        if !config_path.exists() {
+            anyhow::bail!(
+                "Config file '{}' not found. Run this command from your project directory.",
+                self.config_path
+            );
+        }
+
+        let config_dir = config_path.parent().unwrap_or(Path::new("."));
+        let mut any_changes = false;
+
+        // 1. Remove connect: section from avocado.yaml
+        match config_edit::remove_connect_fields(config_path) {
+            Ok(true) => {
+                print_success("Removed connect section from avocado.yaml.", OutputLevel::Normal);
+                any_changes = true;
+            }
+            Ok(false) => {
+                print_info(
+                    "No connect section found in avocado.yaml.",
+                    OutputLevel::Normal,
+                );
+            }
+            Err(e) => {
+                print_warning(
+                    &format!("Failed to remove connect section: {e}"),
+                    OutputLevel::Normal,
+                );
+            }
+        }
+
+        // 2. Remove avocado-ext-connect-config extension from avocado.yaml
+        match config_edit::remove_connect_config_extension(config_path, &self.runtime) {
+            Ok(true) => {
+                print_success(
+                    "Removed avocado-ext-connect-config extension from avocado.yaml.",
+                    OutputLevel::Normal,
+                );
+                any_changes = true;
+            }
+            Ok(false) => {
+                print_info(
+                    "No avocado-ext-connect-config extension found in avocado.yaml.",
+                    OutputLevel::Normal,
+                );
+            }
+            Err(e) => {
+                print_warning(
+                    &format!("Failed to remove connect-config extension: {e}"),
+                    OutputLevel::Normal,
+                );
+            }
+        }
+
+        // 3. Remove overlay/etc/avocado-conn/ directory (contains config.toml)
+        let overlay_conn_dir = config_dir.join("overlay/etc/avocado-conn");
+        if overlay_conn_dir.exists() {
+            std::fs::remove_dir_all(&overlay_conn_dir)
+                .with_context(|| format!("Failed to remove {}", overlay_conn_dir.display()))?;
+            print_success(
+                &format!("Removed {}", overlay_conn_dir.display()),
+                OutputLevel::Normal,
+            );
+            any_changes = true;
+        } else {
+            print_info(
+                &format!("{} does not exist, skipping.", overlay_conn_dir.display()),
+                OutputLevel::Normal,
+            );
+        }
+
+        if any_changes {
+            println!();
+            print_success("Connect configuration cleaned.", OutputLevel::Normal);
+        } else {
+            println!();
+            print_info(
+                "Nothing to clean — no connect configuration found.",
+                OutputLevel::Normal,
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/src/commands/connect/mod.rs
+++ b/src/commands/connect/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod claim_tokens;
+pub mod clean;
 pub mod client;
 pub mod cohorts;
 pub mod deploy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use commands::connect::deploy::ConnectDeployCommand;
 use commands::connect::devices::{
     ConnectDevicesCreateCommand, ConnectDevicesDeleteCommand, ConnectDevicesListCommand,
 };
+use commands::connect::clean::ConnectCleanCommand;
 use commands::connect::init::ConnectInitCommand;
 use commands::connect::keys::{
     ConnectKeysApproveCommand, ConnectKeysListCommand, ConnectKeysRegisterCommand,
@@ -508,6 +509,15 @@ enum ConnectCommands {
         /// Profile name (defaults to the active default profile)
         #[arg(long)]
         profile: Option<String>,
+    },
+    /// Remove connect configuration (connect section, connect-config extension, and device config overlay)
+    Clean {
+        /// Runtime to remove connect-config extension from (default: dev)
+        #[arg(short, long, default_value = "dev")]
+        runtime: String,
+        /// Path to avocado.yaml configuration file
+        #[arg(short = 'C', long, default_value = "avocado.yaml")]
+        config: String,
     },
     /// Manage organizations
     Orgs {
@@ -2707,6 +2717,14 @@ async fn main() -> Result<()> {
                     profile,
                 };
                 cmd.execute().await?;
+                Ok(())
+            }
+            ConnectCommands::Clean { runtime, config } => {
+                let cmd = ConnectCleanCommand {
+                    runtime,
+                    config_path: config,
+                };
+                cmd.execute()?;
                 Ok(())
             }
             ConnectCommands::Orgs { command } => match command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use commands::connect::auth::{
 use commands::connect::claim_tokens::{
     ConnectClaimTokensCreateCommand, ConnectClaimTokensDeleteCommand, ConnectClaimTokensListCommand,
 };
+use commands::connect::clean::ConnectCleanCommand;
 use commands::connect::cohorts::{
     ConnectCohortsCreateCommand, ConnectCohortsDeleteCommand, ConnectCohortsListCommand,
 };
@@ -22,7 +23,6 @@ use commands::connect::deploy::ConnectDeployCommand;
 use commands::connect::devices::{
     ConnectDevicesCreateCommand, ConnectDevicesDeleteCommand, ConnectDevicesListCommand,
 };
-use commands::connect::clean::ConnectCleanCommand;
 use commands::connect::init::ConnectInitCommand;
 use commands::connect::keys::{
     ConnectKeysApproveCommand, ConnectKeysListCommand, ConnectKeysRegisterCommand,

--- a/src/utils/config_edit.rs
+++ b/src/utils/config_edit.rs
@@ -829,6 +829,260 @@ pub fn ensure_extension_overlay(
     Ok(default_overlay.to_string())
 }
 
+/// Remove the top-level `connect:` section from avocado.yaml.
+///
+/// Returns `true` if the section was found and removed.
+pub fn remove_connect_fields(config_path: &Path) -> Result<bool> {
+    let content = std::fs::read_to_string(config_path)
+        .with_context(|| format!("Failed to read {}", config_path.display()))?;
+
+    let (new_content, changed) = remove_connect_fields_in_yaml(&content);
+
+    if changed {
+        std::fs::write(config_path, &new_content)
+            .with_context(|| format!("Failed to write {}", config_path.display()))?;
+    }
+
+    Ok(changed)
+}
+
+/// Pure-function core for remove_connect_fields.
+fn remove_connect_fields_in_yaml(content: &str) -> (String, bool) {
+    let lines: Vec<&str> = content.lines().collect();
+
+    // Find connect: top-level key
+    let connect_line = lines.iter().enumerate().find(|(_, line)| {
+        let trimmed = line.trim();
+        trimmed.starts_with("connect:") && leading_spaces(line) == 0
+    });
+
+    let (idx, _) = match connect_line {
+        Some(pair) => pair,
+        None => return (content.to_string(), false),
+    };
+
+    // Find end of connect section (all indented children + trailing blanks)
+    let mut section_end = idx + 1;
+    for (i, line) in lines.iter().enumerate().skip(idx + 1) {
+        if line.trim().is_empty() || line.trim().starts_with('#') {
+            section_end = i + 1;
+            continue;
+        }
+        let indent = leading_spaces(line);
+        if indent == 0 {
+            break;
+        }
+        section_end = i + 1;
+    }
+
+    // Also consume blank lines immediately before connect:
+    let mut start = idx;
+    while start > 0 && lines[start - 1].trim().is_empty() {
+        start -= 1;
+    }
+
+    let mut result_lines: Vec<String> = Vec::with_capacity(lines.len());
+    for (i, line) in lines.iter().enumerate() {
+        if i >= start && i < section_end {
+            continue;
+        }
+        result_lines.push(line.to_string());
+    }
+
+    let mut out = result_lines.join("\n");
+    if content.ends_with('\n') && !out.ends_with('\n') {
+        out.push('\n');
+    }
+
+    (out, true)
+}
+
+/// Remove the `avocado-ext-connect-config` extension from avocado.yaml.
+///
+/// Removes the extension definition from the `extensions:` section and
+/// the `- avocado-ext-connect-config` entry from the specified runtime's
+/// `extensions:` list. Returns `true` if any changes were made.
+pub fn remove_connect_config_extension(config_path: &Path, runtime_name: &str) -> Result<bool> {
+    let content = std::fs::read_to_string(config_path)
+        .with_context(|| format!("Failed to read {}", config_path.display()))?;
+
+    let (new_content, changed) = remove_connect_config_extension_in_yaml(&content, runtime_name)?;
+
+    if changed {
+        std::fs::write(config_path, &new_content)
+            .with_context(|| format!("Failed to write {}", config_path.display()))?;
+    }
+
+    Ok(changed)
+}
+
+/// Pure-function core for remove_connect_config_extension.
+fn remove_connect_config_extension_in_yaml(
+    content: &str,
+    runtime_name: &str,
+) -> Result<(String, bool)> {
+    let mut result = content.to_string();
+    let mut changed = false;
+
+    let ext_name = "avocado-ext-connect-config";
+
+    // Step 1: Remove from runtime's extensions list
+    if has_runtime_extension_entry(&result, runtime_name, ext_name) {
+        result = remove_runtime_extension_entry(&result, runtime_name, ext_name)?;
+        changed = true;
+    }
+
+    // Step 2: Remove extension definition from extensions: section
+    if has_extension_definition(&result, ext_name) {
+        result = remove_extension_definition(&result, ext_name)?;
+        changed = true;
+    }
+
+    Ok((result, changed))
+}
+
+/// Remove an extension definition from the top-level `extensions:` section.
+fn remove_extension_definition(content: &str, ext_name: &str) -> Result<String> {
+    let lines: Vec<&str> = content.lines().collect();
+    let ext_section = find_top_level_key(&lines, "extensions")?;
+    let ext_indent = leading_spaces(lines[ext_section]);
+
+    // Find the named extension definition
+    let mut ext_line = None;
+    for (i, line) in lines.iter().enumerate().skip(ext_section + 1) {
+        if line.trim().is_empty() || line.trim().starts_with('#') {
+            continue;
+        }
+        let indent = leading_spaces(line);
+        if indent <= ext_indent {
+            break;
+        }
+        let trimmed = line.trim();
+        if trimmed.starts_with(&format!("{ext_name}:"))
+            || trimmed.starts_with(&format!("\"{ext_name}\":"))
+        {
+            ext_line = Some(i);
+            break;
+        }
+    }
+
+    let ext_line = ext_line
+        .ok_or_else(|| anyhow::anyhow!("Extension '{ext_name}' not found in avocado.yaml"))?;
+    let ext_def_indent = leading_spaces(lines[ext_line]);
+
+    // Find end of this extension's block (all lines indented deeper)
+    let mut block_end = ext_line + 1;
+    for (i, line) in lines.iter().enumerate().skip(ext_line + 1) {
+        if line.trim().is_empty() || line.trim().starts_with('#') {
+            block_end = i + 1;
+            continue;
+        }
+        let indent = leading_spaces(line);
+        if indent <= ext_def_indent {
+            break;
+        }
+        block_end = i + 1;
+    }
+
+    // Consume blank lines before the extension definition
+    let mut start = ext_line;
+    while start > 0 && lines[start - 1].trim().is_empty() {
+        start -= 1;
+    }
+
+    let mut result_lines: Vec<String> = Vec::with_capacity(lines.len());
+    for (i, line) in lines.iter().enumerate() {
+        if i >= start && i < block_end {
+            continue;
+        }
+        result_lines.push(line.to_string());
+    }
+
+    let mut out = result_lines.join("\n");
+    if content.ends_with('\n') && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    Ok(out)
+}
+
+/// Remove an extension entry from a runtime's `extensions:` list.
+fn remove_runtime_extension_entry(
+    content: &str,
+    runtime_name: &str,
+    ext_name: &str,
+) -> Result<String> {
+    let lines: Vec<&str> = content.lines().collect();
+    let rt_section = find_top_level_key(&lines, "runtimes")?;
+    let rt_indent = leading_spaces(lines[rt_section]);
+
+    // Find the named runtime
+    let mut runtime_line = None;
+    for (i, line) in lines.iter().enumerate().skip(rt_section + 1) {
+        if line.trim().is_empty() || line.trim().starts_with('#') {
+            continue;
+        }
+        let indent = leading_spaces(line);
+        if indent <= rt_indent {
+            break;
+        }
+        let trimmed = line.trim();
+        if trimmed.starts_with(&format!("{runtime_name}:")) {
+            runtime_line = Some(i);
+            break;
+        }
+    }
+
+    let runtime_line = runtime_line
+        .ok_or_else(|| anyhow::anyhow!("Runtime '{runtime_name}' not found in avocado.yaml"))?;
+    let runtime_indent = leading_spaces(lines[runtime_line]);
+
+    // Find extensions: list within this runtime
+    let mut ext_list_line = None;
+    for (i, line) in lines.iter().enumerate().skip(runtime_line + 1) {
+        if line.trim().is_empty() || line.trim().starts_with('#') {
+            continue;
+        }
+        let indent = leading_spaces(line);
+        if indent <= runtime_indent {
+            break;
+        }
+        if line.trim() == "extensions:" {
+            ext_list_line = Some(i);
+            break;
+        }
+    }
+
+    let ext_list_line = ext_list_line.ok_or_else(|| {
+        anyhow::anyhow!("No 'extensions:' list found in runtime '{runtime_name}'")
+    })?;
+    let list_indent = leading_spaces(lines[ext_list_line]);
+
+    // Find and remove the matching entry
+    let target = format!("- {ext_name}");
+    let mut result_lines: Vec<String> = Vec::with_capacity(lines.len());
+
+    for (i, line) in lines.iter().enumerate() {
+        if i > ext_list_line {
+            let indent = leading_spaces(line);
+            if !line.trim().is_empty() && !line.trim().starts_with('#') && indent <= list_indent {
+                // Past the extensions list — just copy
+                result_lines.push(line.to_string());
+                continue;
+            }
+            if line.trim() == target {
+                continue; // skip this entry
+            }
+        }
+        result_lines.push(line.to_string());
+    }
+
+    let mut out = result_lines.join("\n");
+    if content.ends_with('\n') && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    Ok(out)
+}
+
 /// Set connect fields (org, project, server_key) in avocado.yaml.
 ///
 /// If a `connect:` section already exists, updates fields in place.
@@ -1304,5 +1558,134 @@ extensions:
         // File should now contain overlay:
         let after = std::fs::read_to_string(tmp.path()).unwrap();
         assert!(after.contains("overlay: overlay"));
+    }
+
+    #[test]
+    fn test_remove_connect_fields_present() {
+        let config = r#"sdk:
+  image: docker.io/avocadolinux/sdk:latest
+
+connect:
+  org: 019d2097-a017-733e-a67f-edbafaa7eee9
+  project: 019d2097-a11a-798d-9a3e-e8c624495567
+  server_key: 463d217f9c292dc4d36cdc86d19a6e7074f7ca71e1a8bcf084d7a1c5df0f5e75
+"#;
+        let (result, changed) = remove_connect_fields_in_yaml(config);
+        assert!(changed);
+        assert!(!result.contains("connect:"));
+        assert!(!result.contains("server_key"));
+        assert!(result.contains("sdk:"));
+    }
+
+    #[test]
+    fn test_remove_connect_fields_absent() {
+        let config = r#"sdk:
+  image: docker.io/avocadolinux/sdk:latest
+"#;
+        let (result, changed) = remove_connect_fields_in_yaml(config);
+        assert!(!changed);
+        assert_eq!(result, config);
+    }
+
+    #[test]
+    fn test_remove_connect_fields_at_end_of_file() {
+        let config = r#"runtimes:
+  dev:
+    packages:
+      avocado-runtime: '*'
+
+connect:
+  org: abc
+  project: def
+  server_key: ghi
+"#;
+        let (result, changed) = remove_connect_fields_in_yaml(config);
+        assert!(changed);
+        assert!(!result.contains("connect:"));
+        assert!(result.contains("runtimes:"));
+        // Should not have excessive trailing whitespace
+        assert!(!result.ends_with("\n\n\n"));
+    }
+
+    #[test]
+    fn test_remove_connect_config_extension() {
+        let config = r#"runtimes:
+  dev:
+    extensions:
+      - avocado-ext-dev
+      - avocado-ext-connect-config
+      - avocado-ext-connect
+      - avocado-ext-tunnels
+    packages:
+      avocado-runtime: '*'
+
+extensions:
+  avocado-ext-dev:
+    source:
+      type: package
+      version: '*'
+
+  avocado-ext-connect-config:
+    types:
+      - confext
+    version: "0.1.0"
+    overlay: overlay
+
+  avocado-ext-connect:
+    source:
+      type: package
+      version: "*"
+
+  avocado-ext-tunnels:
+    source:
+      type: package
+      version: "*"
+"#;
+        let (result, changed) =
+            remove_connect_config_extension_in_yaml(config, "dev").unwrap();
+        assert!(changed);
+        // Extension definition removed
+        assert!(!result.contains("avocado-ext-connect-config"));
+        // Other extensions preserved
+        assert!(result.contains("avocado-ext-connect:"));
+        assert!(result.contains("avocado-ext-tunnels:"));
+        assert!(result.contains("avocado-ext-dev:"));
+        // Runtime list entry removed
+        assert!(!result.contains("- avocado-ext-connect-config"));
+        assert!(result.contains("- avocado-ext-connect"));
+        assert!(result.contains("- avocado-ext-tunnels"));
+    }
+
+    #[test]
+    fn test_remove_connect_config_extension_not_present() {
+        let config = r#"runtimes:
+  dev:
+    extensions:
+      - avocado-ext-dev
+      - avocado-ext-connect
+      - avocado-ext-tunnels
+    packages:
+      avocado-runtime: '*'
+
+extensions:
+  avocado-ext-dev:
+    source:
+      type: package
+      version: '*'
+
+  avocado-ext-connect:
+    source:
+      type: package
+      version: "*"
+
+  avocado-ext-tunnels:
+    source:
+      type: package
+      version: "*"
+"#;
+        let (result, changed) =
+            remove_connect_config_extension_in_yaml(config, "dev").unwrap();
+        assert!(!changed);
+        assert_eq!(result, config);
     }
 }

--- a/src/utils/config_edit.rs
+++ b/src/utils/config_edit.rs
@@ -1641,8 +1641,7 @@ extensions:
       type: package
       version: "*"
 "#;
-        let (result, changed) =
-            remove_connect_config_extension_in_yaml(config, "dev").unwrap();
+        let (result, changed) = remove_connect_config_extension_in_yaml(config, "dev").unwrap();
         assert!(changed);
         // Extension definition removed
         assert!(!result.contains("avocado-ext-connect-config"));
@@ -1683,8 +1682,7 @@ extensions:
       type: package
       version: "*"
 "#;
-        let (result, changed) =
-            remove_connect_config_extension_in_yaml(config, "dev").unwrap();
+        let (result, changed) = remove_connect_config_extension_in_yaml(config, "dev").unwrap();
         assert!(!changed);
         assert_eq!(result, config);
     }


### PR DESCRIPTION
`avocado connect clean`

  New command that reverses what avocado connect init sets up. It removes:

  1. `connect:` section from avocado.yaml (org, project, server_key)
  2. `avocado-ext-connect-config` extension — both the definition in `extensions:` and
  the - `avocado-ext-connect-config` entry from the runtime's extensions list
  3. `overlay/etc/avocado-conn/` directory (contains `config.toml` with the claim token)

  It intentionally preserves avocado-ext-connect and avocado-ext-tunnels — those are
   infrastructure extensions present even in projects without connect configuration
  (like qemu-quickstart).

  CLI flags:
  - `-r, --runtime <name>` — runtime to remove connect-config from (default: dev)
  - `-C, --config <path>` — path to avocado.yaml (default: avocado.yaml)

  Files changed:
  - `src/commands/connect/clean.rs` — new ConnectCleanCommand
  - `src/commands/connect/mod.rs` — added pub mod clean
  - `src/utils/config_edit.rs` — added remove_connect_fields(),
  `remove_connect_config_extension()`, and supporting private functions
  (r`emove_extension_definition`, r`emove_runtime_extension_entry`)
  - `src/main.rs` — added Clean variant to ConnectCommands, import, and dispatch