### PR TITLE
Add --connect-sign flag to avocado deploy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets --all-features -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-check
+        name: cargo check
+        entry: cargo check --all-targets
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-audit
+        name: cargo audit
+        entry: cargo audit
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]

--- a/src/commands/config_show.rs
+++ b/src/commands/config_show.rs
@@ -88,6 +88,10 @@ fn build_base_payload(config_path: &str, cfg: &Config) -> serde_json::Value {
                         "target": r.target,
                         "target_board": r.target_board,
                         "version": r.version,
+                        // Desktop gates "Sign via Connect" on this signal. Resolved
+                        // the same way the deploy nudge does (per-runtime signing key,
+                        // falling back to connect.server_key) so the two agree.
+                        "signing_enabled": cfg.get_server_key_for_runtime(name).is_some(),
                     })
                 })
                 .collect();
@@ -469,6 +473,64 @@ mod tests {
 
     fn yaml(s: &str) -> Value {
         serde_yaml::from_str(s).unwrap()
+    }
+
+    fn config(s: &str) -> Config {
+        serde_yaml::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn base_payload_marks_signing_enabled_per_runtime() {
+        // global-key inherits connect.server_key; own-key sets its own;
+        // the per-runtime resolver (get_server_key_for_runtime) must light
+        // both up so the desktop can gate "Sign via Connect" the same way
+        // the deploy nudge does.
+        let cfg = config(
+            r#"
+connect:
+  org: my-org
+  project: my-proj
+  server_key: deadbeef
+runtimes:
+  global-key:
+    target: qemux86-64
+  own-key:
+    target: qemux86-64
+    signing:
+      server_key: cafe1234
+"#,
+        );
+
+        let payload = build_base_payload("/tmp/avocado.yaml", &cfg);
+        let runtimes = payload["runtimes"].as_array().unwrap();
+
+        let global = runtimes.iter().find(|r| r["name"] == "global-key").unwrap();
+        let own = runtimes.iter().find(|r| r["name"] == "own-key").unwrap();
+        assert_eq!(global["signing_enabled"], true);
+        assert_eq!(own["signing_enabled"], true);
+
+        // Existing connect block is unchanged.
+        assert_eq!(payload["connect"]["org"], "my-org");
+        assert_eq!(payload["connect"]["project"], "my-proj");
+    }
+
+    #[test]
+    fn base_payload_signing_disabled_without_key() {
+        let cfg = config(
+            r#"
+runtimes:
+  no-key:
+    target: qemux86-64
+"#,
+        );
+        let payload = build_base_payload("/tmp/avocado.yaml", &cfg);
+        let no_key = payload["runtimes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["name"] == "no-key")
+            .unwrap();
+        assert_eq!(no_key["signing_enabled"], false);
     }
 
     #[test]

--- a/src/commands/connect/client.rs
+++ b/src/commands/connect/client.rs
@@ -205,10 +205,6 @@ struct ServerKeyWrapper {
 // Connect signing types
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Serialize)]
-pub struct SignForDeployRequest<'a> {
-    pub targets: &'a [TargetFileInfo],
-}
 
 #[derive(Debug, Deserialize)]
 pub struct SignForDeployResponse {
@@ -1437,13 +1433,11 @@ impl ConnectClient {
             self.api_url, org
         );
 
-        let body = SignForDeployRequest { targets };
-
         let res = self
             .http
             .post(&url)
             .header("authorization", format!("Bearer {}", self.token))
-            .json(&body)
+            .json(&serde_json::json!({ "targets": targets }))
             .send()
             .await
             .context("Failed to sign deploy metadata")?;
@@ -2304,27 +2298,6 @@ mod tests {
         } else {
             panic!("expected UrlExpired");
         }
-    }
-
-    // --- sign_for_deploy types ---
-
-    #[test]
-    fn test_sign_for_deploy_request_serializes_targets_no_runtime_uuid() {
-        use crate::utils::update_repo::TargetFileInfo;
-        let targets = vec![TargetFileInfo {
-            name: "firmware.raw".to_string(),
-            sha256: "ab".repeat(32),
-            size: 2048,
-        }];
-        let req = SignForDeployRequest { targets: &targets };
-        let json: serde_json::Value = serde_json::to_value(&req).unwrap();
-        // targets array must be present
-        assert!(json["targets"].is_array());
-        let t = &json["targets"][0];
-        assert_eq!(t["name"], "firmware.raw");
-        assert_eq!(t["size"], 2048);
-        // must NOT include runtime_uuid
-        assert!(json.get("runtime_uuid").is_none());
     }
 
     #[test]

--- a/src/commands/connect/client.rs
+++ b/src/commands/connect/client.rs
@@ -1422,10 +1422,17 @@ impl ConnectClient {
     }
 
     /// Sign TUF deploy metadata via the Connect platform.
+    ///
+    /// `runtime_uuid` is required — the server uses it to name the per-runtime
+    /// delegation role (`runtime-<uuid>`) so the returned `delegated_targets_json`
+    /// matches the path this CLI writes it to locally
+    /// (`delegations/runtime-<uuid>.json`), which is where the device's TUF
+    /// client expects to find it.
     pub async fn sign_for_deploy(
         &self,
         org: &str,
         targets: &[TargetFileInfo],
+        runtime_uuid: &str,
     ) -> Result<SignForDeployResponse> {
         let url = format!("{}/api/orgs/{}/signing/sign-for-deploy", self.api_url, org);
 
@@ -1433,7 +1440,7 @@ impl ConnectClient {
             .http
             .post(&url)
             .header("authorization", format!("Bearer {}", self.token))
-            .json(&serde_json::json!({ "targets": targets }))
+            .json(&serde_json::json!({ "targets": targets, "runtime_uuid": runtime_uuid }))
             .send()
             .await
             .context("Failed to sign deploy metadata")?;

--- a/src/commands/connect/client.rs
+++ b/src/commands/connect/client.rs
@@ -205,7 +205,6 @@ struct ServerKeyWrapper {
 // Connect signing types
 // ---------------------------------------------------------------------------
 
-
 #[derive(Debug, Deserialize)]
 pub struct SignForDeployResponse {
     pub targets_json: String,
@@ -1428,10 +1427,7 @@ impl ConnectClient {
         org: &str,
         targets: &[TargetFileInfo],
     ) -> Result<SignForDeployResponse> {
-        let url = format!(
-            "{}/api/orgs/{}/signing/sign-for-deploy",
-            self.api_url, org
-        );
+        let url = format!("{}/api/orgs/{}/signing/sign-for-deploy", self.api_url, org);
 
         let res = self
             .http

--- a/src/commands/connect/client.rs
+++ b/src/commands/connect/client.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context, Result};
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
+
+use crate::utils::update_repo::TargetFileInfo;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -197,6 +199,28 @@ pub struct ServerKeyResponse {
 #[derive(Debug, Deserialize)]
 struct ServerKeyWrapper {
     data: ServerKeyResponse,
+}
+
+// ---------------------------------------------------------------------------
+// Connect signing types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct SignForDeployRequest<'a> {
+    pub targets: &'a [TargetFileInfo],
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SignForDeployResponse {
+    pub targets_json: String,
+    pub snapshot_json: String,
+    pub timestamp_json: String,
+    pub delegated_targets_json: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SignForDeployWrapper {
+    data: SignForDeployResponse,
 }
 
 // ---------------------------------------------------------------------------
@@ -1401,6 +1425,38 @@ impl ConnectClient {
         let resp: ServerKeyWrapper = res.json().await?;
         Ok(resp.data)
     }
+
+    /// Sign TUF deploy metadata via the Connect platform.
+    pub async fn sign_for_deploy(
+        &self,
+        org: &str,
+        targets: &[TargetFileInfo],
+    ) -> Result<SignForDeployResponse> {
+        let url = format!(
+            "{}/api/orgs/{}/signing/sign-for-deploy",
+            self.api_url, org
+        );
+
+        let body = SignForDeployRequest { targets };
+
+        let res = self
+            .http
+            .post(&url)
+            .header("authorization", format!("Bearer {}", self.token))
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to sign deploy metadata")?;
+
+        let status = res.status();
+        if !status.is_success() {
+            let body = res.text().await.unwrap_or_default();
+            anyhow::bail!("Failed to sign deploy metadata (HTTP {status}): {body}");
+        }
+
+        let resp: SignForDeployWrapper = res.json().await?;
+        Ok(resp.data)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2248,5 +2304,43 @@ mod tests {
         } else {
             panic!("expected UrlExpired");
         }
+    }
+
+    // --- sign_for_deploy types ---
+
+    #[test]
+    fn test_sign_for_deploy_request_serializes_targets_no_runtime_uuid() {
+        use crate::utils::update_repo::TargetFileInfo;
+        let targets = vec![TargetFileInfo {
+            name: "firmware.raw".to_string(),
+            sha256: "ab".repeat(32),
+            size: 2048,
+        }];
+        let req = SignForDeployRequest { targets: &targets };
+        let json: serde_json::Value = serde_json::to_value(&req).unwrap();
+        // targets array must be present
+        assert!(json["targets"].is_array());
+        let t = &json["targets"][0];
+        assert_eq!(t["name"], "firmware.raw");
+        assert_eq!(t["size"], 2048);
+        // must NOT include runtime_uuid
+        assert!(json.get("runtime_uuid").is_none());
+    }
+
+    #[test]
+    fn test_sign_for_deploy_response_deserializes_four_fields() {
+        let raw = r#"{
+            "data": {
+                "targets_json": "{\"targets\":true}",
+                "snapshot_json": "{\"snapshot\":true}",
+                "timestamp_json": "{\"timestamp\":true}",
+                "delegated_targets_json": "{\"delegated\":true}"
+            }
+        }"#;
+        let resp: SignForDeployWrapper = serde_json::from_str(raw).unwrap();
+        assert_eq!(resp.data.targets_json, "{\"targets\":true}");
+        assert_eq!(resp.data.snapshot_json, "{\"snapshot\":true}");
+        assert_eq!(resp.data.timestamp_json, "{\"timestamp\":true}");
+        assert_eq!(resp.data.delegated_targets_json, "{\"delegated\":true}");
     }
 }

--- a/src/commands/runtime/deploy.rs
+++ b/src/commands/runtime/deploy.rs
@@ -359,7 +359,11 @@ impl RuntimeDeployCommand {
 
         // --- Phase 2: Generate and sign TUF metadata ---
         print_info(
-            "Phase 2: Generating signed TUF metadata...",
+            if self.connect_sign {
+                "Phase 2: Signing TUF metadata via Connect..."
+            } else {
+                "Phase 2: Generating signed TUF metadata..."
+            },
             OutputLevel::Normal,
         );
         Self::emit_phase_status(PHASE_METADATA, "running");

--- a/src/commands/runtime/deploy.rs
+++ b/src/commands/runtime/deploy.rs
@@ -411,8 +411,7 @@ impl RuntimeDeployCommand {
                 std::fs::write(staging_dir.join("timestamp.json"), &signed.timestamp_json)
                     .context("Failed to write timestamp.json")?;
                 std::fs::write(
-                    delegations_dir
-                        .join(format!("runtime-{}.json", collection.runtime_uuid)),
+                    delegations_dir.join(format!("runtime-{}.json", collection.runtime_uuid)),
                     &signed.delegated_targets_json,
                 )
                 .context("Failed to write delegated targets json")?;
@@ -436,10 +435,8 @@ impl RuntimeDeployCommand {
                     );
                 }
 
-                let signing_key_name =
-                    config.get_runtime_signing_key_name(&self.runtime_name);
-                let content_key_name =
-                    config.get_runtime_content_key_name(&self.runtime_name);
+                let signing_key_name = config.get_runtime_signing_key_name(&self.runtime_name);
+                let content_key_name = config.get_runtime_content_key_name(&self.runtime_name);
 
                 let mut resolved_signing_key_name = signing_key_name.clone();
                 let signer = match crate::utils::update_signing::resolve_signing_key(
@@ -448,8 +445,7 @@ impl RuntimeDeployCommand {
                     Some(s) => s,
                     None => {
                         // Auto-generate a development signing key for local deploys
-                        let dev_key_name =
-                            crate::utils::signing_keys::ensure_dev_signing_key()?;
+                        let dev_key_name = crate::utils::signing_keys::ensure_dev_signing_key()?;
                         resolved_signing_key_name = Some(dev_key_name.clone());
                         crate::utils::update_signing::resolve_signing_key(Some(&dev_key_name))?
                             .expect("dev signing key was just created")
@@ -484,8 +480,7 @@ impl RuntimeDeployCommand {
                 )
                 .context("Failed to write timestamp.json")?;
                 std::fs::write(
-                    delegations_dir
-                        .join(format!("runtime-{}.json", collection.runtime_uuid)),
+                    delegations_dir.join(format!("runtime-{}.json", collection.runtime_uuid)),
                     &repo_metadata.delegated_targets_json,
                 )
                 .context("Failed to write delegated targets json")?;

--- a/src/commands/runtime/deploy.rs
+++ b/src/commands/runtime/deploy.rs
@@ -406,7 +406,9 @@ impl RuntimeDeployCommand {
                     })?;
                 let client = ConnectClient::from_profile(profile)?;
 
-                let signed = client.sign_for_deploy(&org, &collection.targets).await?;
+                let signed = client
+                    .sign_for_deploy(&org, &collection.targets, &collection.runtime_uuid)
+                    .await?;
 
                 std::fs::write(staging_dir.join("targets.json"), &signed.targets_json)
                     .context("Failed to write targets.json")?;

--- a/src/commands/runtime/deploy.rs
+++ b/src/commands/runtime/deploy.rs
@@ -1,3 +1,4 @@
+use crate::commands::connect::client::{self as connect_client, ConnectClient};
 use crate::utils::{
     config::{ComposedConfig, Config},
     container::{is_docker_desktop, is_vm_routing_active, RunConfig, SdkContainer},
@@ -82,6 +83,7 @@ pub struct RuntimeDeployCommand {
     container_args: Option<Vec<String>>,
     dnf_args: Option<Vec<String>>,
     no_stamps: bool,
+    connect_sign: bool,
     sdk_arch: Option<String>,
     /// Pre-composed configuration to avoid reloading
     composed_config: Option<Arc<ComposedConfig>>,
@@ -114,6 +116,7 @@ impl RuntimeDeployCommand {
             container_args,
             dnf_args,
             no_stamps: false,
+            connect_sign: false,
             sdk_arch: None,
             composed_config: None,
         }
@@ -122,6 +125,12 @@ impl RuntimeDeployCommand {
     /// Set the no_stamps flag
     pub fn with_no_stamps(mut self, no_stamps: bool) -> Self {
         self.no_stamps = no_stamps;
+        self
+    }
+
+    /// Route Phase 2 TUF metadata signing through the Connect platform
+    pub fn with_connect_sign(mut self, connect_sign: bool) -> Self {
+        self.connect_sign = connect_sign;
         self
     }
 
@@ -360,40 +369,11 @@ impl RuntimeDeployCommand {
             .unwrap_or(std::path::Path::new("."));
         let staging_dir = project_dir.join(DEPLOY_STAGING_DIR);
 
+        let delegations_dir = staging_dir.join("delegations");
         // Group all metadata work in a single fallible block so any
         // failure is attributed to PHASE_METADATA without wrapping every
         // `?` site individually.
-        let metadata_result: Result<()> = (|| {
-            let signing_key_name = config.get_runtime_signing_key_name(&self.runtime_name);
-            let content_key_name = config.get_runtime_content_key_name(&self.runtime_name);
-
-            let mut resolved_signing_key_name = signing_key_name.clone();
-            let signer = match crate::utils::update_signing::resolve_signing_key(
-                signing_key_name.as_deref(),
-            )? {
-                Some(s) => s,
-                None => {
-                    // Auto-generate a development signing key for local deploys
-                    let dev_key_name = crate::utils::signing_keys::ensure_dev_signing_key()?;
-                    resolved_signing_key_name = Some(dev_key_name.clone());
-                    crate::utils::update_signing::resolve_signing_key(Some(&dev_key_name))?
-                        .expect("dev signing key was just created")
-                }
-            };
-            let content_signer = crate::utils::update_signing::resolve_content_key(
-                content_key_name.as_deref(),
-                resolved_signing_key_name.as_deref(),
-            )?
-            .expect("signing key is set, so content key resolution should return Some");
-
-            let repo_metadata = update_repo::generate_repo_metadata(
-                &collection.targets,
-                &collection.runtime_uuid,
-                &signer,
-                &content_signer,
-            )?;
-
-            let delegations_dir = staging_dir.join("delegations");
+        let metadata_result: Result<()> = async {
             std::fs::create_dir_all(&delegations_dir).with_context(|| {
                 format!(
                     "Failed to create deploy staging directory: {}",
@@ -401,32 +381,122 @@ impl RuntimeDeployCommand {
                 )
             })?;
 
-            std::fs::write(
-                staging_dir.join("targets.json"),
-                &repo_metadata.targets_json,
-            )
-            .context("Failed to write targets.json")?;
-            std::fs::write(
-                staging_dir.join("snapshot.json"),
-                &repo_metadata.snapshot_json,
-            )
-            .context("Failed to write snapshot.json")?;
-            std::fs::write(
-                staging_dir.join("timestamp.json"),
-                &repo_metadata.timestamp_json,
-            )
-            .context("Failed to write timestamp.json")?;
+            if self.connect_sign {
+                // Route Phase 2 through the Connect signing endpoint.
+                let connect_config = connect_client::load_config()?.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "--connect-sign requires an active Connect session. \
+                         Run `avocado connect auth login` first."
+                    )
+                })?;
+                let org_hint = config.connect.as_ref().and_then(|c| c.org.as_deref());
+                let (_, profile) = connect_config.resolve_profile(None, org_hint)?;
+                let org = org_hint
+                    .map(str::to_owned)
+                    .or_else(|| profile.organization_id.clone())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "--connect-sign requires a Connect org. Set `connect.org` in \
+                             avocado.yaml, or authenticate with an org-associated account."
+                        )
+                    })?;
+                let client = ConnectClient::from_profile(profile)?;
+
+                let signed = client.sign_for_deploy(&org, &collection.targets).await?;
+
+                std::fs::write(staging_dir.join("targets.json"), &signed.targets_json)
+                    .context("Failed to write targets.json")?;
+                std::fs::write(staging_dir.join("snapshot.json"), &signed.snapshot_json)
+                    .context("Failed to write snapshot.json")?;
+                std::fs::write(staging_dir.join("timestamp.json"), &signed.timestamp_json)
+                    .context("Failed to write timestamp.json")?;
+                std::fs::write(
+                    delegations_dir
+                        .join(format!("runtime-{}.json", collection.runtime_uuid)),
+                    &signed.delegated_targets_json,
+                )
+                .context("Failed to write delegated targets json")?;
+
+                print_info(
+                    "Connect-signed metadata expires after 7 days. \
+                     Re-run `avocado deploy --connect-sign` to refresh.",
+                    OutputLevel::Normal,
+                );
+            } else {
+                // Default: sign locally with the project or dev key.
+                if config
+                    .get_server_key_for_runtime(&self.runtime_name)
+                    .is_some()
+                {
+                    print_warning(
+                        "This project has a Connect server key configured. \
+                         A locally-signed deploy may be rejected by a device that has \
+                         received a Connect OTA update. Use `--connect-sign` to sign via Connect.",
+                        OutputLevel::Normal,
+                    );
+                }
+
+                let signing_key_name =
+                    config.get_runtime_signing_key_name(&self.runtime_name);
+                let content_key_name =
+                    config.get_runtime_content_key_name(&self.runtime_name);
+
+                let mut resolved_signing_key_name = signing_key_name.clone();
+                let signer = match crate::utils::update_signing::resolve_signing_key(
+                    signing_key_name.as_deref(),
+                )? {
+                    Some(s) => s,
+                    None => {
+                        // Auto-generate a development signing key for local deploys
+                        let dev_key_name =
+                            crate::utils::signing_keys::ensure_dev_signing_key()?;
+                        resolved_signing_key_name = Some(dev_key_name.clone());
+                        crate::utils::update_signing::resolve_signing_key(Some(&dev_key_name))?
+                            .expect("dev signing key was just created")
+                    }
+                };
+                let content_signer = crate::utils::update_signing::resolve_content_key(
+                    content_key_name.as_deref(),
+                    resolved_signing_key_name.as_deref(),
+                )?
+                .expect("signing key is set, so content key resolution should return Some");
+
+                let repo_metadata = update_repo::generate_repo_metadata(
+                    &collection.targets,
+                    &collection.runtime_uuid,
+                    &signer,
+                    &content_signer,
+                )?;
+
+                std::fs::write(
+                    staging_dir.join("targets.json"),
+                    &repo_metadata.targets_json,
+                )
+                .context("Failed to write targets.json")?;
+                std::fs::write(
+                    staging_dir.join("snapshot.json"),
+                    &repo_metadata.snapshot_json,
+                )
+                .context("Failed to write snapshot.json")?;
+                std::fs::write(
+                    staging_dir.join("timestamp.json"),
+                    &repo_metadata.timestamp_json,
+                )
+                .context("Failed to write timestamp.json")?;
+                std::fs::write(
+                    delegations_dir
+                        .join(format!("runtime-{}.json", collection.runtime_uuid)),
+                    &repo_metadata.delegated_targets_json,
+                )
+                .context("Failed to write delegated targets json")?;
+            }
             if let Some(root_json) = &collection.root_json {
                 std::fs::write(staging_dir.join("root.json"), root_json)
                     .context("Failed to write root.json to staging")?;
             }
-            std::fs::write(
-                delegations_dir.join(format!("runtime-{}.json", collection.runtime_uuid)),
-                &repo_metadata.delegated_targets_json,
-            )
-            .context("Failed to write delegated targets json")?;
             Ok(())
-        })();
+        }
+        .await;
 
         if let Err(e) = metadata_result {
             Self::emit_phase_error(PHASE_METADATA, &e.to_string());
@@ -1407,5 +1477,36 @@ mod tests {
         let before = args.clone();
         strip_host_network_args(&mut args);
         assert_eq!(args, before);
+    }
+
+    // --- connect-sign builder and nudge ---
+
+    #[test]
+    fn test_connect_sign_default_false() {
+        let cmd = RuntimeDeployCommand::new(
+            "my-runtime".to_string(),
+            "avocado.yaml".to_string(),
+            false,
+            None,
+            "192.168.1.1".to_string(),
+            None,
+            None,
+        );
+        assert!(!cmd.connect_sign);
+    }
+
+    #[test]
+    fn test_with_connect_sign_sets_flag() {
+        let cmd = RuntimeDeployCommand::new(
+            "my-runtime".to_string(),
+            "avocado.yaml".to_string(),
+            false,
+            None,
+            "192.168.1.1".to_string(),
+            None,
+            None,
+        )
+        .with_connect_sign(true);
+        assert!(cmd.connect_sign);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -441,6 +441,10 @@ enum Commands {
         /// Additional arguments to pass to DNF commands
         #[arg(long = "dnf-arg", num_args = 1, allow_hyphen_values = true, action = clap::ArgAction::Append)]
         dnf_args: Option<Vec<String>>,
+        /// Sign TUF metadata via the Connect platform instead of locally.
+        /// Use this when deploying to a device that has received a Connect OTA update.
+        #[arg(long)]
+        connect_sign: bool,
         /// Output format. JSON skips TUI rendering and emits NDJSON events.
         #[arg(long, value_enum, default_value_t = OutputFormat::Human)]
         output: OutputFormat,
@@ -1782,6 +1786,10 @@ enum RuntimeCommands {
         /// Additional arguments to pass to DNF commands
         #[arg(long = "dnf-arg", num_args = 1, allow_hyphen_values = true, action = clap::ArgAction::Append)]
         dnf_args: Option<Vec<String>>,
+        /// Sign TUF metadata via the Connect platform instead of locally.
+        /// Use this when deploying to a device that has received a Connect OTA update.
+        #[arg(long)]
+        connect_sign: bool,
         /// Output format. JSON skips TUI rendering and emits NDJSON events.
         #[arg(long, value_enum, default_value_t = OutputFormat::Human)]
         output: OutputFormat,
@@ -2335,6 +2343,7 @@ async fn main() -> Result<()> {
             device,
             container_args,
             dnf_args,
+            connect_sign,
             output,
         } => {
             let runtime = resolve_runtime_at_path(&config, name.as_deref().or(runtime.as_deref()))?;
@@ -2351,6 +2360,7 @@ async fn main() -> Result<()> {
                 dnf_args,
             )
             .with_no_stamps(cli.no_stamps)
+            .with_connect_sign(connect_sign)
             .with_sdk_arch(cli.sdk_arch.clone());
             deploy_cmd.execute().await?;
             Ok(())
@@ -2657,6 +2667,7 @@ async fn main() -> Result<()> {
                 device,
                 container_args,
                 dnf_args,
+                connect_sign,
                 output,
             } => {
                 let runtime =
@@ -2674,6 +2685,7 @@ async fn main() -> Result<()> {
                     dnf_args,
                 )
                 .with_no_stamps(cli.no_stamps)
+                .with_connect_sign(connect_sign)
                 .with_sdk_arch(cli.sdk_arch.clone());
                 deploy_cmd.execute().await?;
                 Ok(())

--- a/src/utils/update_repo.rs
+++ b/src/utils/update_repo.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
@@ -16,7 +16,7 @@ pub fn compute_image_id(sha256_hex: &str) -> String {
 }
 
 /// Information about a single target file in the TUF repository.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TargetFileInfo {
     pub name: String,
     pub sha256: String,
@@ -774,5 +774,24 @@ mod tests {
             .as_str()
             .unwrap();
         assert_eq!(content_key_hex, content_signer.public_key_hex);
+    }
+
+    #[test]
+    fn test_target_file_info_serialize_roundtrip() {
+        let info = TargetFileInfo {
+            name: "firmware.raw".to_string(),
+            sha256: "ab".repeat(32),
+            size: 1024,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        // Assert the wire keys match what the Connect signing API expects.
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["name"], "firmware.raw");
+        assert_eq!(v["sha256"], "ab".repeat(32).as_str());
+        assert_eq!(v["size"], 1024u64);
+        let back: TargetFileInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.name, info.name);
+        assert_eq!(back.sha256, info.sha256);
+        assert_eq!(back.size, info.size);
     }
 }


### PR DESCRIPTION
## Problem

Devices that have received a Connect OTA update trust the Connect server key
as their TUF root, so locally-signed TUF metadata is rejected. `avocado deploy`
has no way to sign metadata via Connect, leaving these devices stuck.

## Solution

Add `--connect-sign` to both `avocado deploy` entry points. When set, Phase 2
routes through a new `ConnectClient::sign_for_deploy` method that POSTs the
target list to `/api/orgs/{org}/signing/sign-for-deploy` and writes the four
returned JSON blobs to staging. The local path is unchanged; `--connect-sign`
is an explicit opt-in.

A nudge prints on local deploys when the project has `connect.server_key` set,
surfacing the flag without forcing it.

## Key changes

- `TargetFileInfo` gains `Serialize` so the targets array goes directly into the request body
- `ConnectClient::sign_for_deploy` and response types added, mirroring the `get_tuf_server_key` pattern
- Phase 2 in `deploy.rs` branches on `--connect-sign`: resolves org early, calls the API, writes the four TUF JSON files, prints 7-day expiry notice
- Phase 2 progress label switches to "Signing TUF metadata via Connect..." under `--connect-sign`
- `root.json` write moved outside the if/else so both signing paths stage it
- Flag wired to both `Commands::Deploy` and `RuntimeCommands::Deploy` in `main.rs`
- `config show --output json` now emits a per-runtime `signing_enabled` boolean so Avocado Desktop can gate "Sign via Connect" (unblocks ENG-2005)
- `.pre-commit-config.yaml` added: cargo fmt/clippy/check on commit, cargo audit on push

## Reviewer notes

**Gated on ENG-1963** — the `sign-for-deploy` endpoint is not live yet. Unit
tests pass; a live E2E needs three things in place:

1. ENG-1963 endpoint landed and reachable
2. A device that has taken a Connect OTA (rejects local signing as baseline)
3. An authenticated Connect session with a valid org

E2E sequence once ready:
```sh
# Confirm baseline failure
avocado deploy -r <runtime> -d <device-ip>

# Connect-signed deploy
avocado deploy --connect-sign -r <runtime> -d <device-ip>
# -> success + 7-day expiry notice; device applies without TUF errors
```

This PR also closes the ENG-2005 config-show contract: `config show --output json`
exposes `signing_enabled` per runtime, resolved identically to the deploy nudge
(per-runtime `signing.server_key`, falling back to `connect.server_key`).

No new dependencies introduced.