### PR TITLE
Release 0.35.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,9 +1980,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocado-cli"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]


### PR DESCRIPTION
## Summary
Bump avocado-cli from 0.34.0 to 0.35.0.

### Features
- **btrfs subvolumes**: add subvolume config for var partitions with per-extension and runtime-level options (compression, quotas, nodatacow, rw/ro), with conflict detection, rebuild-hash integration, and per-property echo during post-creation setup (#085af83, #234be34)
- **`avocado connect clean`**: new command to clean up connect state (#2964d8d)
- **SDK version locking per host arch**: remove the `strip_arch` workaround so full NEVRA versions are stored in the SDK lock file, giving exact package pinning per host architecture (#085af83)

### Fixes
- subvolumes are created rw at mkfs time and flipped to ro after properties are set, since read-only subvolumes reject `btrfs property set` (#e2dbb1d)
- skip compression on nodatacow subvolumes — NOCOW and compression are mutually exclusive on btrfs (#2c5b944)
- replace unsupported `mkfs.btrfs --inode-flags` with `--compress` + post-creation loop mount (`chattr +C` for nodatacow, per-subvolume properties via loop mount) (#2eb039d)

### Other
- `init --reference` now pulls from the standalone `avocado-linux/references` repo instead of `avocado-linux/avocado-os/references/` (#b41a013)
- formatting / rustfmt cleanup (#934d86e, #1534672)

## Test plan
- [ ] Verify `avocado --version` reports 0.35.0
- [ ] CI passes
- [ ] `avocado connect clean` works as expected
- [ ] Runtime build with btrfs subvolume config (compression, nodatacow, ro) produces a valid image
- [ ] `avocado init --reference <name>` resolves against the standalone references repo