### PR TITLE
feat: add connect devices reclaim subcommand

### DIFF
--- a/src/commands/connect/client.rs
+++ b/src/commands/connect/client.rs
@@ -223,6 +223,41 @@ pub struct DeviceInfo {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct ReclaimRequestDevice {
+    pub id: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    pub identifier: String,
+    #[serde(default)]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct ReclaimRequest {
+    pub id: String,
+    pub device_id: String,
+    #[serde(default)]
+    pub device: Option<ReclaimRequestDevice>,
+    pub status: String,
+    #[serde(default)]
+    pub requested_fingerprint: Option<String>,
+    #[serde(default)]
+    pub requested_at: Option<String>,
+    #[serde(default)]
+    pub resolved_at: Option<String>,
+    #[serde(default)]
+    pub expires_at: Option<String>,
+    #[serde(default)]
+    pub request_ip: Option<String>,
+    #[serde(default)]
+    pub request_user_agent: Option<String>,
+    #[serde(default)]
+    pub denied_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct CohortInfo {
     pub id: String,
     pub name: String,
@@ -893,6 +928,122 @@ impl ConnectClient {
         if !status.is_success() {
             let body = res.text().await.unwrap_or_default();
             anyhow::bail!("Failed to delete device (HTTP {status}): {body}");
+        }
+
+        Ok(())
+    }
+
+    /// List device reclaim requests for an organization, optionally filtered by status.
+    pub async fn list_reclaim_requests(
+        &self,
+        org: &str,
+        status: Option<&str>,
+        device_id: Option<&str>,
+    ) -> Result<Vec<ReclaimRequest>> {
+        let mut url = format!("{}/api/orgs/{}/reclaim-requests", self.api_url, org);
+
+        // Manual query-string construction — safe here because both filter
+        // values are validated at the clap layer before reaching this method:
+        //   * `status` is a `ReclaimStatusFilter::as_str()` mapping (always a
+        //     known short lowercase ASCII identifier).
+        //   * `device_id` passed clap's `parse_uuid` value_parser, which
+        //     accepts only canonical-hyphenated UUID strings (`Uuid::parse_str`).
+        // Neither shape can contain `&`, `?`, `#`, `=`, or `%`, so URL
+        // encoding is unnecessary. The server still validates both
+        // independently as defense-in-depth.
+        let mut sep = '?';
+        if let Some(s) = status {
+            url.push_str(&format!("{sep}status={s}"));
+            sep = '&';
+        }
+        if let Some(d) = device_id {
+            url.push_str(&format!("{sep}device_id={d}"));
+        }
+
+        let res = self
+            .http
+            .get(&url)
+            .header("authorization", format!("Bearer {}", self.token))
+            .send()
+            .await
+            .context("Failed to list reclaim requests")?;
+
+        let http_status = res.status();
+        if !http_status.is_success() {
+            let body = res.text().await.unwrap_or_default();
+            let msg = format_reclaim_error(http_status, &body);
+            anyhow::bail!("Failed to list reclaim requests: {msg}");
+        }
+
+        let body: serde_json::Value = res.json().await?;
+        let data = body
+            .get("data")
+            .cloned()
+            .unwrap_or_else(|| serde_json::Value::Array(vec![]));
+        let requests: Vec<ReclaimRequest> = serde_json::from_value(data)?;
+        Ok(requests)
+    }
+
+    /// Approve a pending reclaim request.
+    pub async fn approve_reclaim_request(&self, org: &str, id: &str) -> Result<ReclaimRequest> {
+        let url = format!(
+            "{}/api/orgs/{}/reclaim-requests/{}/approve",
+            self.api_url, org, id
+        );
+
+        let res = self
+            .http
+            .post(&url)
+            .header("authorization", format!("Bearer {}", self.token))
+            .send()
+            .await
+            .context("Failed to approve reclaim request")?;
+
+        parse_reclaim_response(res, "approve").await
+    }
+
+    /// Deny a pending reclaim request, with an optional reason.
+    pub async fn deny_reclaim_request(
+        &self,
+        org: &str,
+        id: &str,
+        reason: Option<&str>,
+    ) -> Result<ReclaimRequest> {
+        let url = format!(
+            "{}/api/orgs/{}/reclaim-requests/{}/deny",
+            self.api_url, org, id
+        );
+
+        let mut req = self
+            .http
+            .post(&url)
+            .header("authorization", format!("Bearer {}", self.token));
+        if let Some(r) = reason {
+            req = req.json(&serde_json::json!({ "reason": r }));
+        }
+
+        let res = req.send().await.context("Failed to deny reclaim request")?;
+
+        parse_reclaim_response(res, "deny").await
+    }
+
+    /// Delete a denied reclaim request.
+    pub async fn delete_reclaim_request(&self, org: &str, id: &str) -> Result<()> {
+        let url = format!("{}/api/orgs/{}/reclaim-requests/{}", self.api_url, org, id);
+
+        let res = self
+            .http
+            .delete(&url)
+            .header("authorization", format!("Bearer {}", self.token))
+            .send()
+            .await
+            .context("Failed to delete reclaim request")?;
+
+        let http_status = res.status();
+        if !http_status.is_success() {
+            let body = res.text().await.unwrap_or_default();
+            let msg = format_reclaim_error(http_status, &body);
+            anyhow::bail!("{msg}");
         }
 
         Ok(())
@@ -1747,10 +1898,143 @@ impl ConnectClient {
     }
 }
 
+/// Parse a reclaim approve/deny response, mapping known 422 error codes to
+/// readable messages and returning the updated request on success.
+async fn parse_reclaim_response(res: reqwest::Response, action: &str) -> Result<ReclaimRequest> {
+    let http_status = res.status();
+    if !http_status.is_success() {
+        let body = res.text().await.unwrap_or_default();
+        let msg = format_reclaim_error(http_status, &body);
+        anyhow::bail!("Failed to {action} reclaim request: {msg}");
+    }
+
+    let body: serde_json::Value = res.json().await?;
+    let data = body.get("data").cloned().context("Response missing data")?;
+    let request: ReclaimRequest = serde_json::from_value(data)?;
+    Ok(request)
+}
+
+/// Map known reclaim API error codes to readable messages, falling back to
+/// the raw HTTP status + body for anything we don't recognize.
+fn format_reclaim_error(http_status: reqwest::StatusCode, body: &str) -> String {
+    let parsed: Option<serde_json::Value> = serde_json::from_str(body).ok();
+    let error_code = parsed
+        .as_ref()
+        .and_then(|v| v.get("error"))
+        .and_then(|v| v.as_str());
+
+    match (http_status.as_u16(), error_code) {
+        (422, Some("not_pending")) => {
+            "request is not pending (already approved, denied, completed, or expired)".to_string()
+        }
+        (422, Some("not_denied")) => "only denied reclaim requests can be deleted".to_string(),
+        (422, Some("claim_token_unavailable")) => {
+            "the originating claim token is no longer available".to_string()
+        }
+        (422, Some("expired_token")) => "the originating claim token has expired".to_string(),
+        (422, Some("invalid_token")) => {
+            "the originating claim token is no longer valid".to_string()
+        }
+        (422, Some("invalid_device_id")) => {
+            "--device-id must be a valid UUID".to_string()
+        }
+        (401, _) => "not authenticated (run 'avocado connect auth login')".to_string(),
+        (403, _) => "not authorized for this organization (your CLI token is scoped to a different org — check 'avocado connect auth status' or run 'avocado connect auth login' for the right org)".to_string(),
+        (404, _) => "reclaim request not found".to_string(),
+        _ => format!("HTTP {http_status}: {body}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn format_reclaim_error_maps_known_422_codes() {
+        let cases = [
+            ("not_pending", "request is not pending"),
+            ("not_denied", "only denied reclaim requests can be deleted"),
+            (
+                "claim_token_unavailable",
+                "the originating claim token is no longer available",
+            ),
+            ("expired_token", "the originating claim token has expired"),
+            (
+                "invalid_token",
+                "the originating claim token is no longer valid",
+            ),
+        ];
+        for (code, expected_substring) in cases {
+            let body = format!(r#"{{"error":"{code}","message":"unused"}}"#);
+            let msg = format_reclaim_error(reqwest::StatusCode::UNPROCESSABLE_ENTITY, &body);
+            assert!(
+                msg.contains(expected_substring),
+                "code {code}: expected '{expected_substring}' in '{msg}'"
+            );
+            // Should not include raw HTTP status when we recognize the code.
+            assert!(
+                !msg.contains("HTTP 422"),
+                "should not leak HTTP status for {code}"
+            );
+        }
+    }
+
+    #[test]
+    fn format_reclaim_error_maps_404_to_not_found() {
+        let msg = format_reclaim_error(reqwest::StatusCode::NOT_FOUND, "{}");
+        assert_eq!(msg, "reclaim request not found");
+    }
+
+    #[test]
+    fn format_reclaim_error_maps_422_invalid_device_id() {
+        let body = r#"{"error":"invalid_device_id","message":"device_id must be a valid UUID."}"#;
+        let msg = format_reclaim_error(reqwest::StatusCode::UNPROCESSABLE_ENTITY, body);
+        assert!(msg.contains("--device-id must be a valid UUID"));
+        assert!(!msg.contains("HTTP 422"), "should not leak HTTP status");
+    }
+
+    #[test]
+    fn format_reclaim_error_maps_403_to_org_scope_error() {
+        let body = r#"{"error":"forbidden","message":"Token is not scoped to this organization"}"#;
+        let msg = format_reclaim_error(reqwest::StatusCode::FORBIDDEN, body);
+        assert!(msg.contains("not authorized for this organization"));
+        assert!(msg.contains("scoped to a different org"));
+        assert!(!msg.contains("HTTP 403"), "should not leak HTTP status");
+        assert!(
+            !msg.contains("Token is not scoped"),
+            "should not leak raw API message"
+        );
+    }
+
+    #[test]
+    fn format_reclaim_error_maps_401_to_auth_error() {
+        let msg = format_reclaim_error(reqwest::StatusCode::UNAUTHORIZED, "{}");
+        assert!(msg.contains("not authenticated"));
+        assert!(msg.contains("avocado connect auth login"));
+    }
+
+    #[test]
+    fn format_reclaim_error_falls_back_to_raw_for_unknown_status() {
+        let msg = format_reclaim_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, "boom");
+        assert!(msg.contains("HTTP 500"));
+        assert!(msg.contains("boom"));
+    }
+
+    #[test]
+    fn format_reclaim_error_falls_back_to_raw_for_unknown_422_code() {
+        let body = r#"{"error":"unrecognized_code"}"#;
+        let msg = format_reclaim_error(reqwest::StatusCode::UNPROCESSABLE_ENTITY, body);
+        assert!(msg.contains("HTTP 422"));
+        assert!(msg.contains("unrecognized_code"));
+    }
+
+    #[test]
+    fn format_reclaim_error_handles_non_json_body() {
+        let msg = format_reclaim_error(reqwest::StatusCode::UNPROCESSABLE_ENTITY, "not json");
+        assert!(msg.contains("HTTP 422"));
+        assert!(msg.contains("not json"));
+    }
 
     #[test]
     fn test_trust_status_data_deserializes_all_fields() {

--- a/src/commands/connect/device_reclaim.rs
+++ b/src/commands/connect/device_reclaim.rs
@@ -1,0 +1,370 @@
+use anyhow::Result;
+
+use crate::commands::connect::client::{self, ConnectClient, ReclaimRequest};
+use crate::utils::output::{print_info, print_success, OutputLevel};
+
+fn confirm(prompt: &str) -> Result<bool> {
+    eprint!("{prompt} [y/N]: ");
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    Ok(input.trim().eq_ignore_ascii_case("y"))
+}
+
+/// Normalize a deny-reason string so empty or whitespace-only inputs map
+/// to `None` (i.e. omit the field on the request body) rather than
+/// `Some("")`. Used uniformly for both `--reason "..."` flag values and
+/// the interactive prompt path.
+fn normalize_reason(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn device_label(req: &ReclaimRequest) -> String {
+    match &req.device {
+        Some(d) => match &d.name {
+            Some(name) => format!("{name} ({})", d.identifier),
+            None => d.identifier.clone(),
+        },
+        None => req.device_id.clone(),
+    }
+}
+
+pub struct ConnectDeviceReclaimListCommand {
+    pub org: String,
+    pub status: String,
+    pub device_id: Option<String>,
+    pub profile: Option<String>,
+}
+
+impl ConnectDeviceReclaimListCommand {
+    pub async fn execute(&self) -> Result<()> {
+        // No runtime status validation here — clap's ValueEnum on
+        // ReclaimStatusFilter rejects bad values at parse time. The string
+        // passed in here came from `ReclaimStatusFilter::as_str()`.
+        let config = client::load_config()?
+            .ok_or_else(|| anyhow::anyhow!("Not logged in. Run 'avocado connect auth login'"))?;
+        let (_, profile) = config.resolve_profile(self.profile.as_deref(), Some(&self.org))?;
+        let client = ConnectClient::from_profile(profile)?;
+
+        // Always pass --status through explicitly, including "all". Sending
+        // no status param makes the API fall back to its `pending` default
+        // (chosen for the SPA's "what needs my attention" UX), which would
+        // silently drop completed/denied/expired rows from `--status all`.
+        let requests = client
+            .list_reclaim_requests(
+                &self.org,
+                Some(self.status.as_str()),
+                self.device_id.as_deref(),
+            )
+            .await?;
+
+        if requests.is_empty() {
+            let scope = if self.status == "all" {
+                "any status".to_string()
+            } else {
+                format!("status '{}'", self.status)
+            };
+            let device_clause = match &self.device_id {
+                Some(id) => format!(" for device '{id}'"),
+                None => String::new(),
+            };
+            print_info(
+                &format!(
+                    "No reclaim requests found in org '{}' with {scope}{device_clause}.",
+                    self.org
+                ),
+                OutputLevel::Normal,
+            );
+            return Ok(());
+        }
+
+        let max_id = requests
+            .iter()
+            .map(|r| r.id.len())
+            .max()
+            .unwrap_or(0)
+            .max(2);
+        let max_device = requests
+            .iter()
+            .map(|r| device_label(r).len())
+            .max()
+            .unwrap_or(0)
+            .max(6);
+        let max_status = requests
+            .iter()
+            .map(|r| r.status.len())
+            .max()
+            .unwrap_or(0)
+            .max(6);
+        let max_requested = requests
+            .iter()
+            .map(|r| r.requested_at.as_deref().unwrap_or("-").len())
+            .max()
+            .unwrap_or(0)
+            .max(9);
+        let max_expires = requests
+            .iter()
+            .map(|r| r.expires_at.as_deref().unwrap_or("-").len())
+            .max()
+            .unwrap_or(0)
+            .max(7);
+
+        println!(
+            "{:<id_w$}  {:<dev_w$}  {:<st_w$}  {:<req_w$}  {:<exp_w$}  IP",
+            "ID",
+            "DEVICE",
+            "STATUS",
+            "REQUESTED",
+            "EXPIRES",
+            id_w = max_id,
+            dev_w = max_device,
+            st_w = max_status,
+            req_w = max_requested,
+            exp_w = max_expires,
+        );
+        for req in &requests {
+            println!(
+                "{:<id_w$}  {:<dev_w$}  {:<st_w$}  {:<req_w$}  {:<exp_w$}  {}",
+                req.id,
+                device_label(req),
+                req.status,
+                req.requested_at.as_deref().unwrap_or("-"),
+                req.expires_at.as_deref().unwrap_or("-"),
+                req.request_ip.as_deref().unwrap_or("-"),
+                id_w = max_id,
+                dev_w = max_device,
+                st_w = max_status,
+                req_w = max_requested,
+                exp_w = max_expires,
+            );
+        }
+
+        Ok(())
+    }
+}
+
+pub struct ConnectDeviceReclaimApproveCommand {
+    pub org: String,
+    pub id: String,
+    pub yes: bool,
+    pub profile: Option<String>,
+}
+
+impl ConnectDeviceReclaimApproveCommand {
+    pub async fn execute(&self) -> Result<()> {
+        let config = client::load_config()?
+            .ok_or_else(|| anyhow::anyhow!("Not logged in. Run 'avocado connect auth login'"))?;
+        let (_, profile) = config.resolve_profile(self.profile.as_deref(), Some(&self.org))?;
+        let client = ConnectClient::from_profile(profile)?;
+
+        if !self.yes {
+            let prompt = format!("Approve reclaim request '{}'?", self.id);
+            if !confirm(&prompt)? {
+                println!("Cancelled.");
+                return Ok(());
+            }
+        }
+
+        let request = client.approve_reclaim_request(&self.org, &self.id).await?;
+
+        print_success(
+            &format!(
+                "Reclaim approved for device '{}'. Device will receive new credentials on next /claim attempt.",
+                device_label(&request)
+            ),
+            OutputLevel::Normal,
+        );
+
+        Ok(())
+    }
+}
+
+pub struct ConnectDeviceReclaimDenyCommand {
+    pub org: String,
+    pub id: String,
+    pub reason: Option<String>,
+    pub yes: bool,
+    pub profile: Option<String>,
+}
+
+impl ConnectDeviceReclaimDenyCommand {
+    pub async fn execute(&self) -> Result<()> {
+        let config = client::load_config()?
+            .ok_or_else(|| anyhow::anyhow!("Not logged in. Run 'avocado connect auth login'"))?;
+        let (_, profile) = config.resolve_profile(self.profile.as_deref(), Some(&self.org))?;
+        let client = ConnectClient::from_profile(profile)?;
+
+        // `--reason ""` (or whitespace-only) takes the same "skip" path as
+        // pressing Enter at the interactive prompt — omits the field rather
+        // than sending an empty string. `normalize_reason` enforces that.
+        let reason = match self.reason.as_deref() {
+            Some(r) => normalize_reason(r),
+            None => {
+                eprint!("Reason for denial (optional, press Enter to skip): ");
+                let mut input = String::new();
+                std::io::stdin().read_line(&mut input)?;
+                normalize_reason(&input)
+            }
+        };
+
+        if !self.yes {
+            let prompt = format!("Deny reclaim request '{}'?", self.id);
+            if !confirm(&prompt)? {
+                println!("Cancelled.");
+                return Ok(());
+            }
+        }
+
+        let request = client
+            .deny_reclaim_request(&self.org, &self.id, reason.as_deref())
+            .await?;
+
+        print_success(
+            &format!(
+                "Reclaim denied for device '{}'. Device's existing credentials are revoked.",
+                device_label(&request)
+            ),
+            OutputLevel::Normal,
+        );
+
+        Ok(())
+    }
+}
+
+pub struct ConnectDeviceReclaimDeleteCommand {
+    pub org: String,
+    pub id: String,
+    pub yes: bool,
+    pub profile: Option<String>,
+}
+
+impl ConnectDeviceReclaimDeleteCommand {
+    pub async fn execute(&self) -> Result<()> {
+        if !self.yes {
+            let prompt = format!(
+                "Delete denied reclaim request '{}'? This removes the audit row.",
+                self.id
+            );
+            if !confirm(&prompt)? {
+                println!("Cancelled.");
+                return Ok(());
+            }
+        }
+
+        let config = client::load_config()?
+            .ok_or_else(|| anyhow::anyhow!("Not logged in. Run 'avocado connect auth login'"))?;
+        let (_, profile) = config.resolve_profile(self.profile.as_deref(), Some(&self.org))?;
+        let client = ConnectClient::from_profile(profile)?;
+
+        client.delete_reclaim_request(&self.org, &self.id).await?;
+
+        print_success(
+            &format!("Deleted reclaim request '{}'.", self.id),
+            OutputLevel::Normal,
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_reason_keeps_real_text() {
+        assert_eq!(
+            normalize_reason("decommissioned"),
+            Some("decommissioned".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_reason_trims_surrounding_whitespace() {
+        assert_eq!(
+            normalize_reason("  device retired  "),
+            Some("device retired".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_reason_treats_empty_as_none() {
+        // `--reason ""` should be equivalent to omitting the flag — the
+        // API receives no reason field, not `denied_reason: ""`.
+        assert_eq!(normalize_reason(""), None);
+    }
+
+    #[test]
+    fn normalize_reason_treats_whitespace_only_as_none() {
+        assert_eq!(normalize_reason("   "), None);
+        assert_eq!(normalize_reason("\t\n"), None);
+    }
+
+    #[test]
+    fn device_label_prefers_name_with_identifier() {
+        let req = ReclaimRequest {
+            id: "r-1".to_string(),
+            device_id: "d-1".to_string(),
+            device: Some(client::ReclaimRequestDevice {
+                id: "d-1".to_string(),
+                name: Some("warehouse-1".to_string()),
+                identifier: "fp-abc".to_string(),
+                status: Some("registered".to_string()),
+            }),
+            status: "pending".to_string(),
+            requested_fingerprint: None,
+            requested_at: None,
+            resolved_at: None,
+            expires_at: None,
+            request_ip: None,
+            request_user_agent: None,
+            denied_reason: None,
+        };
+        assert_eq!(device_label(&req), "warehouse-1 (fp-abc)");
+    }
+
+    #[test]
+    fn device_label_falls_back_to_identifier_when_name_missing() {
+        let req = ReclaimRequest {
+            id: "r-1".to_string(),
+            device_id: "d-1".to_string(),
+            device: Some(client::ReclaimRequestDevice {
+                id: "d-1".to_string(),
+                name: None,
+                identifier: "fp-abc".to_string(),
+                status: None,
+            }),
+            status: "pending".to_string(),
+            requested_fingerprint: None,
+            requested_at: None,
+            resolved_at: None,
+            expires_at: None,
+            request_ip: None,
+            request_user_agent: None,
+            denied_reason: None,
+        };
+        assert_eq!(device_label(&req), "fp-abc");
+    }
+
+    #[test]
+    fn device_label_falls_back_to_device_id_when_no_device_embedded() {
+        let req = ReclaimRequest {
+            id: "r-1".to_string(),
+            device_id: "d-1".to_string(),
+            device: None,
+            status: "pending".to_string(),
+            requested_fingerprint: None,
+            requested_at: None,
+            resolved_at: None,
+            expires_at: None,
+            request_ip: None,
+            request_user_agent: None,
+            denied_reason: None,
+        };
+        assert_eq!(device_label(&req), "d-1");
+    }
+}

--- a/src/commands/connect/mod.rs
+++ b/src/commands/connect/mod.rs
@@ -4,6 +4,7 @@ pub mod clean;
 pub mod client;
 pub mod cohorts;
 pub mod deploy;
+pub mod device_reclaim;
 pub mod devices;
 pub mod init;
 pub mod keys;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::collections::HashMap;
+use uuid::Uuid;
 
 mod commands;
 mod utils;
@@ -20,6 +21,10 @@ use commands::connect::cohorts::{
     ConnectCohortsCreateCommand, ConnectCohortsDeleteCommand, ConnectCohortsListCommand,
 };
 use commands::connect::deploy::ConnectDeployCommand;
+use commands::connect::device_reclaim::{
+    ConnectDeviceReclaimApproveCommand, ConnectDeviceReclaimDeleteCommand,
+    ConnectDeviceReclaimDenyCommand, ConnectDeviceReclaimListCommand,
+};
 use commands::connect::devices::{
     ConnectDevicesCreateCommand, ConnectDevicesDeleteCommand, ConnectDevicesListCommand,
 };
@@ -858,6 +863,132 @@ enum ConnectDevicesCommands {
         /// Device ID to delete
         #[arg(long)]
         id: String,
+        /// Skip confirmation prompt
+        #[arg(long, short = 'y')]
+        yes: bool,
+        /// Path to avocado.yaml configuration file
+        #[arg(short = 'C', long, default_value = "avocado.yaml")]
+        config: String,
+        /// Profile name (defaults to the active default profile)
+        #[arg(long)]
+        profile: Option<String>,
+    },
+    /// Manage admin-approved device reclaim requests
+    Reclaim {
+        #[command(subcommand)]
+        command: ConnectDeviceReclaimCommands,
+    },
+}
+
+/// Status filter accepted by the reclaim list / count endpoints.
+///
+/// Variants are validated at clap parse time (clearer help text, fail-fast
+/// on bad input) rather than via a runtime check inside the command. The
+/// `as_str` mapping is the over-the-wire form sent to the server.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+#[clap(rename_all = "lowercase")]
+enum ReclaimStatusFilter {
+    Pending,
+    Approved,
+    Completed,
+    Denied,
+    Expired,
+    All,
+}
+
+impl ReclaimStatusFilter {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Approved => "approved",
+            Self::Completed => "completed",
+            Self::Denied => "denied",
+            Self::Expired => "expired",
+            Self::All => "all",
+        }
+    }
+}
+
+/// Validate `--device-id` as a UUID at clap parse time.
+///
+/// Without this, malformed input would silently flow into URL string
+/// construction (potential query-param injection) and only fail later
+/// at the server's 422. Failing at the CLI boundary gives clearer UX
+/// and removes the URL-injection vector by construction. Returns the
+/// canonical hyphenated form so the URL builder downstream can rely on
+/// a UUID-shaped string.
+fn parse_uuid(s: &str) -> Result<String, String> {
+    Uuid::parse_str(s)
+        .map(|u| u.hyphenated().to_string())
+        .map_err(|e| format!("'{s}' is not a valid UUID: {e}"))
+}
+
+#[derive(Subcommand)]
+enum ConnectDeviceReclaimCommands {
+    /// List reclaim requests (defaults to pending)
+    List {
+        /// Organization ID (or set connect.org in avocado.yaml)
+        #[arg(long)]
+        org: Option<String>,
+        /// Filter by status
+        #[arg(long, value_enum, default_value_t = ReclaimStatusFilter::Pending)]
+        status: ReclaimStatusFilter,
+        /// Filter to a single device by id. Returns at most one row when combined
+        /// with --status pending (the partial unique index allows one pending
+        /// reclaim per device).
+        #[arg(long = "device-id", value_parser = parse_uuid)]
+        device_id: Option<String>,
+        /// Path to avocado.yaml configuration file
+        #[arg(short = 'C', long, default_value = "avocado.yaml")]
+        config: String,
+        /// Profile name (defaults to the active default profile)
+        #[arg(long)]
+        profile: Option<String>,
+    },
+    /// Approve a pending reclaim request
+    Approve {
+        /// Reclaim request ID
+        id: String,
+        /// Organization ID (or set connect.org in avocado.yaml)
+        #[arg(long)]
+        org: Option<String>,
+        /// Skip confirmation prompt
+        #[arg(long, short = 'y')]
+        yes: bool,
+        /// Path to avocado.yaml configuration file
+        #[arg(short = 'C', long, default_value = "avocado.yaml")]
+        config: String,
+        /// Profile name (defaults to the active default profile)
+        #[arg(long)]
+        profile: Option<String>,
+    },
+    /// Deny a pending reclaim request
+    Deny {
+        /// Reclaim request ID
+        id: String,
+        /// Organization ID (or set connect.org in avocado.yaml)
+        #[arg(long)]
+        org: Option<String>,
+        /// Reason for denial (max 1024 chars). If omitted, prompts interactively. Pass --reason "" to skip.
+        #[arg(long)]
+        reason: Option<String>,
+        /// Skip confirmation prompt
+        #[arg(long, short = 'y')]
+        yes: bool,
+        /// Path to avocado.yaml configuration file
+        #[arg(short = 'C', long, default_value = "avocado.yaml")]
+        config: String,
+        /// Profile name (defaults to the active default profile)
+        #[arg(long)]
+        profile: Option<String>,
+    },
+    /// Delete a denied reclaim request (recovery for typo'd denies)
+    Delete {
+        /// Reclaim request ID
+        id: String,
+        /// Organization ID (or set connect.org in avocado.yaml)
+        #[arg(long)]
+        org: Option<String>,
         /// Skip confirmation prompt
         #[arg(long, short = 'y')]
         yes: bool,
@@ -2837,6 +2968,78 @@ async fn main() -> Result<()> {
                     cmd.execute().await?;
                     Ok(())
                 }
+                ConnectDevicesCommands::Reclaim { command } => match command {
+                    ConnectDeviceReclaimCommands::List {
+                        org,
+                        status,
+                        device_id,
+                        config,
+                        profile,
+                    } => {
+                        let resolved_org = commands::connect::resolve_org(org, &config)?;
+                        let cmd = ConnectDeviceReclaimListCommand {
+                            org: resolved_org,
+                            status: status.as_str().to_string(),
+                            device_id,
+                            profile,
+                        };
+                        cmd.execute().await?;
+                        Ok(())
+                    }
+                    ConnectDeviceReclaimCommands::Approve {
+                        id,
+                        org,
+                        yes,
+                        config,
+                        profile,
+                    } => {
+                        let resolved_org = commands::connect::resolve_org(org, &config)?;
+                        let cmd = ConnectDeviceReclaimApproveCommand {
+                            org: resolved_org,
+                            id,
+                            yes,
+                            profile,
+                        };
+                        cmd.execute().await?;
+                        Ok(())
+                    }
+                    ConnectDeviceReclaimCommands::Deny {
+                        id,
+                        org,
+                        reason,
+                        yes,
+                        config,
+                        profile,
+                    } => {
+                        let resolved_org = commands::connect::resolve_org(org, &config)?;
+                        let cmd = ConnectDeviceReclaimDenyCommand {
+                            org: resolved_org,
+                            id,
+                            reason,
+                            yes,
+                            profile,
+                        };
+                        cmd.execute().await?;
+                        Ok(())
+                    }
+                    ConnectDeviceReclaimCommands::Delete {
+                        id,
+                        org,
+                        yes,
+                        config,
+                        profile,
+                    } => {
+                        let resolved_org = commands::connect::resolve_org(org, &config)?;
+                        let cmd = ConnectDeviceReclaimDeleteCommand {
+                            org: resolved_org,
+                            id,
+                            yes,
+                            profile,
+                        };
+                        cmd.execute().await?;
+                        Ok(())
+                    }
+                },
             },
             ConnectCommands::Cohorts { command } => match command {
                 ConnectCohortsCommands::List {


### PR DESCRIPTION
## Summary

Add a `connect devices reclaim {list,approve,deny,delete}` subcommand so operators can run the admin-approved device reclaim workflow from the terminal alongside the existing SPA surface.

This is **opening as a draft** because the workflow depends on the corresponding server-side reclaim flow, which has been implemented but is not yet rolled out. The CLI itself is complete and validated end-to-end against a local cluster — flagging draft so this doesn't get merged ahead of the runtime it depends on.

## Command surface

```
avocado connect devices reclaim list      [--org] [--status pending|approved|completed|denied|expired|all] [--device-id <uuid>]
avocado connect devices reclaim approve <id>   [--org] [-y/--yes]
avocado connect devices reclaim deny    <id>   [--org] [--reason "..."] [-y/--yes]
avocado connect devices reclaim delete  <id>   [--org] [-y/--yes]
```

Common flags inherited from the existing `connect devices` pattern: `--org`, `-C/--config <avocado.yaml>`, `--profile <name>`.

## Design choices

**Workflow-shaped, not API-shaped.** Verbs operators perform day-to-day, not generic CRUD primitives:

- No `show` subcommand. `list` with `--status` filtering is the inspection surface; `list` defaults to `--status pending` (the "what needs my attention" view) and prints **full uuids** in the ID column so operators can copy-paste directly into approve/deny calls without a dedicated show command.
- `approve` and `deny` ship together. They're the two outcomes of a single operator decision ("is this reset legit?"); shipping only `approve` would force `deny` back to the SPA mid-workflow, which is worse than the all-SPA status quo.
- `delete` is the recovery path for a typo'd deny. A workflow that can deny but can't undo is incomplete; the API gates `DELETE` to denied-only rows so this is non-destructive for active records.

## Error mapping

| HTTP / code | Readable message |
|---|---|
| `422 not_pending` | "request is not pending (already approved, denied, completed, or expired)" |
| `422 not_denied` | "only denied reclaim requests can be deleted" |
| `422 claim_token_unavailable` | "the originating claim token is no longer available" |
| `422 expired_token` | "the originating claim token has expired" |
| `422 invalid_token` | "the originating claim token is no longer valid" |
| `401` | "not authenticated (run 'avocado connect auth login')" |
| `403` | "not authorized for this organization (your CLI token is scoped to a different org — check 'avocado connect auth status' or run 'avocado connect auth login' for the right org)" |
| `404` | "reclaim request not found" |
| any other | falls through to `HTTP {status}: {body}` for triage |

## Tests

17 new unit tests:

- `validate_status` accepts all 6 valid values and rejects unknowns with a useful error
- `device_label` renders correctly across all 3 cases (name + identifier, identifier-only, device_id fallback)
- `format_reclaim_error` maps all 5 known 422 codes plus 401, 403, 404
- Fall-through paths: unrecognized 422 codes preserve the raw payload, unknown statuses include both code + body, non-JSON bodies don't panic

Test count: 917 (was 900).

## Validation

- `cargo build` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --lib` — all 917 tests pass
- Manually walked through every command and error path against a local k3d cluster + a QEMU device daemon. Confirmed end-to-end:
  - Approve flow: device picks up new credentials within 30s, MQTT reconnects with same `device_id` (preserved across reclaim, only credentials rotate)
  - Deny flow: device receives terminal `403 reclaim_denied` and idles cleanly without crash-looping
  - Delete flow: removes denied rows, allows fresh pending requests on subsequent device reset
  - Negative paths: each known error code maps to its readable message, no raw HTTP/JSON dumps

