### PR TITLE
release 0.40.1: fix vm update sha mismatch on var artifact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocado-cli"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.40.0"
+version = "0.40.1"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]

--- a/src/utils/vm/manifest.rs
+++ b/src/utils/vm/manifest.rs
@@ -115,8 +115,20 @@ impl Manifest {
     /// Verify every artifact's sha256 against the file on disk.
     /// `artifact_dir` is where the artifacts live (typically same dir as the
     /// manifest); each `artifact.file` is resolved relative to it.
+    ///
+    /// **`SeedOnly` artifacts are intentionally skipped.** Their sha in the
+    /// manifest represents the *initial seed* (what the file looks like at
+    /// release time). After the VM boots, the guest mutates the var image
+    /// (Docker volumes, project state) and the on-disk sha diverges from
+    /// the manifest's seed sha by design. Including them here would fail
+    /// every boot after the first write, and — worse — every `vm update`
+    /// would fail when the new release ships a new seed sha but we kept
+    /// the user's mutated var (the whole point of `SeedOnly`).
     pub fn verify_all(&self, artifact_dir: &Path) -> Result<()> {
         for (role, art) in &self.artifacts {
+            if art.update_policy == UpdatePolicy::SeedOnly {
+                continue;
+            }
             let path = artifact_dir.join(&art.file);
             let computed = sha256_file(&path)
                 .with_context(|| format!("hashing {} for role '{role}'", path.display()))?;
@@ -235,6 +247,41 @@ mod tests {
         let m = Manifest::load(&mp).unwrap();
         let err = m.verify_all(tmp.path()).unwrap_err();
         assert!(format!("{err:#}").contains("sha256 mismatch"));
+    }
+
+    #[test]
+    fn verify_all_skips_seed_only_artifacts() {
+        // var is SeedOnly — after the VM writes to it, the on-disk sha
+        // legitimately diverges from the manifest's seed sha. verify_all
+        // must NOT bail on that mismatch (otherwise every boot after the
+        // first write would fail, and `vm update` to a release with a new
+        // seed sha would fail with sha256 mismatch even though we
+        // intentionally preserved the user's mutated var).
+        let tmp = tempfile::tempdir().unwrap();
+        let var_path = tmp.path().join("var.btrfs");
+        std::fs::write(&var_path, b"user data written after seed").unwrap();
+
+        let raw = r#"{
+            "format": "avocado-direct",
+            "format_version": 1,
+            "platform": "p",
+            "architecture": "arm64",
+            "artifacts": {
+                "var": {
+                    "file": "var.btrfs",
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "type": "btrfs",
+                    "update_policy": "seed_only"
+                }
+            },
+            "cmdline_default": ""
+        }"#;
+        let mp = tmp.path().join("manifest.json");
+        std::fs::write(&mp, raw).unwrap();
+        let m = Manifest::load(&mp).unwrap();
+        // Despite the on-disk file's sha NOT matching the manifest, this
+        // should succeed because var is SeedOnly.
+        m.verify_all(tmp.path()).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Hotfix: `avocado vm update` was leaving installs in an unbootable state because the post-install sha verification refused to honor `update_policy: seed_only`.

Repro (without this fix):

1. Fresh install of avocado-vm 0.2.1 → boot once → guest writes to `var`.
2. `avocado vm update --yes` to 0.3.0 → downloads/swaps kernel/initramfs/rootfs (verified clean), preserves the user's 0.2.1 `var` (correct, `SeedOnly`).
3. Next `vm start` calls `manifest.verify_all()` against the 0.3.0 manifest, hashes the on-disk 0.2.1-derived var, mismatches 0.3.0's seed sha, refuses to boot:

   ```
   sha256 mismatch for role 'var' (avocado-image-var-qemuarm64.btrfs):
     manifest=5ac627..., computed=c8de92...
   ```

The seed sha in a release manifest is what var looks like *at release time*. Once the guest writes to it (Docker volumes, project state) the sha legitimately diverges by design. Checking it post-mutation is incoherent — including against the same release's own seed sha after first boot, not just across updates.

## Change

[src/utils/vm/manifest.rs:127-140](src/utils/vm/manifest.rs#L127-L140) — `verify_all` now skips artifacts whose `update_policy == SeedOnly`. `Replace`-policy artifacts (kernel, initramfs, rootfs) still get verified, so corruption / partial-download of those is still caught.

New test `verify_all_skips_seed_only_artifacts` constructs a manifest with a deliberately wrong sha on a SeedOnly var and asserts verify succeeds.

Version bumped to **0.40.1** (Cargo.toml + Cargo.lock).

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — 2,214 passing, 0 failed (including new `verify_all_skips_seed_only_artifacts`)
- [x] `cargo audit` — exit 0, no advisories
- [x] Manual end-to-end on macOS aarch64: installed 0.2.1, booted, updated to 0.3.0, confirmed clean boot with the patched binary (`avocado-vm` shows version 0.3.0 with the preserved 0.2.1-mutated var)