### PR TITLE
fix: handle long hardlink and symlink targets in save archive

### DIFF
--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -304,17 +304,29 @@ fn build_save_archive(
         let entry_size = entry.header().size().unwrap_or(0);
 
         let mut new_header = entry.header().clone();
-
         let entry_type = entry.header().entry_type();
-        // Re-prefix hardlink targets so they resolve correctly in the archive
-        if entry_type.is_hard_link() {
-            if let Ok(Some(link_name)) = entry.header().link_name() {
-                let new_link = PathBuf::from(format!("{ARCHIVE_PREFIX}/volume")).join(link_name);
-                new_header.set_link_name(&new_link)?;
-            }
-        }
 
-        if entry_type.is_dir() || entry_type.is_symlink() || entry_type.is_hard_link() {
+        if entry_type.is_hard_link() {
+            // Hardlink targets reference other entries in the archive — re-prefix so
+            // they resolve to the new path layout. Use `Entry::link_name()` to read
+            // through any GNU/PAX long-name extensions, and `Builder::append_link`
+            // to write through them (re-prefixing can push targets past the 100-byte
+            // header field).
+            let original_link = entry
+                .link_name()?
+                .ok_or_else(|| anyhow::anyhow!("hardlink entry missing link target"))?;
+            let new_link =
+                PathBuf::from(format!("{ARCHIVE_PREFIX}/volume")).join(original_link.as_ref());
+            tar.append_link(&mut new_header, &new_path, &new_link)?;
+        } else if entry_type.is_symlink() {
+            // Symlink targets are filesystem paths (not archive paths), so we don't
+            // re-prefix them. Still use `append_link` to preserve any long-name
+            // encoding through the proper API.
+            let original_link = entry
+                .link_name()?
+                .ok_or_else(|| anyhow::anyhow!("symlink entry missing link target"))?;
+            tar.append_link(&mut new_header, &new_path, original_link.as_ref())?;
+        } else if entry_type.is_dir() {
             tar.append_data(&mut new_header, &new_path, std::io::empty())?;
         } else {
             tar.append_data(&mut new_header, &new_path, &mut entry)?;


### PR DESCRIPTION
## Problem

`avocado save` aborts on any volume containing hardlinks whose targets exceed 100 bytes after the `avocado-state/volume/` archive prefix is applied. Cargo build artifacts in the SDK volume reliably trigger this:

```
Error: provided value is too long when setting link name for ./qemux86-64/sdk/aarch64/build/avocado-conn/release/build/anyhow-27218e60227aebdd/build-script-build
```

## Root cause

The save loop cloned each entry's header and called `Header::set_link_name` directly. The `tar` crate's header struct has a fixed 100-byte `linkname` field; `set_link_name` returns an error rather than emitting a GNU `K` long-link extension. Re-prefixing the target with `avocado-state/volume/` consistently pushes Cargo build paths past the limit.

A latent issue also existed for symlinks with long original targets: the inner archive's `K` extension was implicitly resolved by `Entry::link_name()` but `header().clone()` + `append_data` would have silently truncated the target on output.

## Fix

- Read targets via `Entry::link_name()` so GNU/PAX long-name extensions are resolved on read.
- Write hardlinks and symlinks via `Builder::append_link()` so the proper long-name extensions are emitted on write.
- Hardlink targets continue to be re-prefixed for the new archive layout; symlink targets are preserved as-is (filesystem paths, not archive paths).

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` no new warnings
- [x] `cargo test save` — 7 existing tests still pass
- [x] Manual: `avocado save --include-src` on a built `runtimes-dev` project (4 GB volume with Cargo artifacts) succeeds and produces a 2 GB archive
- [x] Manual: round-trip — `avocado load` on the saved archive into a fresh directory, `provision`, then `sdk run vm dev` boots successfully
