### PR TITLE
Package + publish avocado-ext-cli extension

### DIFF
--- a/.github/workflows/ext-release.yml
+++ b/.github/workflows/ext-release.yml
@@ -18,6 +18,11 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-*'
   workflow_dispatch:
 
+# Least privilege: checkout + package + publish-via-PAT only (no GitHub writes).
+# The reusable workflow inherits this cap; the PAT publish path needs nothing more.
+permissions:
+  contents: read
+
 jobs:
   version:
     name: Resolve version from Cargo.toml

--- a/.github/workflows/ext-release.yml
+++ b/.github/workflows/ext-release.yml
@@ -1,0 +1,56 @@
+name: Extension Release
+
+# Package + publish the avocado-ext-cli extension on a version tag. Runs alongside
+# release.yml (which builds the standalone binaries + Homebrew tap) on the SAME tag, so a
+# single CLI release tag both ships the binaries and publishes the extension.
+#
+# The extension version TRACKS THE PACKAGED PROGRAM: it is read from Cargo.toml ([package]
+# version) and passed to the reusable helper as `ext-version`, which exports it as
+# AVOCADO_EXT_VERSION so the `version: '{{ env.AVOCADO_EXT_VERSION }}'` template in
+# avocado.yaml resolves at package time. The pushed tag must equal the Cargo.toml version
+# (the helper guards it).
+#
+# Release flow: bump Cargo.toml version -> tag the same value -> push tag.
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+
+jobs:
+  version:
+    name: Resolve version from Cargo.toml
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.cargo.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Read Cargo.toml [package] version
+        id: cargo
+        run: |
+          v="$(python3 -c "import tomllib; print(tomllib.load(open('Cargo.toml','rb'))['package']['version'])")"
+          if [ -z "$v" ]; then
+            echo "::error::could not read [package] version from Cargo.toml" >&2
+            exit 1
+          fi
+          echo "Program version (Cargo.toml): $v"
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { target: qemux86-64, distro-release: "2026", distro-channel: edge }
+          - { target: qemux86-64, distro-release: "2024", distro-channel: edge-next }
+    uses: avocado-linux/actions/.github/workflows/extension-release.yml@v1
+    with:
+      target:         ${{ matrix.target }}
+      distro-release: ${{ matrix.distro-release }}
+      distro-channel: ${{ matrix.distro-channel }}
+      ext-version:    ${{ needs.version.outputs.version }}
+    secrets:
+      connect-token: ${{ secrets.AVOCADO_CONNECT_TOKEN }}
+      connect-org:   ${{ secrets.AVOCADO_CONNECT_ORG }}

--- a/.github/workflows/ext-test.yml
+++ b/.github/workflows/ext-test.yml
@@ -43,5 +43,4 @@ jobs:
       target:         ${{ matrix.target }}
       distro-release: ${{ matrix.distro-release }}
       distro-channel: ${{ matrix.distro-channel }}
-      repo-url:       ${{ matrix.repo-url }}
       ext-version:    ${{ needs.version.outputs.version }}

--- a/.github/workflows/ext-test.yml
+++ b/.github/workflows/ext-test.yml
@@ -12,6 +12,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Least privilege: these jobs only check out and build (no GitHub writes). The
+# reusable workflow inherits this cap.
+permissions:
+  contents: read
+
 jobs:
   version:
     name: Resolve version from Cargo.toml

--- a/.github/workflows/ext-test.yml
+++ b/.github/workflows/ext-test.yml
@@ -1,0 +1,47 @@
+name: Extension Test
+
+# "Does it build" check on PRs for the avocado-ext-cli extension (this repo's Rust source
+# is compiled in place by `avocado ext build`). The matrix lives here (the caller owns it);
+# each leg calls the single-combo reusable helper. This is separate from pr.yml, which runs
+# the CLI's own unit tests + security audit, and from release.yml, which builds the
+# standalone binaries.
+#
+# `ext build` validates the extension version, and this extension's version tracks the
+# packaged program (Cargo.toml), so we resolve it here and pass it through as `ext-version`.
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  version:
+    name: Resolve version from Cargo.toml
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.cargo.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Read Cargo.toml [package] version
+        id: cargo
+        run: |
+          v="$(python3 -c "import tomllib; print(tomllib.load(open('Cargo.toml','rb'))['package']['version'])")"
+          if [ -z "$v" ]; then
+            echo "::error::could not read [package] version from Cargo.toml" >&2
+            exit 1
+          fi
+          echo "Program version (Cargo.toml): $v"
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { target: qemux86-64, distro-release: "2024", distro-channel: edge-next }
+    uses: avocado-linux/actions/.github/workflows/extension-test.yml@v1
+    with:
+      target:         ${{ matrix.target }}
+      distro-release: ${{ matrix.distro-release }}
+      distro-channel: ${{ matrix.distro-channel }}
+      repo-url:       ${{ matrix.repo-url }}
+      ext-version:    ${{ needs.version.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ coverage/
 # Avocado state directories
 _avocado/
 .avocado-state
+.avocado/
 
 # Documentation build
 docs/_build/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,7 +716,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -906,8 +905,6 @@ dependencies = [
  "core_affinity",
  "flate2",
  "flume",
- "libdeflater",
- "libz-ng-sys",
  "log",
  "num_cpus",
  "thiserror 2.0.18",
@@ -1326,24 +1323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libdeflate-sys"
-version = "1.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "libdeflater"
-version = "1.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
-dependencies = [
- "libdeflate-sys",
-]
-
-[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,16 +1342,6 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
-]
-
-[[package]]
-name = "libz-ng-sys"
-version = "1.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be734b33b7bc6a42d92d23e25e69758f866cf564a88d0bf80866fcf5a52c2255"
-dependencies = [
- "cmake",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,11 @@ reqwest = { version = "0.13", default-features = false, features = [
 indicatif = "0.18"
 futures-util = "0.3.30"
 flate2 = "1.0.32"
-gzp = "2.0"
+# Pure-Rust deflate backend. gzp's default features pull C/C++ native deps
+# (deflate_zlib_ng -> libz-ng-sys needs g++, libdeflate -> libdeflater needs a C
+# toolchain) that don't cross-compile in the avocado SDK (no target g++). gzp is
+# only used for `avocado save` gzip, so miniz_oxide is an acceptable trade.
+gzp = { version = "2.0", default-features = false, features = ["deflate_rust"] }
 tar = "0.4.41"
 uuid = { version = "1.0", features = ["v4", "v5"] }
 libc = "0.2"

--- a/avocado-cli-compile.sh
+++ b/avocado-cli-compile.sh
@@ -43,4 +43,15 @@ cat > .cargo/config.toml << EOF
 rustflags = ["--sysroot=$SDKTARGETSYSROOT/usr", "-C", "link-arg=--sysroot=$SDKTARGETSYSROOT"]
 EOF
 
-cargo build --release --target "$RUST_TARGET"
+# The SDK exports $CC as the cross-compiler command (bare name + target flags +
+# --sysroot), but in the `ext build` environment that compiler binary lives in
+# the SDK target-sysroot bindir, which is not on PATH. Without this, the `cc`
+# crate (pulled in by the remaining C dep aws-lc-sys) can't resolve the compiler
+# from $CC and falls back to guessing "<triple>-gcc", failing with ToolNotFound.
+# Put the SDK compiler bindir on PATH so the build uses exactly the $CC the SDK
+# configured. Arch-agnostic: derived from $SDKTARGETSYSROOT, no hardcoded triple.
+export PATH="$SDKTARGETSYSROOT/usr/bin:$PATH"
+
+# --locked: published builds run from staged package_files; fail loudly on a
+# missing/stale Cargo.lock instead of silently re-resolving dependencies.
+cargo build --locked --release --target "$RUST_TARGET"

--- a/avocado-cli-compile.sh
+++ b/avocado-cli-compile.sh
@@ -32,8 +32,9 @@ for var in $(env | grep -o 'CARGO_TARGET_[A-Z0-9_]*_RUSTFLAGS'); do
     unset "$var"
 done
 
-# Remove any existing config that might conflict
-rm -rf .cargo
+# Remove only the generated cross-compile config, preserving any committed
+# .cargo files used for development.
+rm -f .cargo/config.toml
 
 # Create config.toml with cross-compilation settings
 mkdir -p .cargo

--- a/avocado-cli-install.sh
+++ b/avocado-cli-install.sh
@@ -12,6 +12,11 @@ for json_file in "$RUST_TARGET_PATH"/*.json; do
     fi
 done
 
+if [ -z "$RUST_TARGET" ]; then
+    echo "Error: Could not find Rust target for $OECORE_TARGET_ARCH"
+    exit 1
+fi
+
 BINARY_PATH="$(dirname "$0")/target/$RUST_TARGET/release/avocado"
 
 if [ ! -f "$BINARY_PATH" ]; then

--- a/avocado.yaml
+++ b/avocado.yaml
@@ -2,14 +2,15 @@ supported_targets: '*'
 
 extensions:
   avocado-ext-cli:
-    # Version is injected at build time: `AVOCADO_EXT_VERSION=<x> avocado ext package …`
-    # (CI sets it from the release/tag; unset => empty + a warning).
+    # The extension version tracks the packaged program: CI reads it from Cargo.toml
+    # ([package] version) and exports AVOCADO_EXT_VERSION (.github/workflows/ext-release.yml).
+    # Locally: `AVOCADO_EXT_VERSION=<x> avocado ext package …` (unset => empty + a warning).
     version: '{{ env.AVOCADO_EXT_VERSION }}'
     release: r0
     summary: Avocado build system command line interface
     description: Avocado build system command line interface for managing the system
     license: Apache-2.0
-    url: https://github.com/avocadolinux/avocado-cli
+    url: https://github.com/avocado-linux/avocado-cli
     vendor: Avocado Linux <info@avocadolinux.org>
     # Stage the Rust source (the repo root IS the project) plus the packaging
     # artifacts, so `ext package` can compile it. configs/ is required:
@@ -41,7 +42,7 @@ extensions:
         packagegroup-rust-cross-canadian-avocado-{{ avocado.target }}: '*'
 
 sdk:
-  image: docker.io/avocadolinux/sdk:{{ env.AVOCADO_DISTRO_RELEASE }}-{{ env.AVOCADO_DISTRO_CHANNEL }}
+  image: docker.io/avocadolinux/sdk:{{ env.AVOCADO_DISTRO_RELEASE }}
 
   compile:
     avocado-cli-compile:


### PR DESCRIPTION
Wires the existing `avocado-ext-cli` extension config for build + publish via avocado-connect, mirroring avocado-conn/avocado-rat.

- `.github/workflows/ext-test.yml`: PR build via `extension-test.yml@v1`
- `.github/workflows/ext-release.yml`: tag → package + publish; **ext version tracks the packaged program** (read from `Cargo.toml` as `ext-version`). Named `ext-*` so it runs alongside the existing `release.yml` (binaries + Homebrew tap) on the same tag.
- `sdk.image` pinned to release-only tag; `url` org typo fixed