### PR TITLE
feat: use `{{ avocado.target.board }}` for BSP ext in init template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocado-cli"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.37.0"
+version = "0.37.1"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -23,7 +23,7 @@ runtimes:
     extensions:
       - avocado-ext-dev
       - avocado-ext-sshd-dev
-      - avocado-bsp-{{ avocado.target }}
+      - avocado-bsp-{{ avocado.target.board }}
       - config
       - app
     packages:
@@ -44,7 +44,7 @@ extensions:
       type: package
       version: "*"
 
-  avocado-bsp-{{ avocado.target }}:
+  avocado-bsp-{{ avocado.target.board }}:
     source:
       type: package
       version: "*"


### PR DESCRIPTION
## Summary
- Update `avocado init` default template so the generated avocado-bsp extension reference uses `{{ avocado.target.board }}` instead of `{{ avocado.target }}`, letting projects with multiple boards on a shared target resolve to the right BSP package. Falls back to `target` when no board is set, so existing single-board projects are unaffected.
- Bump version to 0.37.1.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (all suites pass)
- [x] Verify `avocado init` on a multi-board target picks up the correct BSP package