### PR TITLE
release: 0.41.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocado-cli"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.41.0"
+version = "0.41.1"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]


### PR DESCRIPTION
## Release 0.41.1

Bumps `avocado-cli` from **0.41.0 → 0.41.1** (`Cargo.toml` + `Cargo.lock`).

### Changes since 0.41.0

**Fixes**
- **Resolve rootfs/initramfs/kernel `source.path` relative to `src_dir`** (34bb5ea). Path sources for `rootfs`/`initramfs`/`kernel` now resolve against `src_dir` (falling back to the config file's directory) — the same base used for extension `source: { type: path }` sources. Previously they resolved against the config dir, breaking configs that live in a subdirectory whose `src_dir` points at a parent (e.g. one runtime per directory, `runtimes/<board>/avocado.yaml` with `src_dir: ../..`). Applied consistently across `ext build`, `ext image`, and `runtime provision` (lockfile resolution).
- **Allow building/imaging non-member extensions standalone** (233e35a). `ext build` and `ext image` no longer hard-error when an extension isn't listed in `runtimes.<r>.extensions`; they warn and proceed. This makes it possible to build a shared extension to verify it compiles (e.g. for a PR) without wiring it into a runtime — shared-extension configs have no `runtimes:` block at all (the CLI synthesizes an empty implicit `default`). Mirrors `ext install`, which already tolerates non-member extensions. The rootfs-sysroot precondition remains the real guardrail.

**Dependencies / Security**
- **Bump `quinn-proto` 0.11.14 → 0.11.15** (c2ebe71), resolving `RUSTSEC-2026-0185` (remote memory exhaustion from unbounded out-of-order stream reassembly). Transitive via `reqwest` HTTP/3; lockfile-only.

### Verification
- `cargo fmt --all -- --check` ✅
- `cargo build` ✅ (lockfile bumped to 0.41.1)
- Full CI (tests, clippy, security audit, Windows check) runs on this PR.