### PR TITLE
chore: fix clippy and cargo-audit failures on stable 1.95

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,9 +1980,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/src/utils/disk_writer.rs
+++ b/src/utils/disk_writer.rs
@@ -437,10 +437,8 @@ fn parse_disk_identifiers_from_plist(plist: &str) -> Vec<String> {
             in_device_id = true;
         } else if in_device_id {
             if let Some(value) = extract_plist_string_value(trimmed) {
-                if value.starts_with("disk") && is_whole_disk_id(&value) {
-                    if !ids.contains(&value) {
-                        ids.push(value);
-                    }
+                if value.starts_with("disk") && is_whole_disk_id(&value) && !ids.contains(&value) {
+                    ids.push(value);
                 }
             }
             in_device_id = false;

--- a/src/utils/tui/renderer.rs
+++ b/src/utils/tui/renderer.rs
@@ -191,13 +191,11 @@ impl TaskRenderer {
         if let Some(task) = state.iter_mut().find(|t| &t.id == id) {
             task.status = status;
             match status {
-                TaskStatus::Running => {
-                    // Only set started_at on the first Running transition —
-                    // subsequent calls (e.g. from multiple container runs
-                    // within the same task) must not reset the clock.
-                    if task.started_at.is_none() {
-                        task.started_at = Some(std::time::Instant::now());
-                    }
+                // Only set started_at on the first Running transition —
+                // subsequent calls (e.g. from multiple container runs
+                // within the same task) must not reset the clock.
+                TaskStatus::Running if task.started_at.is_none() => {
+                    task.started_at = Some(std::time::Instant::now());
                 }
                 TaskStatus::Success | TaskStatus::Failed | TaskStatus::Skipped => {
                     task.finished_at = Some(std::time::Instant::now());


### PR DESCRIPTION
## Summary

- Resolve two clippy lints tripping on rust 1.95 (`collapsible_if` in `disk_writer.rs`, `collapsible_match` in `tui/renderer.rs`)
- Bump `rustls-webpki` to 0.103.12 for RUSTSEC-2026-0098 and RUSTSEC-2026-0099 (`cargo update -p rustls-webpki` only — no Cargo.toml change)

Both issues are latent on `main`; CI doesn't run clippy or cargo-audit on scheduled workflows, so they first surface on PRs.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean on stable 1.95
- [x] `cargo audit` clean (2 informational warnings remain for `rand`, not blocking)
- [x] `cargo test --lib` passes
- [ ] CI passes end-to-end