### PR TITLE
0.36.2: include overlay in rootfs/initramfs singleton discriminator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocado-cli"
-version = "0.36.1"
+version = "0.36.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.36.1"
+version = "0.36.2"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]

--- a/src/commands/rootfs/install.rs
+++ b/src/commands/rootfs/install.rs
@@ -31,11 +31,20 @@ fn parse_overlay_config(value: &serde_yaml::Value) -> (String, bool) {
 /// Build the shell snippet that applies an overlay directory into a sysroot.
 /// `overlay_dir` is the path relative to `/opt/src` (the project root inside the container).
 /// `sysroot_dir` is the sysroot subdirectory name (e.g., "rootfs", "initramfs").
+///
+/// The snippet sources the SDK's `environment-setup` to put SDK-provided tools
+/// (notably `rsync`) on `PATH`. The enclosing install command runs with
+/// `source_environment: false` to keep DNF's environment minimal, so the
+/// overlay step has to source the env itself.
 fn build_overlay_script(overlay_dir: &str, opaque: bool, sysroot_dir: &str) -> String {
+    let env_source = r#"if [ -f "${AVOCADO_SDK_PREFIX}/environment-setup" ]; then
+    . "${AVOCADO_SDK_PREFIX}/environment-setup"
+fi"#;
     if opaque {
         format!(
             r#"
 # Apply overlay (opaque mode) — cp -r replaces directory contents
+{env_source}
 if [ -d "/opt/src/{overlay_dir}" ]; then
     echo "Applying overlay '{overlay_dir}' to {sysroot_dir} sysroot (opaque mode)"
     cp -r "/opt/src/{overlay_dir}/." "$AVOCADO_PREFIX/{sysroot_dir}/"
@@ -50,6 +59,7 @@ fi
         format!(
             r#"
 # Apply overlay (merge mode) — rsync -a adds/replaces files, preserving others
+{env_source}
 if [ -d "/opt/src/{overlay_dir}" ]; then
     echo "Applying overlay '{overlay_dir}' to {sysroot_dir} sysroot (merge mode)"
     rsync -a --chown=root:root "/opt/src/{overlay_dir}/" "$AVOCADO_PREFIX/{sysroot_dir}/"
@@ -987,5 +997,57 @@ impl RootfsInstallCommand {
         }
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_overlay_script;
+
+    #[test]
+    fn overlay_script_sources_sdk_environment_in_merge_mode() {
+        // Merge mode uses rsync, which is provided by the SDK toolchain. The
+        // enclosing install command runs without sourcing the SDK env, so the
+        // overlay snippet must source `environment-setup` itself or rsync will
+        // not be on PATH.
+        let script = build_overlay_script("overlays/dev", false, "initramfs");
+        assert!(
+            script.contains(r#". "${AVOCADO_SDK_PREFIX}/environment-setup""#),
+            "merge-mode overlay script must source the SDK environment-setup; got:\n{script}"
+        );
+        assert!(script.contains("rsync -a --chown=root:root"));
+        assert!(script.contains("(merge mode)"));
+    }
+
+    #[test]
+    fn overlay_script_sources_sdk_environment_in_opaque_mode() {
+        // Opaque mode uses cp, which is universally available, but we still
+        // source the env for symmetry and to keep PATH consistent with any
+        // future tools used here.
+        let script = build_overlay_script("overlays/dev", true, "rootfs");
+        assert!(
+            script.contains(r#". "${AVOCADO_SDK_PREFIX}/environment-setup""#),
+            "opaque-mode overlay script must source the SDK environment-setup; got:\n{script}"
+        );
+        assert!(script.contains("cp -r"));
+        assert!(script.contains("(opaque mode)"));
+    }
+
+    #[test]
+    fn overlay_script_sources_sdk_environment_for_all_sysroots_and_modes() {
+        // Cover the full {rootfs, initramfs} × {merge, opaque} matrix to make
+        // it unambiguous that the env-source line is present regardless of
+        // which sysroot or mode is in use.
+        for sysroot_dir in ["rootfs", "initramfs"] {
+            for opaque in [false, true] {
+                let script = build_overlay_script("overlays/dev", opaque, sysroot_dir);
+                assert!(
+                    script.contains(r#". "${AVOCADO_SDK_PREFIX}/environment-setup""#),
+                    "overlay script for sysroot={sysroot_dir} opaque={opaque} must source \
+                     the SDK environment-setup; got:\n{script}"
+                );
+                assert!(script.contains(&format!(" to {sysroot_dir} sysroot ")));
+            }
+        }
     }
 }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -147,7 +147,7 @@ where
 {
     named_or_single_deserializer::deserialize(
         deserializer,
-        &["packages", "dependencies", "filesystem"],
+        &["packages", "dependencies", "filesystem", "overlay"],
         "rootfs",
     )
 }
@@ -161,7 +161,7 @@ where
 {
     named_or_single_deserializer::deserialize(
         deserializer,
-        &["packages", "dependencies", "filesystem"],
+        &["packages", "dependencies", "filesystem", "overlay"],
         "initramfs",
     )
 }
@@ -9845,6 +9845,78 @@ rootfs:
         assert!(
             err.contains("cannot mix") && err.contains("rootfs"),
             "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_rootfs_singleton_with_overlay_only() {
+        // `overlay` alone must be recognized as a singleton field, not a named entry.
+        let yaml = r#"
+rootfs:
+  overlay: "overlays/dev"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.rootfs.as_ref().unwrap().contains_key("default"));
+        let rfs = config.rootfs_default().unwrap();
+        assert_eq!(
+            rfs.overlay.as_ref().and_then(|v| v.as_str()),
+            Some("overlays/dev")
+        );
+    }
+
+    #[test]
+    fn test_rootfs_singleton_with_overlay_and_packages() {
+        // Mixing `overlay` with other singleton fields must not trigger the
+        // "cannot mix singleton form and named-map form" error.
+        let yaml = r#"
+rootfs:
+  packages:
+    avocado-pkg-rootfs: "*"
+  filesystem: erofs-lz4
+  overlay:
+    dir: "overlays/dev"
+    mode: opaque
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let rfs = config.rootfs_default().unwrap();
+        assert_eq!(rfs.filesystem.as_deref(), Some("erofs-lz4"));
+        let overlay = rfs.overlay.as_ref().unwrap();
+        assert_eq!(
+            overlay.get("dir").and_then(|v| v.as_str()),
+            Some("overlays/dev")
+        );
+        assert_eq!(overlay.get("mode").and_then(|v| v.as_str()), Some("opaque"));
+    }
+
+    #[test]
+    fn test_initramfs_singleton_with_overlay_only() {
+        let yaml = r#"
+initramfs:
+  overlay: "overlays/initramfs"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.initramfs.as_ref().unwrap().contains_key("default"));
+        let ifs = config.initramfs_default().unwrap();
+        assert_eq!(
+            ifs.overlay.as_ref().and_then(|v| v.as_str()),
+            Some("overlays/initramfs")
+        );
+    }
+
+    #[test]
+    fn test_initramfs_singleton_with_overlay_and_packages() {
+        let yaml = r#"
+initramfs:
+  packages: { avocado-pkg-initramfs: "*" }
+  filesystem: cpio.zst
+  overlay: "overlays/initramfs"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let ifs = config.initramfs_default().unwrap();
+        assert_eq!(ifs.filesystem.as_deref(), Some("cpio.zst"));
+        assert_eq!(
+            ifs.overlay.as_ref().and_then(|v| v.as_str()),
+            Some("overlays/initramfs")
         );
     }
 


### PR DESCRIPTION
## Summary
- Fix `cannot mix singleton form ... and named-map form` error when `rootfs:` or `initramfs:` blocks use the new `overlay:` key alongside `packages:` / `filesystem:`. The `overlay` field on `ImageConfig` was added but not registered with the singleton-vs-named-map deserializer, so it was treated as an unknown key and tipped the form-detection heuristic into mixed-form rejection.
- Add unit tests covering overlay-only and overlay-with-other-fields singleton forms for both rootfs and initramfs.
- Bump version to 0.36.2.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --verbose` (868 lib + 7 integration + 6 doc tests pass)
- [x] New tests: `test_rootfs_singleton_with_overlay_only`, `test_rootfs_singleton_with_overlay_and_packages`, `test_initramfs_singleton_with_overlay_only`, `test_initramfs_singleton_with_overlay_and_packages`