### PR TITLE
release 0.40.2: suppress upgrade banner in JSON mode + unlock pinned kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocado-cli"
-version = "0.40.1"
+version = "0.40.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.40.1"
+version = "0.40.2"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -445,6 +445,66 @@ sdk:
     }
 
     #[tokio::test]
+    async fn test_clean_unlock_clears_pinned_kernel_versions() {
+        // Regression: `clean --unlock` must also drop pinned
+        // `kernel_versions` and the per-kernel sysroot table.
+        // Without this, the next install picked the latest packages
+        // (good) but still demanded the old pinned KERNEL_VERSION
+        // by name (`kernel-image-6.6.123-yocto-standard`), and dnf
+        // failed with "No match for argument: …" once the feed had
+        // moved past that exact version.
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        let config_content = r#"
+default_target: "qemux86-64"
+sdk:
+  image: "test-image"
+"#;
+        let config_path = temp_path.join("avocado.yaml");
+        fs::write(&config_path, config_content).unwrap();
+
+        // Seed both a kernel_versions pin and a kernels sysroot
+        // package entry. Both must be cleared.
+        let mut lock = LockFile::new();
+        {
+            let tl = lock.targets.entry("qemux86-64".to_string()).or_default();
+            tl.kernel_versions
+                .insert("rootfs".to_string(), "6.6.123-yocto-standard".to_string());
+            let mut pkgs = std::collections::HashMap::new();
+            pkgs.insert("kernel-image".to_string(), "6.6.123-r0.0".to_string());
+            tl.kernels
+                .insert("6.6.123-yocto-standard".to_string(), pkgs);
+        }
+        lock.save(temp_path).unwrap();
+
+        let clean_cmd = CleanCommand::new(
+            Some(temp_path.to_str().unwrap().to_string()),
+            false,
+            None,
+            false,
+        )
+        .with_config_path(Some(config_path.to_string_lossy().to_string()))
+        .with_target(Some("qemux86-64".to_string()))
+        .with_unlock(true);
+        let result = clean_cmd.execute().await;
+        assert!(result.is_ok(), "clean --unlock failed: {result:?}");
+
+        let reloaded = LockFile::load(temp_path).unwrap();
+        let tl = reloaded.targets.get("qemux86-64").expect("target survives");
+        assert!(
+            tl.kernel_versions.is_empty(),
+            "kernel_versions should be cleared by --unlock, got: {:?}",
+            tl.kernel_versions
+        );
+        assert!(
+            tl.kernels.is_empty(),
+            "kernels sysroot table should be cleared by --unlock, got: {:?}",
+            tl.kernels
+        );
+    }
+
+    #[tokio::test]
     async fn test_clean_skip_volumes_keeps_state_file() {
         // `--skip-volumes` means "leave both the volume and its
         // state-file pointer alone" — stamps-/unlock-only invocations

--- a/src/main.rs
+++ b/src/main.rs
@@ -3783,18 +3783,33 @@ async fn main() -> Result<()> {
         if let Ok(Ok(Some(version))) =
             tokio::time::timeout(std::time::Duration::from_secs(5), handle).await
         {
-            let upgrade_hint = match utils::install_method::current_install_method() {
-                utils::install_method::InstallMethod::Homebrew => {
-                    "Run 'avocado upgrade' or 'brew upgrade avocado-cli' to update."
-                }
-                _ => "Run 'avocado upgrade' to update.",
-            };
-            eprintln!(
-                "\n\x1b[93m[UPDATE]\x1b[0m avocado {} is available (you have {}).\n         {}",
-                version,
-                env!("CARGO_PKG_VERSION"),
-                upgrade_hint
-            );
+            // Suppress the banner when the user asked for JSON / NDJSON
+            // output. The banner goes to stderr, but callers that
+            // capture both streams (e.g. the avocado-desktop CLI runner
+            // merges stdout + stderr in causal order) ended up feeding
+            // the banner into a JSON parser, which then refused the
+            // entire payload. Silent-when-machine-readable is the
+            // safer contract.
+            let json_mode = std::env::args().any(|a| a == "--output")
+                && std::env::args()
+                    .skip_while(|a| a != "--output")
+                    .nth(1)
+                    .as_deref()
+                    == Some("json");
+            if !json_mode {
+                let upgrade_hint = match utils::install_method::current_install_method() {
+                    utils::install_method::InstallMethod::Homebrew => {
+                        "Run 'avocado upgrade' or 'brew upgrade avocado-cli' to update."
+                    }
+                    _ => "Run 'avocado upgrade' to update.",
+                };
+                eprintln!(
+                    "\n\x1b[93m[UPDATE]\x1b[0m avocado {} is available (you have {}).\n         {}",
+                    version,
+                    env!("CARGO_PKG_VERSION"),
+                    upgrade_hint
+                );
+            }
         }
     }
 

--- a/src/utils/lockfile.rs
+++ b/src/utils/lockfile.rs
@@ -1394,7 +1394,19 @@ impl LockFile {
         }
     }
 
-    /// Clear all entries for a target (SDK, rootfs, initramfs, target-sysroot, extensions, runtimes)
+    /// Clear all entries for a target. Drops package locks across every
+    /// sysroot AND releases the pinned `KERNEL_VERSION` map + the
+    /// per-kernel sysroot table.
+    ///
+    /// Leaving `kernel_versions` / `kernels` populated after an unlock
+    /// caused the desktop's Unlock + reinstall flow to fail with
+    /// `No match for argument: kernel-image-<old-pinned-version>`:
+    /// the package locks were cleared so dnf re-resolved sysroot
+    /// content from the latest feed, but the pinned KERNEL_VERSION
+    /// was still demanded by name. When the feed had since dropped
+    /// the exact pinned version (rolling distro), dnf bailed.
+    /// Unlock semantically means "let me re-pick latest"; the kernel
+    /// pins must come along for the ride.
     pub fn clear_all(&mut self, target: &str) {
         if let Some(target_locks) = self.targets.get_mut(target) {
             target_locks.sdk.clear();
@@ -1403,6 +1415,8 @@ impl LockFile {
             target_locks.target_sysroot.clear();
             target_locks.extensions.clear();
             target_locks.runtimes.clear();
+            target_locks.kernel_versions.clear();
+            target_locks.kernels.clear();
         }
     }
 


### PR DESCRIPTION
## Summary

Two CLI bugs that surfaced through the avocado-desktop integration this week. Bundling both as a 0.40.2 hotfix on the 0.40.1 line.

### 1. Update banner pollutes structured output

`avocado` prints a yellow `[UPDATE] avocado X is available …` banner to **stderr** when a newer release lands. The avocado-desktop CLI runner merges stdout + stderr in causal order for parsing (matches the legacy Swift behavior), so any caller running `--output json` ended up feeding the banner into a JSON decoder. Decoder rejected the entire payload.

Net effect: the moment 0.40.1 shipped to CDN, **every 0.40.0 desktop user's project listing went blank** until they upgraded. The desktop now defensively extracts the first balanced JSON object from captured output (separate fix), but the CLI side should also stop emitting noise in JSON mode in the first place.

[src/main.rs:3782-3810](src/main.rs#L3782) — scan `std::env::args()` for `--output json` and suppress the banner. Native human runs still get the nudge.

### 2. `clean --unlock` left pinned kernel versions intact

`LockFile::clear_all()` zeroed sdk/rootfs/initramfs/target-sysroot/extensions/runtimes but **not** `kernel_versions` (pinned KERNEL_VERSION per sysroot) or `kernels` (per-kernel-sysroot package table). After unlocking and reinstalling, dnf re-resolved sysroot content from the latest feed — correct — but the CLI still demanded the **old pinned kernel by exact name**:

```
No match for argument: kernel-image-6.6.123-yocto-standard
Error: Unable to find a match: kernel-image-6.6.123-yocto-standard
```

…once the rolling feed had moved past that exact version. The desktop's Unlock + Install button hit this whenever the feed had rolled forward since the last install.

Unlock semantically means "let me re-pick latest" — the kernel pins need to come along. [src/utils/lockfile.rs:1395-1421](src/utils/lockfile.rs#L1395) — clear both slots. New test `test_clean_unlock_clears_pinned_kernel_versions` seeds both, runs unlock, asserts both are empty after reload.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — 2,222 passed, 0 failed (new test included)
- [x] `cargo audit` — exit 0, no advisories
- [x] Manual: built `cargo build`, ran `avocado config show --output json` against a project — banner absent on stdout AND stderr when in JSON mode, present in non-JSON mode
- [x] Manual: hand-seeded lockfile with `kernel_versions["rootfs"]="6.6.123-yocto-standard"` and ran `avocado clean --unlock` — both slots empty after