### PR TITLE
feat(connect): fall back to profile organization_id when --org omitted

### DIFF
--- a/src/commands/connect/mod.rs
+++ b/src/commands/connect/mod.rs
@@ -16,28 +16,41 @@ pub mod upload;
 
 use anyhow::Result;
 
-/// Resolve organization from CLI flag or avocado.yaml connect config.
-pub fn resolve_org(flag: Option<String>, config_path: &str) -> Result<String> {
-    let connect_config = std::path::Path::new(config_path)
-        .exists()
-        .then(|| crate::utils::config::load_config(config_path).ok())
-        .flatten()
-        .and_then(|c| c.connect);
-
-    flag.or_else(|| connect_config.as_ref().and_then(|c| c.org.clone()))
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "--org is required (or set connect.org in {config_path})\n\
-                 Tip: Run 'avocado connect auth status' to see your organizations"
-            )
-        })
+/// Resolve the active profile's `organization_id` from `credentials.json`.
+///
+/// Errors if `--profile <name>` is given but `<name>` does not exist. Returns
+/// `Ok(None)` when no config file exists, or when the resolved profile has no
+/// `organization_id` set (e.g. a legacy profile or an unscoped token).
+pub fn profile_organization_id(profile: Option<&str>) -> Result<Option<String>> {
+    let Some(cfg) = client::load_config()? else {
+        return Ok(None);
+    };
+    let (_, profile) = cfg.resolve_profile(profile, None)?;
+    Ok(profile.organization_id.clone())
 }
 
-/// Resolve both organization and project from CLI flags or avocado.yaml connect config.
+/// Resolve organization from CLI flag, `connect.org` in `avocado.yaml`, or the
+/// active profile's `organization_id`. Precedence: flag > yaml > profile.
+pub fn resolve_org(
+    flag: Option<String>,
+    config_path: &str,
+    profile_org: Option<String>,
+) -> Result<String> {
+    let yaml_org = load_yaml_org(config_path);
+
+    flag.or(yaml_org)
+        .or(profile_org)
+        .ok_or_else(|| anyhow::anyhow!(no_org_error(config_path)))
+}
+
+/// Resolve both organization and project. Org follows the same precedence as
+/// `resolve_org`. Project only falls back to `connect.project` in `avocado.yaml`
+/// (no profile fallback — profiles are tied to orgs, not projects).
 pub fn resolve_org_and_project(
     org: Option<String>,
     project: Option<String>,
     config_path: &str,
+    profile_org: Option<String>,
 ) -> Result<(String, String)> {
     let connect_config = std::path::Path::new(config_path)
         .exists()
@@ -45,23 +58,142 @@ pub fn resolve_org_and_project(
         .flatten()
         .and_then(|c| c.connect);
 
-    let resolved_org = org
-        .or_else(|| connect_config.as_ref().and_then(|c| c.org.clone()))
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "--org is required (or set connect.org in {config_path})\n\
-                 Tip: Run 'avocado connect auth status' to see your organizations"
-            )
-        })?;
+    let yaml_org = connect_config.as_ref().and_then(|c| c.org.clone());
+    let yaml_project = connect_config.as_ref().and_then(|c| c.project.clone());
 
-    let resolved_project = project
-        .or_else(|| connect_config.as_ref().and_then(|c| c.project.clone()))
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "--project is required (or set connect.project in {config_path})\n\
-                 Tip: Run 'avocado connect projects list --org {resolved_org}' to see projects"
-            )
-        })?;
+    let resolved_org = org
+        .or(yaml_org)
+        .or(profile_org)
+        .ok_or_else(|| anyhow::anyhow!(no_org_error(config_path)))?;
+
+    let resolved_project = project.or(yaml_project).ok_or_else(|| {
+        anyhow::anyhow!(
+            "--project is required (or set connect.project in {config_path})\n\
+             Tip: Run 'avocado connect projects list --org {resolved_org}' to see projects"
+        )
+    })?;
 
     Ok((resolved_org, resolved_project))
+}
+
+fn load_yaml_org(config_path: &str) -> Option<String> {
+    std::path::Path::new(config_path)
+        .exists()
+        .then(|| crate::utils::config::load_config(config_path).ok())
+        .flatten()
+        .and_then(|c| c.connect)
+        .and_then(|c| c.org)
+}
+
+fn no_org_error(config_path: &str) -> String {
+    format!(
+        "no organization selected. Pass --org <id>, set connect.org in {config_path}, \
+         or pass --profile <name> to use that profile's organization.\n\
+         Tip: Run 'avocado connect auth status' to see your profiles and their organizations"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_yaml_with_connect_org(dir: &TempDir, org: &str) -> String {
+        let path = dir.path().join("avocado.yaml");
+        fs::write(
+            &path,
+            format!("connect:\n  org: {org}\n  project: project-from-yaml\n"),
+        )
+        .unwrap();
+        path.to_string_lossy().into_owned()
+    }
+
+    fn nonexistent_config_path(dir: &TempDir) -> String {
+        dir.path()
+            .join("does-not-exist.yaml")
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn flag_wins_over_yaml_and_profile() {
+        let dir = TempDir::new().unwrap();
+        let config = write_yaml_with_connect_org(&dir, "yaml-org");
+        let got =
+            resolve_org(Some("flag-org".into()), &config, Some("profile-org".into())).unwrap();
+        assert_eq!(got, "flag-org");
+    }
+
+    #[test]
+    fn yaml_wins_over_profile_when_flag_absent() {
+        let dir = TempDir::new().unwrap();
+        let config = write_yaml_with_connect_org(&dir, "yaml-org");
+        let got = resolve_org(None, &config, Some("profile-org".into())).unwrap();
+        assert_eq!(got, "yaml-org");
+    }
+
+    #[test]
+    fn profile_fills_in_when_flag_and_yaml_absent() {
+        let dir = TempDir::new().unwrap();
+        let config = nonexistent_config_path(&dir);
+        let got = resolve_org(None, &config, Some("profile-org".into())).unwrap();
+        assert_eq!(got, "profile-org");
+    }
+
+    #[test]
+    fn errors_when_all_three_absent() {
+        let dir = TempDir::new().unwrap();
+        let config = nonexistent_config_path(&dir);
+        let err = resolve_org(None, &config, None).unwrap_err().to_string();
+        assert!(err.contains("--org"));
+        assert!(err.contains("connect.org"));
+        assert!(err.contains("profile"));
+    }
+
+    #[test]
+    fn yaml_present_but_org_unset_falls_through_to_profile() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("avocado.yaml");
+        // Valid YAML with no connect section at all.
+        fs::write(&path, "ext:\n  foo: bar\n").unwrap();
+        let config = path.to_string_lossy().into_owned();
+        let got = resolve_org(None, &config, Some("profile-org".into())).unwrap();
+        assert_eq!(got, "profile-org");
+    }
+
+    #[test]
+    fn resolve_org_and_project_uses_profile_org_when_yaml_missing_org() {
+        let dir = TempDir::new().unwrap();
+        let config = nonexistent_config_path(&dir);
+        let (org, project) = resolve_org_and_project(
+            None,
+            Some("project-flag".into()),
+            &config,
+            Some("profile-org".into()),
+        )
+        .unwrap();
+        assert_eq!(org, "profile-org");
+        assert_eq!(project, "project-flag");
+    }
+
+    #[test]
+    fn resolve_org_and_project_project_flag_wins_over_yaml() {
+        let dir = TempDir::new().unwrap();
+        let config = write_yaml_with_connect_org(&dir, "yaml-org");
+        let (org, project) =
+            resolve_org_and_project(None, Some("project-flag".into()), &config, None).unwrap();
+        assert_eq!(org, "yaml-org");
+        assert_eq!(project, "project-flag");
+    }
+
+    #[test]
+    fn resolve_org_and_project_errors_with_no_project() {
+        let dir = TempDir::new().unwrap();
+        let config = nonexistent_config_path(&dir);
+        let err = resolve_org_and_project(None, None, &config, Some("profile-org".into()))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--project"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3296,7 +3296,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
                     let cmd = ConnectProjectsListCommand {
                         org: resolved_org,
                         profile,
@@ -3312,7 +3314,9 @@ async fn main() -> Result<()> {
                     profile,
                     output,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
                     let cmd = ConnectProjectsCreateCommand {
                         org: resolved_org,
                         name,
@@ -3330,7 +3334,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
                     let cmd = ConnectProjectsDeleteCommand {
                         org: resolved_org,
                         id,
@@ -3347,7 +3353,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
                     let cmd = ConnectDevicesListCommand {
                         org: resolved_org,
                         profile,
@@ -3362,7 +3370,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
                     let cmd = ConnectDevicesCreateCommand {
                         org: resolved_org,
                         name,
@@ -3379,7 +3389,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
                     let cmd = ConnectDevicesDeleteCommand {
                         org: resolved_org,
                         id,
@@ -3397,7 +3409,10 @@ async fn main() -> Result<()> {
                         config,
                         profile,
                     } => {
-                        let resolved_org = commands::connect::resolve_org(org, &config)?;
+                        let profile_org =
+                            commands::connect::profile_organization_id(profile.as_deref())?;
+                        let resolved_org =
+                            commands::connect::resolve_org(org, &config, profile_org)?;
                         let cmd = ConnectDeviceReclaimListCommand {
                             org: resolved_org,
                             status: status.as_str().to_string(),
@@ -3414,7 +3429,10 @@ async fn main() -> Result<()> {
                         config,
                         profile,
                     } => {
-                        let resolved_org = commands::connect::resolve_org(org, &config)?;
+                        let profile_org =
+                            commands::connect::profile_organization_id(profile.as_deref())?;
+                        let resolved_org =
+                            commands::connect::resolve_org(org, &config, profile_org)?;
                         let cmd = ConnectDeviceReclaimApproveCommand {
                             org: resolved_org,
                             id,
@@ -3432,7 +3450,10 @@ async fn main() -> Result<()> {
                         config,
                         profile,
                     } => {
-                        let resolved_org = commands::connect::resolve_org(org, &config)?;
+                        let profile_org =
+                            commands::connect::profile_organization_id(profile.as_deref())?;
+                        let resolved_org =
+                            commands::connect::resolve_org(org, &config, profile_org)?;
                         let cmd = ConnectDeviceReclaimDenyCommand {
                             org: resolved_org,
                             id,
@@ -3450,7 +3471,10 @@ async fn main() -> Result<()> {
                         config,
                         profile,
                     } => {
-                        let resolved_org = commands::connect::resolve_org(org, &config)?;
+                        let profile_org =
+                            commands::connect::profile_organization_id(profile.as_deref())?;
+                        let resolved_org =
+                            commands::connect::resolve_org(org, &config, profile_org)?;
                         let cmd = ConnectDeviceReclaimDeleteCommand {
                             org: resolved_org,
                             id,
@@ -3469,8 +3493,15 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
                     let (resolved_org, resolved_project) =
-                        commands::connect::resolve_org_and_project(org, project, &config)?;
+                        commands::connect::resolve_org_and_project(
+                            org,
+                            project,
+                            &config,
+                            profile_org,
+                        )?;
                     let cmd = ConnectCohortsListCommand {
                         org: resolved_org,
                         project: resolved_project,
@@ -3487,8 +3518,15 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
                     let (resolved_org, resolved_project) =
-                        commands::connect::resolve_org_and_project(org, project, &config)?;
+                        commands::connect::resolve_org_and_project(
+                            org,
+                            project,
+                            &config,
+                            profile_org,
+                        )?;
                     let cmd = ConnectCohortsCreateCommand {
                         org: resolved_org,
                         project: resolved_project,
@@ -3507,8 +3545,15 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
                     let (resolved_org, resolved_project) =
-                        commands::connect::resolve_org_and_project(org, project, &config)?;
+                        commands::connect::resolve_org_and_project(
+                            org,
+                            project,
+                            &config,
+                            profile_org,
+                        )?;
                     let cmd = ConnectCohortsDeleteCommand {
                         org: resolved_org,
                         project: resolved_project,
@@ -3526,7 +3571,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
                     let cmd = ConnectClaimTokensListCommand {
                         org: resolved_org,
                         profile,
@@ -3545,7 +3592,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
                     let cmd = ConnectClaimTokensCreateCommand {
                         org: resolved_org,
                         project,
@@ -3566,7 +3615,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
                     let cmd = ConnectClaimTokensDeleteCommand {
                         org: resolved_org,
                         id,
@@ -3593,10 +3644,12 @@ async fn main() -> Result<()> {
                 deploy_tag,
                 deploy_activate,
             } => {
+                let profile_org = commands::connect::profile_organization_id(profile.as_deref())?;
                 let (resolved_org, resolved_project) = commands::connect::resolve_org_and_project(
                     org.clone(),
                     project.clone(),
                     &config,
+                    profile_org,
                 )?;
 
                 let cmd = ConnectUploadCommand {
@@ -3630,8 +3683,9 @@ async fn main() -> Result<()> {
                 config,
                 profile,
             } => {
+                let profile_org = commands::connect::profile_organization_id(profile.as_deref())?;
                 let (resolved_org, resolved_project) =
-                    commands::connect::resolve_org_and_project(org, project, &config)?;
+                    commands::connect::resolve_org_and_project(org, project, &config, profile_org)?;
                 let cmd = ConnectDeployCommand {
                     org: resolved_org,
                     project: resolved_project,
@@ -3651,7 +3705,8 @@ async fn main() -> Result<()> {
                 config,
                 profile,
             } => {
-                let resolved_org = commands::connect::resolve_org(org, &config)?;
+                let profile_org = commands::connect::profile_organization_id(profile.as_deref())?;
+                let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
 
                 let cmd = ConnectServerKeyCommand {
                     org: resolved_org,
@@ -3668,7 +3723,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
 
                     let cmd = ConnectKeysRegisterCommand {
                         org: resolved_org,
@@ -3685,7 +3742,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
 
                     let cmd = ConnectKeysApproveCommand {
                         org: resolved_org,
@@ -3701,7 +3760,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
 
                     let cmd = ConnectKeysListCommand {
                         org: resolved_org,
@@ -3717,7 +3778,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
 
                     let cmd = ConnectKeysRetireCommand {
                         org: resolved_org,
@@ -3734,7 +3797,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
 
                     let cmd = ConnectTrustStatusCommand {
                         org: resolved_org,
@@ -3749,7 +3814,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
 
                     let cmd = ConnectTrustPromoteRootCommand {
                         key,
@@ -3765,7 +3832,9 @@ async fn main() -> Result<()> {
                     config,
                     profile,
                 } => {
-                    let resolved_org = commands::connect::resolve_org(org, &config)?;
+                    let profile_org =
+                        commands::connect::profile_organization_id(profile.as_deref())?;
+                    let resolved_org = commands::connect::resolve_org(org, &config, profile_org)?;
 
                     let cmd = ConnectTrustRotateServerKeyCommand {
                         key,


### PR DESCRIPTION
## Summary

Org-scoped `avocado connect ...` subcommands now consult the active profile's `organization_id` in `credentials.json` before erroring out. Resolution order:

1. `--org <id>` flag
2. `connect.org` in `avocado.yaml`
3. Active profile's `organization_id` (new fallback)
4. Error

Profile tokens are physically scoped to one org, so the profile's `organization_id` is the only valid value anyway — repeating it on every command was friction without choice.

The `Profile.organization_id` field already exists today and is populated by `auth login` for both the single-org auto-scoping path and the multi-org explicit `--org` path.

## What changed

- `src/commands/connect/mod.rs` — added `profile_organization_id` helper; `resolve_org` and `resolve_org_and_project` now accept a third `profile_org: Option<String>` parameter; refined "no org selected" error to name all three sources; 8 unit tests covering the precedence matrix
- `src/main.rs` — threaded `profile_org` through all 26 org-scoped call sites (21 via `resolve_org` + 5 via `resolve_org_and_project`)

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --lib` (1006 passed, 0 failed)
- [x] From `/tmp` with no `avocado.yaml`:
  - `avocado connect projects list` → refined error naming flag + yaml + profile
  - `avocado connect projects list --profile <org-scoped>` → succeeds
  - `avocado connect projects list --profile bogus` → "Profile 'bogus' not found"
