### PR TITLE
0.36.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocado-cli"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]

--- a/src/commands/rootfs/install.rs
+++ b/src/commands/rootfs/install.rs
@@ -145,27 +145,38 @@ async fn stage_kernel_sysroot_from_rootfs(
 set -e
 KERNEL_DIR="$AVOCADO_PREFIX/kernel/{kver}"
 mkdir -p "$KERNEL_DIR"
-ROOTFS_BOOT="$AVOCADO_PREFIX/rootfs/boot"
-if [ ! -d "$ROOTFS_BOOT" ]; then
+ROOTFS_ROOT="$AVOCADO_PREFIX/rootfs"
+if [ ! -d "$ROOTFS_ROOT/boot" ]; then
     echo "[ERROR] Rootfs sysroot has no /boot directory; cannot stage kernel sysroot for {kver}" >&2
     exit 1
 fi
-# Copy any kver-tagged Image files. Two naming conventions appear across
-# distros: `Image-<kver>(.gz)?` and `Image.gz-<kver>`. Match both.
-shopt -s nullglob
-matched=0
-for f in "$ROOTFS_BOOT"/Image-{kver}* "$ROOTFS_BOOT"/Image.gz-{kver}*; do
-    cp -a "$f" "$KERNEL_DIR/"
-    matched=$((matched+1))
-done
-if [ "$matched" -eq 0 ]; then
-    echo "[ERROR] Did not find Image*-{kver}* in rootfs /boot; cannot stage kernel sysroot" >&2
+# Locate bootable kernel images by their versioned filename suffix rather than
+# by enumerating KERNEL_IMAGETYPE names. Any file in /boot named *-{kver} or
+# *-{kver}.gz that isn't a known non-bootable kernel-base artifact qualifies.
+# (The RPM sysroot db is not queryable here — packages installed via dnf
+# --installroot are not tracked in the sysroot's own rpmdb.)
+mapfile -t boot_files < <(
+    find "$ROOTFS_ROOT/boot" -maxdepth 1 -type f \
+        \( -name "*-{kver}" -o -name "*-{kver}.gz" \) \
+        ! -name "System.map-*" ! -name "config-*" \
+    | sort
+)
+if [ "${{#boot_files[@]}}" -eq 0 ]; then
+    echo "[ERROR] No bootable kernel image found for {kver} in rootfs /boot" >&2
     exit 1
 fi
-# Provide a stable name (`Image`) alongside the versioned file so consumers
-# don't need to know the kver to find the bootable artifact.
-if [ -f "$KERNEL_DIR/Image-{kver}" ] && [ ! -e "$KERNEL_DIR/Image" ]; then
-    ln -s "Image-{kver}" "$KERNEL_DIR/Image"
+for abs_path in "${{boot_files[@]}}"; do
+    cp -a "$abs_path" "$KERNEL_DIR/"
+done
+# Stable 'Image' symlink — prefer uncompressed over .gz so consumers can use
+# it directly without decompression.
+for abs_path in "${{boot_files[@]}}"; do
+    [[ "$abs_path" == *.gz ]] && continue
+    ln -s "$(basename "$abs_path")" "$KERNEL_DIR/Image"
+    break
+done
+if [ ! -e "$KERNEL_DIR/Image" ]; then
+    ln -s "$(basename "${{boot_files[0]}}")" "$KERNEL_DIR/Image"
 fi
 "#
     );

--- a/src/commands/runtime/provision.rs
+++ b/src/commands/runtime/provision.rs
@@ -338,9 +338,11 @@ impl RuntimeProvisionCommand {
                 {
                     // Prefer the content-addressed kernel sysroot when populated
                     // (Phase 2c stages it from the rootfs install). The
-                    // `Image` symlink inside that directory points at
-                    // `Image-<kver>`. Fall back to the rootfs `/boot/Image-<kver>`
-                    // path for v4 lockfiles or if staging silently failed.
+                    // `Image` symlink inside that directory points at the
+                    // arch-appropriate image (`Image-<kver>` on ARM64,
+                    // `bzImage-<kver>` on x86-64). Fall back to the rootfs
+                    // `/boot/Image-<kver>` path for v4 lockfiles or if staging
+                    // silently failed.
                     let kernel_sysroot = SysrootType::Kernel(kver.clone());
                     let kernel_sysroot_populated = lock_file
                         .get_sysroot_versions(&target_arch, &kernel_sysroot)


### PR DESCRIPTION
## Summary
- Generalize kernel sysroot staging to match versioned suffix `*-<kver>(.gz)?` instead of hardcoded `Image-<kver>` / `Image.gz-<kver>`, so x86-64 (`bzImage-<kver>`) stages alongside ARM64.
- Exclude non-bootable kernel-base artifacts (`System.map-*`, `config-*`); prefer uncompressed image for the stable `Image` symlink.
- Bump version to 0.36.1.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build`
- [x] `cargo test`
- [x] `cargo audit`
- [x] End-to-end rootfs install + runtime provision against an ARM64 target (regression check)
- [x] End-to-end rootfs install + runtime provision against an x86-64 target (new path: `bzImage-<kver>`)