### PR TITLE
feat: add btrfs subvolume config for var partition

### DIFF
--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -1356,12 +1356,101 @@ echo "Provisioned update authority: metadata/root.json""#
             (None, false) => unreachable!("dev signing key should have been auto-generated above"),
         };
 
-        // Extension list from runtime config (used by var_files and docker priming)
+        // Extension list from runtime config (used by var_files, docker priming, and subvolumes)
         let ext_list: Vec<&str> = merged_runtime
             .get("extensions")
             .and_then(|e| e.as_sequence())
             .map(|seq| seq.iter().filter_map(|v| v.as_str()).collect())
             .unwrap_or_default();
+
+        // Resolve subvolumes from extensions + runtime config
+        let (resolved_subvolumes, subvol_warnings) =
+            crate::utils::config::resolve_subvolumes(&ext_list, parsed, &merged_runtime)?;
+
+        // Generate subvolume-related script sections
+        let subvol_warnings_section = if subvol_warnings.is_empty() {
+            String::new()
+        } else {
+            subvol_warnings
+                .iter()
+                .map(|w| format!("echo \"WARNING: {w}\""))
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+
+        // Generate mkdir commands for subvolume paths
+        let subvol_mkdir_section = resolved_subvolumes
+            .iter()
+            .map(|s| format!("mkdir -p \"$VAR_DIR/{}\"", s.path))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Generate mkfs.btrfs --subvol flags
+        let subvol_flags: Vec<String> = resolved_subvolumes
+            .iter()
+            .map(|s| {
+                let mode = if s.writable { "rw" } else { "ro" };
+                format!("    --subvol {}:{}", mode, s.path)
+            })
+            .collect();
+
+        // Generate --inode-flags for nodatacow subvolumes
+        let nodatacow_flags: Vec<String> = resolved_subvolumes
+            .iter()
+            .filter(|s| s.nodatacow)
+            .map(|s| format!("    --inode-flags nodatacow:{}", s.path))
+            .collect();
+
+        let mkfs_flags = [subvol_flags, nodatacow_flags].concat().join(" \\\n");
+
+        // Generate post-creation section for compression and quotas
+        let needs_post_creation = resolved_subvolumes
+            .iter()
+            .any(|s| s.compression.is_some() || s.quota.is_some());
+
+        let post_creation_section = if needs_post_creation {
+            let mut commands = vec![
+                "# Post-creation: set per-subvolume compression and quotas".to_string(),
+                "LOOP_DEV=$(losetup --find --show \"$VAR_IMAGE\")".to_string(),
+                "mkdir -p /tmp/btrfs-var-setup".to_string(),
+                "mount -t btrfs \"$LOOP_DEV\" /tmp/btrfs-var-setup".to_string(),
+            ];
+
+            // Per-subvolume compression properties
+            for s in &resolved_subvolumes {
+                if let Some(ref comp) = s.compression {
+                    if comp != "no" {
+                        commands.push(format!(
+                            "btrfs property set /tmp/btrfs-var-setup/{} compression {}",
+                            s.path, comp
+                        ));
+                    }
+                }
+            }
+
+            // Quotas (only if any subvolume has a quota)
+            let has_quotas = resolved_subvolumes.iter().any(|s| s.quota.is_some());
+            if has_quotas {
+                commands.push("btrfs quota enable /tmp/btrfs-var-setup".to_string());
+                for s in &resolved_subvolumes {
+                    if let Some(ref quota) = s.quota {
+                        if quota != "none" {
+                            commands.push(format!(
+                                "btrfs qgroup limit {} /tmp/btrfs-var-setup/{}",
+                                quota, s.path
+                            ));
+                        }
+                    }
+                }
+            }
+
+            commands.push("umount /tmp/btrfs-var-setup".to_string());
+            commands.push("losetup -d \"$LOOP_DEV\"".to_string());
+            commands.push("echo \"Applied btrfs subvolume properties.\"".to_string());
+            commands.join("\n")
+        } else {
+            String::new()
+        };
 
         // Build var_files section: apply extension var_files to var staging in reverse order
         // (last in extensions list applied first = lowest priority, first applied last = wins conflicts)
@@ -1583,6 +1672,8 @@ RUNTIME_VERSION="{runtime_version}"
 VAR_DIR=$AVOCADO_PREFIX/runtimes/$RUNTIME_NAME/var-staging
 mkdir -p "$VAR_DIR/lib/avocado/images"
 mkdir -p "$VAR_DIR/lib/avocado/runtimes"
+{subvol_mkdir_section}
+{subvol_warnings_section}
 
 OUTPUT_DIR="$AVOCADO_PREFIX/runtimes/$RUNTIME_NAME"
 mkdir -p $OUTPUT_DIR
@@ -1634,10 +1725,12 @@ echo "Building var image (${{VAR_INPUT_MB}}MB source)..."
 _PROGRESS_PID=$!
 
 mkfs.btrfs -r "$VAR_DIR" \
-    --subvol rw:lib/avocado \
+{mkfs_flags} \
     -f "$VAR_IMAGE"
 
 kill $_PROGRESS_PID 2>/dev/null; wait $_PROGRESS_PID 2>/dev/null || true
+
+{post_creation_section}
 FINAL_SIZE=$(stat -c%s "$VAR_IMAGE" 2>/dev/null || echo 0)
 FINAL_MB=$(( FINAL_SIZE / 1048576 ))
 echo ""
@@ -1742,6 +1835,10 @@ PYEOF
             copy_section = copy_section,
             rootfs_build_section = rootfs_build_section,
             initramfs_build_section = initramfs_build_section,
+            subvol_mkdir_section = subvol_mkdir_section,
+            subvol_warnings_section = subvol_warnings_section,
+            mkfs_flags = mkfs_flags,
+            post_creation_section = post_creation_section,
             var_files_section = var_files_section,
             runtime_var_files_section = runtime_var_files_section,
             manifest_section = manifest_section,

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -1423,6 +1423,7 @@ echo "Provisioned update authority: metadata/root.json""#
         let post_creation_section = if needs_post_creation {
             let mut commands = vec![
                 "# Post-creation: apply per-subvolume properties via loop mount".to_string(),
+                "echo \"Applying subvolume properties...\"".to_string(),
                 "LOOP_DEV=$(losetup --find --show \"$VAR_IMAGE\")".to_string(),
                 "mkdir -p /tmp/btrfs-var-setup".to_string(),
                 "mount -t btrfs \"$LOOP_DEV\" /tmp/btrfs-var-setup".to_string(),
@@ -1435,11 +1436,14 @@ echo "Provisioned update authority: metadata/root.json""#
                         "chattr +C /tmp/btrfs-var-setup/{}",
                         s.path
                     ));
+                    commands.push(format!(
+                        "echo \"  {}: nodatacow\"",
+                        s.path
+                    ));
                 }
             }
 
             // Per-subvolume compression properties
-            // (sets the property so future writes use this algorithm)
             // Skip subvolumes with nodatacow -- NOCOW and compression are mutually
             // exclusive on btrfs (COW is required for transparent compression).
             for s in &resolved_subvolumes {
@@ -1450,6 +1454,10 @@ echo "Provisioned update authority: metadata/root.json""#
                     if comp != "no" {
                         commands.push(format!(
                             "btrfs property set /tmp/btrfs-var-setup/{} compression {}",
+                            s.path, comp
+                        ));
+                        commands.push(format!(
+                            "echo \"  {}: compression={}\"",
                             s.path, comp
                         ));
                     }
@@ -1467,6 +1475,10 @@ echo "Provisioned update authority: metadata/root.json""#
                                 "btrfs qgroup limit {} /tmp/btrfs-var-setup/{}",
                                 quota, s.path
                             ));
+                            commands.push(format!(
+                                "echo \"  {}: quota={}\"",
+                                s.path, quota
+                            ));
                         }
                     }
                 }
@@ -1479,12 +1491,15 @@ echo "Provisioned update authority: metadata/root.json""#
                         "btrfs property set /tmp/btrfs-var-setup/{} ro true",
                         s.path
                     ));
+                    commands.push(format!(
+                        "echo \"  {}: read-only\"",
+                        s.path
+                    ));
                 }
             }
 
             commands.push("umount /tmp/btrfs-var-setup".to_string());
             commands.push("losetup -d \"$LOOP_DEV\"".to_string());
-            commands.push("echo \"Applied btrfs subvolume properties.\"".to_string());
             commands.join("\n")
         } else {
             String::new()

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -1386,12 +1386,12 @@ echo "Provisioned update authority: metadata/root.json""#
             .join("\n");
 
         // Generate mkfs.btrfs --subvol flags
+        // Always create as rw at mkfs time -- read-only subvolumes need properties
+        // set first (compression, etc.), then flipped to ro in the post-creation step.
+        let has_ro_subvolumes = resolved_subvolumes.iter().any(|s| !s.writable);
         let subvol_flags: Vec<String> = resolved_subvolumes
             .iter()
-            .map(|s| {
-                let mode = if s.writable { "rw" } else { "ro" };
-                format!("    --subvol {}:{}", mode, s.path)
-            })
+            .map(|s| format!("    --subvol rw:{}", s.path))
             .collect();
 
         let mkfs_flags = subvol_flags.join(" \\\n");
@@ -1415,9 +1415,10 @@ echo "Provisioned update authority: metadata/root.json""#
         //   nodatacow: chattr +C (requires e2fsprogs in SDK)
         //   compression: btrfs property set
         //   quotas: btrfs quota enable + btrfs qgroup limit
-        let needs_post_creation = resolved_subvolumes
-            .iter()
-            .any(|s| s.nodatacow || s.quota.is_some() || s.compression.is_some());
+        let needs_post_creation = has_ro_subvolumes
+            || resolved_subvolumes
+                .iter()
+                .any(|s| s.nodatacow || s.quota.is_some() || s.compression.is_some());
 
         let post_creation_section = if needs_post_creation {
             let mut commands = vec![
@@ -1468,6 +1469,16 @@ echo "Provisioned update authority: metadata/root.json""#
                             ));
                         }
                     }
+                }
+            }
+
+            // Flip read-only subvolumes to ro (created as rw so properties could be set first)
+            for s in &resolved_subvolumes {
+                if !s.writable {
+                    commands.push(format!(
+                        "btrfs property set /tmp/btrfs-var-setup/{} ro true",
+                        s.path
+                    ));
                 }
             }
 

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -1412,8 +1412,8 @@ echo "Provisioned update authority: metadata/root.json""#
 
         // Generate post-creation section for nodatacow, per-subvolume compression, and quotas.
         // These require loop-mounting the btrfs image:
-        //   nodatacow: chattr +C on the subvolume directory
-        //   compression: btrfs property set (for per-subvolume overrides beyond global --compress)
+        //   nodatacow: chattr +C (requires e2fsprogs in SDK)
+        //   compression: btrfs property set
         //   quotas: btrfs quota enable + btrfs qgroup limit
         let needs_post_creation = resolved_subvolumes
             .iter()
@@ -1427,7 +1427,7 @@ echo "Provisioned update authority: metadata/root.json""#
                 "mount -t btrfs \"$LOOP_DEV\" /tmp/btrfs-var-setup".to_string(),
             ];
 
-            // nodatacow via chattr +C
+            // nodatacow via chattr +C (requires e2fsprogs in SDK)
             for s in &resolved_subvolumes {
                 if s.nodatacow {
                     commands.push(format!(
@@ -1439,7 +1439,12 @@ echo "Provisioned update authority: metadata/root.json""#
 
             // Per-subvolume compression properties
             // (sets the property so future writes use this algorithm)
+            // Skip subvolumes with nodatacow -- NOCOW and compression are mutually
+            // exclusive on btrfs (COW is required for transparent compression).
             for s in &resolved_subvolumes {
+                if s.nodatacow {
+                    continue;
+                }
                 if let Some(ref comp) = s.compression {
                     if comp != "no" {
                         commands.push(format!(

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -1394,29 +1394,51 @@ echo "Provisioned update authority: metadata/root.json""#
             })
             .collect();
 
-        // Generate --inode-flags for nodatacow subvolumes
-        let nodatacow_flags: Vec<String> = resolved_subvolumes
-            .iter()
-            .filter(|s| s.nodatacow)
-            .map(|s| format!("    --inode-flags nodatacow:{}", s.path))
-            .collect();
+        let mkfs_flags = subvol_flags.join(" \\\n");
 
-        let mkfs_flags = [subvol_flags, nodatacow_flags].concat().join(" \\\n");
+        // Determine if we can use mkfs.btrfs --compress for a global default
+        // (applies compression at image creation time to all packed files)
+        let global_compress_flag = {
+            // Use the runtime-level var.compression as a global --compress flag
+            let var_compression = merged_runtime
+                .get("var")
+                .and_then(|v| v.get("compression"))
+                .and_then(|v| v.as_str());
+            match var_compression {
+                Some(c) if c != "no" => format!("    --compress {c}"),
+                _ => String::new(),
+            }
+        };
 
-        // Generate post-creation section for compression and quotas
+        // Generate post-creation section for nodatacow, per-subvolume compression, and quotas.
+        // These require loop-mounting the btrfs image:
+        //   nodatacow: chattr +C on the subvolume directory
+        //   compression: btrfs property set (for per-subvolume overrides beyond global --compress)
+        //   quotas: btrfs quota enable + btrfs qgroup limit
         let needs_post_creation = resolved_subvolumes
             .iter()
-            .any(|s| s.compression.is_some() || s.quota.is_some());
+            .any(|s| s.nodatacow || s.quota.is_some() || s.compression.is_some());
 
         let post_creation_section = if needs_post_creation {
             let mut commands = vec![
-                "# Post-creation: set per-subvolume compression and quotas".to_string(),
+                "# Post-creation: apply per-subvolume properties via loop mount".to_string(),
                 "LOOP_DEV=$(losetup --find --show \"$VAR_IMAGE\")".to_string(),
                 "mkdir -p /tmp/btrfs-var-setup".to_string(),
                 "mount -t btrfs \"$LOOP_DEV\" /tmp/btrfs-var-setup".to_string(),
             ];
 
+            // nodatacow via chattr +C
+            for s in &resolved_subvolumes {
+                if s.nodatacow {
+                    commands.push(format!(
+                        "chattr +C /tmp/btrfs-var-setup/{}",
+                        s.path
+                    ));
+                }
+            }
+
             // Per-subvolume compression properties
+            // (sets the property so future writes use this algorithm)
             for s in &resolved_subvolumes {
                 if let Some(ref comp) = s.compression {
                     if comp != "no" {
@@ -1428,7 +1450,7 @@ echo "Provisioned update authority: metadata/root.json""#
                 }
             }
 
-            // Quotas (only if any subvolume has a quota)
+            // Quotas
             let has_quotas = resolved_subvolumes.iter().any(|s| s.quota.is_some());
             if has_quotas {
                 commands.push("btrfs quota enable /tmp/btrfs-var-setup".to_string());
@@ -1726,7 +1748,7 @@ _PROGRESS_PID=$!
 
 mkfs.btrfs -r "$VAR_DIR" \
 {mkfs_flags} \
-    -f "$VAR_IMAGE"
+{global_compress_flag}    -f "$VAR_IMAGE"
 
 kill $_PROGRESS_PID 2>/dev/null; wait $_PROGRESS_PID 2>/dev/null || true
 
@@ -1838,6 +1860,11 @@ PYEOF
             subvol_mkdir_section = subvol_mkdir_section,
             subvol_warnings_section = subvol_warnings_section,
             mkfs_flags = mkfs_flags,
+            global_compress_flag = if global_compress_flag.is_empty() {
+                "".to_string()
+            } else {
+                format!("{global_compress_flag} \\\n")
+            },
             post_creation_section = post_creation_section,
             var_files_section = var_files_section,
             runtime_var_files_section = runtime_var_files_section,

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -1432,14 +1432,8 @@ echo "Provisioned update authority: metadata/root.json""#
             // nodatacow via chattr +C (requires e2fsprogs in SDK)
             for s in &resolved_subvolumes {
                 if s.nodatacow {
-                    commands.push(format!(
-                        "chattr +C /tmp/btrfs-var-setup/{}",
-                        s.path
-                    ));
-                    commands.push(format!(
-                        "echo \"  {}: nodatacow\"",
-                        s.path
-                    ));
+                    commands.push(format!("chattr +C /tmp/btrfs-var-setup/{}", s.path));
+                    commands.push(format!("echo \"  {}: nodatacow\"", s.path));
                 }
             }
 
@@ -1456,10 +1450,7 @@ echo "Provisioned update authority: metadata/root.json""#
                             "btrfs property set /tmp/btrfs-var-setup/{} compression {}",
                             s.path, comp
                         ));
-                        commands.push(format!(
-                            "echo \"  {}: compression={}\"",
-                            s.path, comp
-                        ));
+                        commands.push(format!("echo \"  {}: compression={}\"", s.path, comp));
                     }
                 }
             }
@@ -1475,10 +1466,7 @@ echo "Provisioned update authority: metadata/root.json""#
                                 "btrfs qgroup limit {} /tmp/btrfs-var-setup/{}",
                                 quota, s.path
                             ));
-                            commands.push(format!(
-                                "echo \"  {}: quota={}\"",
-                                s.path, quota
-                            ));
+                            commands.push(format!("echo \"  {}: quota={}\"", s.path, quota));
                         }
                     }
                 }
@@ -1491,10 +1479,7 @@ echo "Provisioned update authority: metadata/root.json""#
                         "btrfs property set /tmp/btrfs-var-setup/{} ro true",
                         s.path
                     ));
-                    commands.push(format!(
-                        "echo \"  {}: read-only\"",
-                        s.path
-                    ));
+                    commands.push(format!("echo \"  {}: read-only\"", s.path));
                 }
             }
 

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -401,6 +401,8 @@ pub struct RuntimeConfig {
     /// Optional kernel configuration. When omitted, the avocado-runtime meta-package
     /// handles kernel provisioning via avocado-img-bootfiles (legacy behavior).
     pub kernel: Option<KernelConfig>,
+    /// Var partition configuration: default compression, subvolume definitions.
+    pub var: Option<VarConfig>,
 }
 
 /// SDK configuration section
@@ -569,6 +571,306 @@ pub struct DockerImageRef {
 pub struct VarFileMapping {
     pub source: String,
     pub dest: String,
+}
+
+/// Var partition configuration for a runtime.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct VarConfig {
+    /// Default compression for all subvolumes when not set per-subvolume.
+    /// Valid values: "no", "zstd", "zstd:3", "lzo", "zlib", "zlib:6", etc.
+    pub compression: Option<String>,
+    /// Subvolumes keyed by path relative to var root (e.g. "lib/mydata").
+    pub subvolumes: Option<HashMap<String, SubvolumeEntry>>,
+}
+
+/// A subvolume entry supporting shorthand and full forms.
+///
+/// Shorthand: `true` means rw with defaults, `false` means disabled.
+/// String shorthand: `"ro"` means read-only with defaults.
+/// Full form: a `SubvolumeConfig` object with all options.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum SubvolumeEntry {
+    /// Shorthand: `true` = rw with defaults, `false` = disabled
+    Bool(bool),
+    /// Shorthand: "ro" = read-only with defaults
+    String(String),
+    /// Full configuration object
+    Full(SubvolumeConfig),
+}
+
+impl SubvolumeEntry {
+    /// Normalize any shorthand form into a full SubvolumeConfig.
+    pub fn to_config(&self) -> SubvolumeConfig {
+        match self {
+            SubvolumeEntry::Bool(true) => SubvolumeConfig {
+                writable: Some(true),
+                ..Default::default()
+            },
+            SubvolumeEntry::Bool(false) => SubvolumeConfig {
+                enabled: Some(false),
+                ..Default::default()
+            },
+            SubvolumeEntry::String(s) if s == "ro" => SubvolumeConfig {
+                writable: Some(false),
+                ..Default::default()
+            },
+            SubvolumeEntry::String(_) => SubvolumeConfig {
+                writable: Some(true),
+                ..Default::default()
+            },
+            SubvolumeEntry::Full(config) => config.clone(),
+        }
+    }
+}
+
+/// Full configuration for a single btrfs subvolume.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct SubvolumeConfig {
+    /// Whether the subvolume is writable (default: true).
+    pub writable: Option<bool>,
+    /// Compression algorithm: "no", "zstd", "zstd:3", "lzo", "zlib:6", etc.
+    /// When not set, inherits from the runtime's `var.compression` or none.
+    pub compression: Option<String>,
+    /// Set NOCOW inode flag (default: false). Useful for databases, VM images.
+    pub nodatacow: Option<bool>,
+    /// Qgroup size limit, e.g. "500M", "5G", "none". Default: none.
+    pub quota: Option<String>,
+    /// Whether this subvolume is enabled (default: true).
+    /// Set to false to suppress an extension-declared subvolume from the runtime.
+    pub enabled: Option<bool>,
+}
+
+impl SubvolumeConfig {
+    /// Deep-merge another config on top of this one (other wins for set fields).
+    pub fn merge_over(&self, other: &SubvolumeConfig) -> SubvolumeConfig {
+        SubvolumeConfig {
+            writable: other.writable.or(self.writable),
+            compression: other.compression.clone().or(self.compression.clone()),
+            nodatacow: other.nodatacow.or(self.nodatacow),
+            quota: other.quota.clone().or(self.quota.clone()),
+            enabled: other.enabled.or(self.enabled),
+        }
+    }
+
+    /// Returns true if this subvolume is enabled (default: true).
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.unwrap_or(true)
+    }
+
+    /// Returns true if this subvolume is writable (default: true).
+    pub fn is_writable(&self) -> bool {
+        self.writable.unwrap_or(true)
+    }
+
+    /// Returns true if NOCOW is set.
+    pub fn is_nodatacow(&self) -> bool {
+        self.nodatacow.unwrap_or(false)
+    }
+}
+
+/// A fully resolved subvolume ready for mkfs.btrfs flag generation.
+#[derive(Debug, Clone)]
+pub struct ResolvedSubvolume {
+    pub path: String,
+    pub writable: bool,
+    pub compression: Option<String>,
+    pub nodatacow: bool,
+    pub quota: Option<String>,
+}
+
+/// Extract subvolumes map from an extension config value.
+/// Normalizes shorthand forms into SubvolumeConfig.
+/// Returns an empty HashMap if no subvolumes are configured.
+pub fn get_ext_subvolumes(ext_config: &serde_yaml::Value) -> HashMap<String, SubvolumeConfig> {
+    let Some(subvols) = ext_config.get("subvolumes").and_then(|v| v.as_mapping()) else {
+        return HashMap::new();
+    };
+    subvols
+        .iter()
+        .filter_map(|(key, value)| {
+            let path = key.as_str()?.to_string();
+            let entry: SubvolumeEntry = serde_yaml::from_value(value.clone()).ok()?;
+            Some((path, entry.to_config()))
+        })
+        .collect()
+}
+
+/// Extract var config from a runtime config value.
+/// Returns the default compression and subvolumes map from the runtime's `var` section.
+fn get_runtime_var_config(
+    merged_runtime: &serde_yaml::Value,
+) -> (Option<String>, HashMap<String, SubvolumeConfig>) {
+    let Some(var) = merged_runtime.get("var") else {
+        return (None, HashMap::new());
+    };
+    let default_compression = var
+        .get("compression")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let subvolumes = var
+        .get("subvolumes")
+        .and_then(|v| v.as_mapping())
+        .map(|mapping| {
+            mapping
+                .iter()
+                .filter_map(|(key, value)| {
+                    let path = key.as_str()?.to_string();
+                    let entry: SubvolumeEntry = serde_yaml::from_value(value.clone()).ok()?;
+                    Some((path, entry.to_config()))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    (default_compression, subvolumes)
+}
+
+/// Resolve subvolumes from extensions + runtime into a final list.
+///
+/// Returns `(resolved_subvolumes, warnings)`.
+///
+/// Merge order:
+/// 1. Built-in implicit `lib/avocado` (writable: true)
+/// 2. Extension subvolumes (first-listed extension wins on path conflicts)
+/// 3. Runtime `var.subvolumes` deep-merges on top (always wins)
+/// 4. Partition-level `var.compression` applied as default
+/// 5. `enabled: false` subvolumes filtered out
+///
+/// Warnings are emitted for:
+/// - Exact path conflicts between extensions (first wins, others skipped)
+/// - Nested subvolume paths (parent/child quota isolation)
+///   Paths explicitly declared in runtime `var.subvolumes` suppress warnings.
+pub fn resolve_subvolumes(
+    ext_list: &[&str],
+    parsed: &serde_yaml::Value,
+    merged_runtime: &serde_yaml::Value,
+) -> Result<(Vec<ResolvedSubvolume>, Vec<String>)> {
+    let mut warnings: Vec<String> = Vec::new();
+
+    // Step 1: Start with the built-in implicit lib/avocado subvolume
+    let mut merged: HashMap<String, SubvolumeConfig> = HashMap::new();
+    merged.insert(
+        "lib/avocado".to_string(),
+        SubvolumeConfig {
+            writable: Some(true),
+            ..Default::default()
+        },
+    );
+
+    // Track which extension claimed each path (for conflict warnings)
+    let mut path_owners: HashMap<String, String> = HashMap::new();
+    path_owners.insert("lib/avocado".to_string(), "(built-in)".to_string());
+
+    // Step 2: Collect from extensions in list order; first-listed wins
+    let (default_compression, runtime_subvolumes) = get_runtime_var_config(merged_runtime);
+    let runtime_paths: std::collections::HashSet<&String> = runtime_subvolumes.keys().collect();
+
+    for ext_name in ext_list {
+        let ext_subvols = parsed
+            .get("extensions")
+            .and_then(|e| e.get(*ext_name))
+            .map(get_ext_subvolumes)
+            .unwrap_or_default();
+
+        for (path, config) in ext_subvols {
+            if let Some(owner) = path_owners.get(&path) {
+                // Exact path conflict -- emit warning unless runtime resolves it
+                if !runtime_paths.contains(&path) {
+                    warnings.push(format!(
+                        "extensions '{}' and '{}' both declare subvolume '{}'; \
+                         using config from '{}' (listed first in runtime)",
+                        ext_name, owner, path, owner
+                    ));
+                }
+            } else {
+                // First extension to claim this path
+                if merged.contains_key(&path) {
+                    // Path exists from built-in -- extension overrides built-in defaults
+                    let existing = merged.get(&path).unwrap();
+                    merged.insert(path.clone(), existing.merge_over(&config));
+                } else {
+                    merged.insert(path.clone(), config);
+                }
+                path_owners.insert(path.clone(), ext_name.to_string());
+            }
+        }
+    }
+
+    // Step 3: Runtime var.subvolumes deep-merges on top (always wins)
+    for (path, runtime_config) in &runtime_subvolumes {
+        if let Some(existing) = merged.get(path) {
+            merged.insert(path.clone(), existing.merge_over(runtime_config));
+        } else {
+            merged.insert(path.clone(), runtime_config.clone());
+        }
+    }
+
+    // Step 4: Apply partition-level default compression
+    if let Some(ref default_comp) = default_compression {
+        for config in merged.values_mut() {
+            if config.compression.is_none() && config.is_enabled() {
+                config.compression = Some(default_comp.clone());
+            }
+        }
+    }
+
+    // Step 5: Check for nested path overlaps (warn about quota isolation)
+    let enabled_paths: Vec<String> = merged
+        .iter()
+        .filter(|(_, c)| c.is_enabled())
+        .map(|(p, _)| p.clone())
+        .collect();
+    for i in 0..enabled_paths.len() {
+        for j in (i + 1)..enabled_paths.len() {
+            let (a, b) = (&enabled_paths[i], &enabled_paths[j]);
+            let nested = if b.starts_with(&format!("{}/", a)) {
+                Some((a, b))
+            } else if a.starts_with(&format!("{}/", b)) {
+                Some((b, a))
+            } else {
+                None
+            };
+            if let Some((parent, child)) = nested {
+                // Suppress if runtime explicitly declared the child
+                if !runtime_paths.contains(child) {
+                    warnings.push(format!(
+                        "subvolume '{}' is nested inside '{}'; \
+                         quota on parent will not cover child subvolume",
+                        child, parent
+                    ));
+                }
+            }
+        }
+    }
+
+    // Step 6: Filter out disabled subvolumes and sort by path for deterministic output
+    let mut resolved: Vec<ResolvedSubvolume> = merged
+        .into_iter()
+        .filter(|(_, config)| config.is_enabled())
+        .map(|(path, config)| {
+            let writable = config.is_writable();
+            let nodatacow = config.is_nodatacow();
+            ResolvedSubvolume {
+                path,
+                writable,
+                compression: config.compression,
+                nodatacow,
+                quota: config.quota,
+            }
+        })
+        .collect();
+    resolved.sort_by(|a, b| a.path.cmp(&b.path));
+
+    // Validate: lib/avocado must not be disabled
+    if !resolved.iter().any(|s| s.path == "lib/avocado") {
+        return Err(anyhow::anyhow!(
+            "subvolume 'lib/avocado' cannot be disabled; it is required for manifest and images"
+        ));
+    }
+
+    Ok((resolved, warnings))
 }
 
 /// Extract var_files glob patterns from an extension config value.
@@ -1434,6 +1736,7 @@ impl Config {
                                 "stone_manifest",
                                 "signing",
                                 "var_files",
+                                "var",
                             ]
                             .contains(&key_str)
                             {
@@ -1483,6 +1786,7 @@ impl Config {
                                 "overlay",
                                 "var_files",
                                 "docker_images",
+                                "subvolumes",
                             ]
                             .contains(&key_str)
                             {
@@ -8269,5 +8573,408 @@ var_files:
         let yaml: serde_yaml::Value = serde_yaml::from_str("extensions: [base]").unwrap();
         let result = get_runtime_var_files(&yaml);
         assert!(result.is_empty());
+    }
+
+    // --- Subvolume tests ---
+
+    #[test]
+    fn test_subvolume_entry_bool_true() {
+        let entry: SubvolumeEntry = serde_yaml::from_str("true").unwrap();
+        let config = entry.to_config();
+        assert_eq!(config.writable, Some(true));
+        assert!(config.is_enabled());
+    }
+
+    #[test]
+    fn test_subvolume_entry_bool_false() {
+        let entry: SubvolumeEntry = serde_yaml::from_str("false").unwrap();
+        let config = entry.to_config();
+        assert_eq!(config.enabled, Some(false));
+        assert!(!config.is_enabled());
+    }
+
+    #[test]
+    fn test_subvolume_entry_string_ro() {
+        let entry: SubvolumeEntry = serde_yaml::from_str("ro").unwrap();
+        let config = entry.to_config();
+        assert_eq!(config.writable, Some(false));
+        assert!(!config.is_writable());
+        assert!(config.is_enabled());
+    }
+
+    #[test]
+    fn test_subvolume_entry_full_form() {
+        let yaml = r#"
+writable: true
+compression: "zstd:3"
+nodatacow: true
+quota: "5G"
+"#;
+        let entry: SubvolumeEntry = serde_yaml::from_str(yaml).unwrap();
+        let config = entry.to_config();
+        assert_eq!(config.writable, Some(true));
+        assert_eq!(config.compression, Some("zstd:3".to_string()));
+        assert_eq!(config.nodatacow, Some(true));
+        assert_eq!(config.quota, Some("5G".to_string()));
+        assert!(config.is_enabled());
+    }
+
+    #[test]
+    fn test_subvolume_config_merge_over() {
+        let base = SubvolumeConfig {
+            writable: Some(true),
+            compression: Some("zstd".to_string()),
+            quota: Some("1G".to_string()),
+            ..Default::default()
+        };
+        let override_config = SubvolumeConfig {
+            quota: Some("5G".to_string()),
+            nodatacow: Some(true),
+            ..Default::default()
+        };
+        let merged = base.merge_over(&override_config);
+        assert_eq!(merged.writable, Some(true)); // kept from base
+        assert_eq!(merged.compression, Some("zstd".to_string())); // kept from base
+        assert_eq!(merged.quota, Some("5G".to_string())); // overridden
+        assert_eq!(merged.nodatacow, Some(true)); // new from override
+    }
+
+    #[test]
+    fn test_get_ext_subvolumes_parses_map() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+subvolumes:
+  lib/docker:
+    writable: true
+    nodatacow: true
+    quota: "10G"
+  lib/myapp/cache: true
+"#,
+        )
+        .unwrap();
+        let result = get_ext_subvolumes(&yaml);
+        assert_eq!(result.len(), 2);
+        let docker = result.get("lib/docker").unwrap();
+        assert_eq!(docker.writable, Some(true));
+        assert_eq!(docker.nodatacow, Some(true));
+        assert_eq!(docker.quota, Some("10G".to_string()));
+        let cache = result.get("lib/myapp/cache").unwrap();
+        assert_eq!(cache.writable, Some(true));
+    }
+
+    #[test]
+    fn test_get_ext_subvolumes_returns_empty_when_missing() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str("packages: {}").unwrap();
+        let result = get_ext_subvolumes(&yaml);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_subvolumes_defaults_only() {
+        // No extensions, no runtime var config -> just lib/avocado
+        let parsed: serde_yaml::Value = serde_yaml::from_str("extensions: {}").unwrap();
+        let runtime: serde_yaml::Value = serde_yaml::from_str("extensions: []").unwrap();
+        let ext_list: Vec<&str> = vec![];
+        let (resolved, warnings) = resolve_subvolumes(&ext_list, &parsed, &runtime).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].path, "lib/avocado");
+        assert!(resolved[0].writable);
+        assert!(resolved[0].compression.is_none());
+        assert!(!resolved[0].nodatacow);
+        assert!(resolved[0].quota.is_none());
+    }
+
+    #[test]
+    fn test_resolve_subvolumes_extension_adds_subvolume() {
+        let parsed: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions:
+  my-ext:
+    subvolumes:
+      lib/docker:
+        nodatacow: true
+        quota: "10G"
+"#,
+        )
+        .unwrap();
+        let runtime: serde_yaml::Value = serde_yaml::from_str("extensions: [my-ext]").unwrap();
+        let ext_list = vec!["my-ext"];
+        let (resolved, warnings) = resolve_subvolumes(&ext_list, &parsed, &runtime).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(resolved.len(), 2);
+        // Sorted by path: lib/avocado, lib/docker
+        assert_eq!(resolved[0].path, "lib/avocado");
+        assert_eq!(resolved[1].path, "lib/docker");
+        assert!(resolved[1].nodatacow);
+        assert_eq!(resolved[1].quota, Some("10G".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_subvolumes_runtime_overrides_extension() {
+        let parsed: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions:
+  my-ext:
+    subvolumes:
+      lib/docker:
+        quota: "10G"
+        nodatacow: true
+"#,
+        )
+        .unwrap();
+        let runtime: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions: [my-ext]
+var:
+  subvolumes:
+    lib/docker:
+      quota: "20G"
+"#,
+        )
+        .unwrap();
+        let ext_list = vec!["my-ext"];
+        let (resolved, _) = resolve_subvolumes(&ext_list, &parsed, &runtime).unwrap();
+        let docker = resolved.iter().find(|s| s.path == "lib/docker").unwrap();
+        assert_eq!(docker.quota, Some("20G".to_string()));
+        assert!(docker.nodatacow); // preserved from extension
+    }
+
+    #[test]
+    fn test_resolve_subvolumes_runtime_overrides_builtin() {
+        let parsed: serde_yaml::Value = serde_yaml::from_str("extensions: {}").unwrap();
+        let runtime: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions: []
+var:
+  subvolumes:
+    lib/avocado:
+      compression: "zstd:3"
+      quota: "500M"
+"#,
+        )
+        .unwrap();
+        let ext_list: Vec<&str> = vec![];
+        let (resolved, _) = resolve_subvolumes(&ext_list, &parsed, &runtime).unwrap();
+        let avocado = resolved.iter().find(|s| s.path == "lib/avocado").unwrap();
+        assert_eq!(avocado.compression, Some("zstd:3".to_string()));
+        assert_eq!(avocado.quota, Some("500M".to_string()));
+        assert!(avocado.writable);
+    }
+
+    #[test]
+    fn test_resolve_subvolumes_default_compression() {
+        let parsed: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions:
+  my-ext:
+    subvolumes:
+      lib/data:
+        writable: true
+"#,
+        )
+        .unwrap();
+        let runtime: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions: [my-ext]
+var:
+  compression: zstd
+"#,
+        )
+        .unwrap();
+        let ext_list = vec!["my-ext"];
+        let (resolved, _) = resolve_subvolumes(&ext_list, &parsed, &runtime).unwrap();
+        // Both subvolumes should inherit the default compression
+        for s in &resolved {
+            assert_eq!(s.compression, Some("zstd".to_string()));
+        }
+    }
+
+    #[test]
+    fn test_resolve_subvolumes_enabled_false_removes() {
+        let parsed: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions:
+  my-ext:
+    subvolumes:
+      lib/cache: true
+"#,
+        )
+        .unwrap();
+        let runtime: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions: [my-ext]
+var:
+  subvolumes:
+    lib/cache:
+      enabled: false
+"#,
+        )
+        .unwrap();
+        let ext_list = vec!["my-ext"];
+        let (resolved, _) = resolve_subvolumes(&ext_list, &parsed, &runtime).unwrap();
+        assert!(!resolved.iter().any(|s| s.path == "lib/cache"));
+    }
+
+    #[test]
+    fn test_resolve_subvolumes_lib_avocado_cannot_be_disabled() {
+        let parsed: serde_yaml::Value = serde_yaml::from_str("extensions: {}").unwrap();
+        let runtime: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions: []
+var:
+  subvolumes:
+    lib/avocado:
+      enabled: false
+"#,
+        )
+        .unwrap();
+        let ext_list: Vec<&str> = vec![];
+        let result = resolve_subvolumes(&ext_list, &parsed, &runtime);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("lib/avocado"));
+    }
+
+    #[test]
+    fn test_resolve_subvolumes_exact_path_conflict_warns() {
+        let parsed: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions:
+  ext-a:
+    subvolumes:
+      lib/docker:
+        quota: "10G"
+  ext-b:
+    subvolumes:
+      lib/docker:
+        quota: "5G"
+"#,
+        )
+        .unwrap();
+        let runtime: serde_yaml::Value =
+            serde_yaml::from_str("extensions: [ext-a, ext-b]").unwrap();
+        let ext_list = vec!["ext-a", "ext-b"];
+        let (resolved, warnings) = resolve_subvolumes(&ext_list, &parsed, &runtime).unwrap();
+        // ext-a wins (first listed)
+        let docker = resolved.iter().find(|s| s.path == "lib/docker").unwrap();
+        assert_eq!(docker.quota, Some("10G".to_string()));
+        // Warning emitted for conflict
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("ext-b"));
+        assert!(warnings[0].contains("ext-a"));
+        assert!(warnings[0].contains("lib/docker"));
+    }
+
+    #[test]
+    fn test_resolve_subvolumes_exact_path_conflict_suppressed_by_runtime() {
+        let parsed: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions:
+  ext-a:
+    subvolumes:
+      lib/docker:
+        quota: "10G"
+  ext-b:
+    subvolumes:
+      lib/docker:
+        quota: "5G"
+"#,
+        )
+        .unwrap();
+        let runtime: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions: [ext-a, ext-b]
+var:
+  subvolumes:
+    lib/docker:
+      quota: "20G"
+"#,
+        )
+        .unwrap();
+        let ext_list = vec!["ext-a", "ext-b"];
+        let (resolved, warnings) = resolve_subvolumes(&ext_list, &parsed, &runtime).unwrap();
+        // No warning since runtime resolves it
+        assert!(warnings.is_empty());
+        let docker = resolved.iter().find(|s| s.path == "lib/docker").unwrap();
+        assert_eq!(docker.quota, Some("20G".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_subvolumes_nested_path_warns() {
+        let parsed: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions:
+  ext-a:
+    subvolumes:
+      lib/myapp: true
+  ext-b:
+    subvolumes:
+      lib/myapp/data:
+        quota: "2G"
+"#,
+        )
+        .unwrap();
+        let runtime: serde_yaml::Value =
+            serde_yaml::from_str("extensions: [ext-a, ext-b]").unwrap();
+        let ext_list = vec!["ext-a", "ext-b"];
+        let (_, warnings) = resolve_subvolumes(&ext_list, &parsed, &runtime).unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("nested"));
+        assert!(warnings[0].contains("lib/myapp/data"));
+        assert!(warnings[0].contains("lib/myapp"));
+    }
+
+    #[test]
+    fn test_resolve_subvolumes_nested_suppressed_when_child_disabled() {
+        let parsed: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions:
+  ext-a:
+    subvolumes:
+      lib/myapp: true
+  ext-b:
+    subvolumes:
+      lib/myapp/data:
+        quota: "2G"
+"#,
+        )
+        .unwrap();
+        let runtime: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions: [ext-a, ext-b]
+var:
+  subvolumes:
+    lib/myapp/data:
+      enabled: false
+"#,
+        )
+        .unwrap();
+        let ext_list = vec!["ext-a", "ext-b"];
+        let (resolved, warnings) = resolve_subvolumes(&ext_list, &parsed, &runtime).unwrap();
+        // No nested warning since child is disabled (filtered before nesting check)
+        assert!(warnings.is_empty());
+        assert!(!resolved.iter().any(|s| s.path == "lib/myapp/data"));
+    }
+
+    #[test]
+    fn test_var_config_deserialization() {
+        let yaml = r#"
+compression: zstd
+subvolumes:
+  lib/avocado:
+    compression: "zstd:3"
+    quota: "500M"
+  lib/logs:
+    compression: "zlib:6"
+    quota: "1G"
+  lib/cache: true
+"#;
+        let config: VarConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.compression, Some("zstd".to_string()));
+        let subvolumes = config.subvolumes.unwrap();
+        assert_eq!(subvolumes.len(), 3);
+        let avocado = subvolumes.get("lib/avocado").unwrap().to_config();
+        assert_eq!(avocado.compression, Some("zstd:3".to_string()));
+        assert_eq!(avocado.quota, Some("500M".to_string()));
     }
 }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -808,9 +808,10 @@ pub fn resolve_subvolumes(
     }
 
     // Step 4: Apply partition-level default compression
+    // Skip subvolumes with nodatacow -- NOCOW and compression are mutually exclusive on btrfs.
     if let Some(ref default_comp) = default_compression {
         for config in merged.values_mut() {
-            if config.compression.is_none() && config.is_enabled() {
+            if config.compression.is_none() && config.is_enabled() && !config.is_nodatacow() {
                 config.compression = Some(default_comp.clone());
             }
         }

--- a/src/utils/container.rs
+++ b/src/utils/container.rs
@@ -1215,9 +1215,7 @@ impl SdkContainer {
 
         match output {
             Some(output) => {
-                // For SDK sysroots, strip architecture from version string (but arch is tracked in sysroot key)
-                let strip_arch = matches!(sysroot, crate::utils::lockfile::SysrootType::Sdk(_));
-                let versions = crate::utils::lockfile::parse_rpm_query_output(&output, strip_arch);
+                let versions = crate::utils::lockfile::parse_rpm_query_output(&output);
                 if self.verbose {
                     print_info(
                         &format!(

--- a/src/utils/lockfile.rs
+++ b/src/utils/lockfile.rs
@@ -809,9 +809,8 @@ impl LockFile {
 /// Parse rpm -q output into a map of package names to versions
 /// Expected format: "NAME VERSION-RELEASE.ARCH" per line
 ///
-/// For SDK packages, we strip the architecture suffix to make the lock file portable
-/// across different host architectures (x86_64, aarch64, etc.)
-pub fn parse_rpm_query_output(output: &str, strip_arch: bool) -> HashMap<String, String> {
+/// Returns a map of package name -> full version string (including architecture suffix).
+pub fn parse_rpm_query_output(output: &str) -> HashMap<String, String> {
     let mut result = HashMap::new();
 
     for line in output.lines() {
@@ -842,19 +841,7 @@ pub fn parse_rpm_query_output(output: &str, strip_arch: bool) -> HashMap<String,
                 continue;
             }
 
-            let version_to_store = if strip_arch {
-                // Strip the architecture suffix (.ARCH) from the version
-                // Format: VERSION-RELEASE.ARCH -> VERSION-RELEASE
-                if let Some(idx) = version.rfind('.') {
-                    version[..idx].to_string()
-                } else {
-                    version.to_string()
-                }
-            } else {
-                version.to_string()
-            };
-
-            result.insert(name.to_string(), version_to_store);
+            result.insert(name.to_string(), version.to_string());
         }
     }
 
@@ -975,8 +962,7 @@ package-xyz is not installed
 wget 1.21-r0.core2_64
 "#;
 
-        // Test without stripping architecture
-        let result = parse_rpm_query_output(output, false);
+        let result = parse_rpm_query_output(output);
         assert_eq!(result.len(), 3);
         assert_eq!(result.get("curl"), Some(&"7.88.1-r0.core2_64".to_string()));
         assert_eq!(
@@ -985,16 +971,6 @@ wget 1.21-r0.core2_64
         );
         assert_eq!(result.get("wget"), Some(&"1.21-r0.core2_64".to_string()));
         assert_eq!(result.get("package-xyz"), None);
-
-        // Test with stripping architecture (for SDK packages)
-        let result_stripped = parse_rpm_query_output(output, true);
-        assert_eq!(result_stripped.len(), 3);
-        assert_eq!(result_stripped.get("curl"), Some(&"7.88.1-r0".to_string()));
-        assert_eq!(
-            result_stripped.get("openssl"),
-            Some(&"3.0.8-r0".to_string())
-        );
-        assert_eq!(result_stripped.get("wget"), Some(&"1.21-r0".to_string()));
     }
 
     #[test]
@@ -1281,24 +1257,22 @@ wget 1.21-r0.core2_64
     #[test]
     fn test_parse_rpm_query_output_edge_cases() {
         // Empty output
-        let result = parse_rpm_query_output("", false);
+        let result = parse_rpm_query_output("");
         assert!(result.is_empty());
 
         // Whitespace only
-        let result = parse_rpm_query_output("   \n  \n  ", false);
+        let result = parse_rpm_query_output("   \n  \n  ");
         assert!(result.is_empty());
 
         // Only "not installed" messages
-        let result = parse_rpm_query_output(
-            "package-a is not installed\npackage-b is not installed",
-            false,
-        );
+        let result =
+            parse_rpm_query_output("package-a is not installed\npackage-b is not installed");
         assert!(result.is_empty());
 
         // Mixed valid and invalid
         let output =
             "valid-pkg 1.0.0-r0.x86_64\nbad-pkg is not installed\nanother-pkg 2.0.0-r0.x86_64";
-        let result = parse_rpm_query_output(output, false);
+        let result = parse_rpm_query_output(output);
         assert_eq!(result.len(), 2);
         assert!(result.contains_key("valid-pkg"));
         assert!(result.contains_key("another-pkg"));
@@ -1318,7 +1292,7 @@ wget 1.21-r0.core2_64
 [WARNING] Warning message
 "#;
 
-        let result = parse_rpm_query_output(output, false);
+        let result = parse_rpm_query_output(output);
         assert_eq!(result.len(), 3);
         assert_eq!(result.get("curl"), Some(&"7.88.1-r0.core2_64".to_string()));
         assert_eq!(
@@ -1335,42 +1309,26 @@ wget 1.21-r0.core2_64
     }
 
     #[test]
-    fn test_parse_rpm_query_output_strips_arch_for_sdk() {
-        // Test SDK package output with architecture stripping
+    fn test_parse_rpm_query_output_preserves_full_version_for_sdk() {
+        // SDK package versions should be preserved in full (including architecture suffix)
+        // since SDK packages are already nested per host architecture in the lock file
         let output = r#"nativesdk-curl 7.88.1-r0.x86_64_avocadosdk
 nativesdk-openssl 3.0.8-r0.x86_64_avocadosdk
 avocado-sdk-toolchain 0.1.0-r0.x86_64_avocadosdk
 "#;
 
-        // With strip_arch=true (for SDK packages)
-        let result_stripped = parse_rpm_query_output(output, true);
-        assert_eq!(result_stripped.len(), 3);
+        let result = parse_rpm_query_output(output);
+        assert_eq!(result.len(), 3);
         assert_eq!(
-            result_stripped.get("nativesdk-curl"),
-            Some(&"7.88.1-r0".to_string())
-        );
-        assert_eq!(
-            result_stripped.get("nativesdk-openssl"),
-            Some(&"3.0.8-r0".to_string())
-        );
-        assert_eq!(
-            result_stripped.get("avocado-sdk-toolchain"),
-            Some(&"0.1.0-r0".to_string())
-        );
-
-        // With strip_arch=false (for non-SDK packages)
-        let result_full = parse_rpm_query_output(output, false);
-        assert_eq!(result_full.len(), 3);
-        assert_eq!(
-            result_full.get("nativesdk-curl"),
+            result.get("nativesdk-curl"),
             Some(&"7.88.1-r0.x86_64_avocadosdk".to_string())
         );
         assert_eq!(
-            result_full.get("nativesdk-openssl"),
+            result.get("nativesdk-openssl"),
             Some(&"3.0.8-r0.x86_64_avocadosdk".to_string())
         );
         assert_eq!(
-            result_full.get("avocado-sdk-toolchain"),
+            result.get("avocado-sdk-toolchain"),
             Some(&"0.1.0-r0.x86_64_avocadosdk".to_string())
         );
     }

--- a/src/utils/stamps.rs
+++ b/src/utils/stamps.rs
@@ -950,6 +950,13 @@ pub fn compute_ext_input_hash_with_fs(
                 var_files.clone(),
             );
         }
+        // Include subvolumes as they affect var image creation flags
+        if let Some(subvolumes) = ext.get("subvolumes") {
+            hash_data.insert(
+                serde_yaml::Value::String(format!("ext.{ext_name}.subvolumes")),
+                subvolumes.clone(),
+            );
+        }
         // Include image config as it determines output format and kabtool args
         if let Some(image) = ext.get("image") {
             hash_data.insert(
@@ -1069,6 +1076,14 @@ pub fn compute_runtime_input_hash(
         hash_data.insert(
             serde_yaml::Value::String(format!("runtime.{runtime_name}.var_files")),
             var_files.clone(),
+        );
+    }
+
+    // Include runtime-level var config (subvolumes, compression) if specified
+    if let Some(var) = merged_runtime.get("var") {
+        hash_data.insert(
+            serde_yaml::Value::String(format!("runtime.{runtime_name}.var")),
+            var.clone(),
         );
     }
 
@@ -2750,6 +2765,79 @@ var_files:
         assert_ne!(
             hash_without.config_hash, hash_with.config_hash,
             "Adding var_files should change the runtime input hash"
+        );
+    }
+
+    #[test]
+    fn test_ext_input_hash_includes_subvolumes() {
+        let config_without: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions:
+  my-ext:
+    version: "1.0.0"
+    types: [sysext]
+    packages:
+      foo: "*"
+"#,
+        )
+        .unwrap();
+
+        let config_with: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions:
+  my-ext:
+    version: "1.0.0"
+    types: [sysext]
+    packages:
+      foo: "*"
+    subvolumes:
+      lib/docker:
+        nodatacow: true
+        quota: "10G"
+"#,
+        )
+        .unwrap();
+
+        let hash_without = compute_ext_input_hash(&config_without, "my-ext").unwrap();
+        let hash_with = compute_ext_input_hash(&config_with, "my-ext").unwrap();
+
+        assert_ne!(
+            hash_without.config_hash, hash_with.config_hash,
+            "Adding subvolumes should change the ext input hash"
+        );
+    }
+
+    #[test]
+    fn test_runtime_input_hash_includes_var_config() {
+        let runtime_without: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+packages:
+  avocado-runtime: "*"
+"#,
+        )
+        .unwrap();
+
+        let runtime_with: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+packages:
+  avocado-runtime: "*"
+var:
+  compression: zstd
+  subvolumes:
+    lib/avocado:
+      quota: "500M"
+"#,
+        )
+        .unwrap();
+
+        let empty_parsed = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+        let hash_without =
+            compute_runtime_input_hash(&runtime_without, "dev", &empty_parsed).unwrap();
+        let hash_with = compute_runtime_input_hash(&runtime_with, "dev", &empty_parsed).unwrap();
+
+        assert_ne!(
+            hash_without.config_hash, hash_with.config_hash,
+            "Adding var config should change the runtime input hash"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Add configurable btrfs subvolume support for the var partition, allowing extensions and runtimes to declare subvolumes with per-subvolume compression, quotas, nodatacow, and read-only/read-write modes
- Support shorthand (`true`, `"ro"`) and full-form subvolume entries with a layered merge strategy: built-in `lib/avocado` → extensions (first-listed wins) → runtime overrides (always wins)
- Emit build-time warnings for extension path conflicts and nested subvolume quota isolation issues, with runtime-level declarations suppressing warnings
- Lock SDK package versions with full architecture suffix (per host arch nesting in lock file makes stripping redundant)
- Include subvolumes and var config in input hashes so changes trigger rebuilds

## Test plan
- [x] Verify `cargo test` passes (new tests cover all subvolume entry forms, merge precedence, conflict warnings, nested path detection, disabled subvolumes, and input hash inclusion)
- [ ] Test runtime build with no `var` config — should produce the same `--subvol rw:lib/avocado` behavior as before
- [ ] Test runtime build with extension-declared subvolumes and verify mkfs flags include them
- [ ] Test runtime override of extension subvolume config (e.g. quota override) and confirm runtime wins
- [ ] Test `enabled: false` to suppress an extension-declared subvolume
- [ ] Verify post-creation btrfs property commands (compression, quotas) are emitted when configured