### PR TITLE
ext package: bake resolved version into the published avocado.yaml

### DIFF
--- a/src/commands/ext/package.rs
+++ b/src/commands/ext/package.rs
@@ -587,15 +587,14 @@ impl ExtPackageCommand {
                 .unwrap_or_else(|| "avocado.yaml".to_string());
             match fs::read_to_string(ext_config_path) {
                 Ok(text) => {
-                    let baked =
-                        bake_extension_version(&text, &self.extension, &metadata.version)
-                            .with_context(|| {
-                                format!(
-                                    "Failed to bake resolved version '{}' into the packaged \
+                    let baked = bake_extension_version(&text, &self.extension, &metadata.version)
+                        .with_context(|| {
+                        format!(
+                            "Failed to bake resolved version '{}' into the packaged \
                                      config for extension '{}'",
-                                    metadata.version, self.extension
-                                )
-                            })?;
+                            metadata.version, self.extension
+                        )
+                    })?;
                     let b64 = BASE64_STANDARD.encode(baked.as_bytes());
                     format!(
                         r#"
@@ -1027,9 +1026,7 @@ fn bake_extension_version(text: &str, ext_name: &str, version: &str) -> Result<S
     }
 
     if !replaced {
-        anyhow::bail!(
-            "could not locate `version:` for extension '{ext_name}' in its avocado.yaml"
-        );
+        anyhow::bail!("could not locate `version:` for extension '{ext_name}' in its avocado.yaml");
     }
 
     let mut result = out.join("\n");

--- a/src/commands/ext/package.rs
+++ b/src/commands/ext/package.rs
@@ -143,6 +143,14 @@ impl ExtPackageCommand {
             }
         };
 
+        // On-disk config filename (avocado.yaml or avocado.yml). Used both for the
+        // default packaged config and for the version bake so a `.yml` ext stages
+        // and bakes under its real name rather than a hardcoded `avocado.yaml`.
+        let cfg_basename = std::path::Path::new(&ext_config_path)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "avocado.yaml".to_string());
+
         if self.verbose {
             match &extension_location {
                 ExtensionLocation::Local { name, config_path } => {
@@ -207,7 +215,8 @@ impl ExtPackageCommand {
         // Determine which files to package
         // Pass both merged config (for package_files), raw config (for all target overlays),
         // and full parsed config (for sdk.compile scripts)
-        let package_files = self.get_package_files(&ext_config, raw_ext_config.as_ref(), parsed);
+        let package_files =
+            self.get_package_files(&ext_config, raw_ext_config.as_ref(), parsed, &cfg_basename);
 
         if self.verbose {
             print_info(
@@ -232,6 +241,7 @@ impl ExtPackageCommand {
                 &target,
                 &ext_config_path,
                 &package_files,
+                &cfg_basename,
             )
             .await?;
 
@@ -306,6 +316,7 @@ impl ExtPackageCommand {
         ext_config: &serde_yaml::Value,
         raw_ext_config: Option<&serde_yaml::Value>,
         full_parsed_config: &serde_yaml::Value,
+        cfg_basename: &str,
     ) -> Vec<String> {
         // Check if package_files is explicitly defined
         if let Some(package_files) = ext_config.get("package_files") {
@@ -320,8 +331,10 @@ impl ExtPackageCommand {
             }
         }
 
-        // Default behavior: avocado.yaml + overlays + compile scripts + install scripts
-        let mut default_files = vec!["avocado.yaml".to_string()];
+        // Default behavior: the config file + overlays + compile scripts + install
+        // scripts. Use the actual on-disk config name so an `avocado.yml` ext is
+        // staged (and later baked) under its real name.
+        let mut default_files = vec![cfg_basename.to_string()];
         let mut seen_files = std::collections::HashSet::new();
 
         // If we have the raw extension config, scan for all overlays
@@ -519,6 +532,7 @@ impl ExtPackageCommand {
         target: &str,
         ext_config_path: &str,
         package_files: &[String],
+        cfg_basename: &str,
     ) -> Result<PathBuf> {
         let container_image = config
             .get_sdk_image()
@@ -581,14 +595,15 @@ impl ExtPackageCommand {
         // `{{ env.AVOCADO_DISTRO_RELEASE }}`) for the consumer to resolve at their
         // build time. Additional required fields can be folded in here later.
         let version_bake_section = {
-            let cfg_basename = std::path::Path::new(ext_config_path)
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_else(|| "avocado.yaml".to_string());
             match fs::read_to_string(ext_config_path) {
                 Ok(text) => {
-                    let baked = bake_extension_version(&text, &self.extension, &metadata.version)
-                        .with_context(|| {
+                    let baked = crate::utils::config_edit::bake_extension_version(
+                        &text,
+                        &self.extension,
+                        target,
+                        &metadata.version,
+                    )
+                    .with_context(|| {
                         format!(
                             "Failed to bake resolved version '{}' into the packaged \
                                      config for extension '{}'",
@@ -596,6 +611,9 @@ impl ExtPackageCommand {
                         )
                     })?;
                     let b64 = BASE64_STANDARD.encode(baked.as_bytes());
+                    // The resolved version is baked into the base64 payload only;
+                    // it is never interpolated into the shell, so a version string
+                    // carrying pre-release/build metadata can't reach the command line.
                     format!(
                         r#"
 # Bake the resolved extension version into the packaged config so the published
@@ -603,12 +621,11 @@ impl ExtPackageCommand {
 # would interpolate to '' during a downstream runtime build.
 if [ -f "$STAGING_DIR/{basename}" ]; then
     printf '%s' '{b64}' | base64 -d > "$STAGING_DIR/{basename}"
-    echo "Baked resolved version '{version}' into {basename}"
+    echo "Baked resolved extension version into {basename}"
 fi
 "#,
                         basename = cfg_basename,
                         b64 = b64,
-                        version = metadata.version,
                     )
                 }
                 // Remote/unreadable source (e.g. packaging a fetched remote ext
@@ -944,98 +961,6 @@ rm -rf "$TMPDIR"
     }
 }
 
-/// Rewrite `extensions.<ext_name>.version` in an avocado.yaml document to a
-/// concrete, resolved `version`, preserving the rest of the file verbatim —
-/// comments and every other templated value stay intact.
-///
-/// This is the package-time resolution of a "required field": the in-source
-/// program extensions declare `version: '{{ env.AVOCADO_EXT_VERSION }}'` so the
-/// packaged version tracks Cargo.toml, but that template only resolves while the
-/// env var is set. Baking the resolved value makes the published config
-/// self-contained while leaving other templates (e.g. `{{ avocado.target }}`)
-/// for the consumer to resolve at their build time.
-///
-/// A deliberate line-scoped edit rather than a serde round-trip: round-tripping
-/// would drop comments and could re-quote/normalize the surviving template
-/// strings. Only the `version:` key that is a direct child of the named
-/// extension is touched (a nested `version:` under, say, `packages:` is left
-/// alone). Returns an error if that key can't be located — the caller has
-/// already proven a valid version exists, so a miss means an unexpected layout.
-fn bake_extension_version(text: &str, ext_name: &str, version: &str) -> Result<String> {
-    // Key portion of a `key: value` line (handles optional quoting of the key).
-    fn line_key(trimmed: &str) -> &str {
-        trimmed
-            .split(':')
-            .next()
-            .unwrap_or("")
-            .trim()
-            .trim_matches(|c| c == '"' || c == '\'')
-    }
-
-    let mut out: Vec<String> = Vec::with_capacity(text.lines().count() + 1);
-    let mut in_extensions = false; // inside the top-level `extensions:` map
-    let mut ext_indent: Option<usize> = None; // indent of the `<ext_name>:` key
-    let mut child_indent: Option<usize> = None; // indent of the ext's direct children
-    let mut replaced = false;
-
-    for line in text.lines() {
-        let trimmed = line.trim_start();
-        // Blank/comment lines are kept verbatim and don't affect block tracking.
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            out.push(line.to_string());
-            continue;
-        }
-        let indent = line.len() - trimmed.len();
-
-        // A line at or above the extension key's indent ends the ext block; a
-        // top-level line also toggles whether we're inside `extensions:`. Fall
-        // through so the same line can re-open a sibling extension block.
-        if let Some(ei) = ext_indent {
-            if indent <= ei {
-                ext_indent = None;
-                child_indent = None;
-            }
-        }
-
-        if indent == 0 {
-            in_extensions = trimmed.starts_with("extensions:");
-            out.push(line.to_string());
-            continue;
-        }
-
-        if in_extensions && ext_indent.is_none() {
-            if line_key(trimmed) == ext_name {
-                ext_indent = Some(indent);
-            }
-            out.push(line.to_string());
-            continue;
-        }
-
-        if ext_indent.is_some() {
-            // Inside the ext block. The first child line fixes the direct-child
-            // indent; only a `version:` at that exact indent is the field we bake.
-            let ci = *child_indent.get_or_insert(indent);
-            if !replaced && indent == ci && line_key(trimmed) == "version" {
-                out.push(format!("{}version: '{version}'", " ".repeat(indent)));
-                replaced = true;
-                continue;
-            }
-        }
-
-        out.push(line.to_string());
-    }
-
-    if !replaced {
-        anyhow::bail!("could not locate `version:` for extension '{ext_name}' in its avocado.yaml");
-    }
-
-    let mut result = out.join("\n");
-    if text.ends_with('\n') {
-        result.push('\n');
-    }
-    Ok(result)
-}
-
 /// RPM metadata structure
 #[derive(Debug)]
 struct RpmMetadata {
@@ -1054,72 +979,6 @@ struct RpmMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_bake_extension_version_replaces_only_version_keeps_other_templates() {
-        let src = "supported_targets: '*'\n\
-extensions:\n  \
-  avocado-ext-cli:\n    \
-    # tracks Cargo.toml at package time\n    \
-    version: '{{ env.AVOCADO_EXT_VERSION }}'\n    \
-    release: r0\n    \
-    sdk:\n      \
-      packages:\n        \
-        packagegroup-rust-cross-canadian-avocado-{{ avocado.target }}: '*'\n\
-sdk:\n  \
-  image: docker.io/avocadolinux/sdk:{{ env.AVOCADO_DISTRO_RELEASE }}\n";
-
-        let out = bake_extension_version(src, "avocado-ext-cli", "1.2.3").unwrap();
-
-        // The version field is resolved...
-        assert!(out.contains("    version: '1.2.3'"));
-        assert!(!out.contains("AVOCADO_EXT_VERSION"));
-        // ...the explanatory comment is preserved...
-        assert!(out.contains("# tracks Cargo.toml at package time"));
-        // ...and every other template is left for the consumer to resolve.
-        assert!(out.contains("packagegroup-rust-cross-canadian-avocado-{{ avocado.target }}"));
-        assert!(out.contains("docker.io/avocadolinux/sdk:{{ env.AVOCADO_DISTRO_RELEASE }}"));
-        assert!(out.ends_with('\n'));
-    }
-
-    #[test]
-    fn test_bake_extension_version_ignores_nested_version_keys() {
-        // A `version:` nested under packages must NOT be mistaken for the field.
-        let src = "extensions:\n  \
-  my-ext:\n    \
-    packages:\n      \
-      some-dep:\n        \
-        version: '9.9.9'\n    \
-    version: '{{ env.AVOCADO_EXT_VERSION }}'\n";
-
-        let out = bake_extension_version(src, "my-ext", "0.4.0").unwrap();
-        assert!(out.contains("        version: '9.9.9'")); // nested untouched
-        assert!(out.contains("    version: '0.4.0'")); // direct child baked
-    }
-
-    #[test]
-    fn test_bake_extension_version_only_named_extension() {
-        let src = "extensions:\n  \
-  ext-a:\n    \
-    version: '{{ env.AVOCADO_EXT_VERSION }}'\n  \
-  ext-b:\n    \
-    version: '{{ env.AVOCADO_EXT_VERSION }}'\n";
-
-        let out = bake_extension_version(src, "ext-b", "2.0.0").unwrap();
-        // ext-a's template is preserved; only ext-b is baked.
-        let a_idx = out.find("ext-a:").unwrap();
-        let b_idx = out.find("ext-b:").unwrap();
-        assert!(out[a_idx..b_idx].contains("'{{ env.AVOCADO_EXT_VERSION }}'"));
-        assert!(out[b_idx..].contains("version: '2.0.0'"));
-        assert!(!out[b_idx..].contains("AVOCADO_EXT_VERSION"));
-    }
-
-    #[test]
-    fn test_bake_extension_version_errors_when_absent() {
-        let src = "extensions:\n  my-ext:\n    release: r0\n";
-        let err = bake_extension_version(src, "my-ext", "1.0.0").unwrap_err();
-        assert!(err.to_string().contains("could not locate `version:`"));
-    }
 
     #[test]
     fn test_generate_summary_from_name() {
@@ -1392,7 +1251,7 @@ sdk:\n  \
 
         // Pass empty full config since we're not testing compile script extraction
         let empty_full_config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
-        let files = cmd.get_package_files(&ext_config, None, &empty_full_config);
+        let files = cmd.get_package_files(&ext_config, None, &empty_full_config, "avocado.yaml");
         assert_eq!(files, vec!["avocado.yaml".to_string()]);
     }
 
@@ -1423,7 +1282,12 @@ sdk:\n  \
         // Use the same config as raw config to test overlay extraction
         // Pass empty full config since we're not testing compile script extraction
         let empty_full_config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
-        let files = cmd.get_package_files(&ext_config, Some(&ext_config), &empty_full_config);
+        let files = cmd.get_package_files(
+            &ext_config,
+            Some(&ext_config),
+            &empty_full_config,
+            "avocado.yaml",
+        );
         assert_eq!(
             files,
             vec!["avocado.yaml".to_string(), "my-overlay".to_string()]
@@ -1467,7 +1331,12 @@ sdk:\n  \
         // Use the same config as raw config to test overlay extraction
         // Pass empty full config since we're not testing compile script extraction
         let empty_full_config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
-        let files = cmd.get_package_files(&ext_config, Some(&ext_config), &empty_full_config);
+        let files = cmd.get_package_files(
+            &ext_config,
+            Some(&ext_config),
+            &empty_full_config,
+            "avocado.yaml",
+        );
         assert_eq!(
             files,
             vec!["avocado.yaml".to_string(), "overlays/prod".to_string()]
@@ -1513,7 +1382,12 @@ sdk:\n  \
 
         // Pass empty full config since we're not testing compile script extraction
         let empty_full_config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
-        let files = cmd.get_package_files(&ext_config, Some(&ext_config), &empty_full_config);
+        let files = cmd.get_package_files(
+            &ext_config,
+            Some(&ext_config),
+            &empty_full_config,
+            "avocado.yaml",
+        );
         assert_eq!(
             files,
             vec![
@@ -1551,7 +1425,7 @@ sdk:\n  \
 
         // Pass empty full config since we're not testing compile script extraction
         let empty_full_config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
-        let files = cmd.get_package_files(&ext_config, None, &empty_full_config);
+        let files = cmd.get_package_files(&ext_config, None, &empty_full_config, "avocado.yaml");
         assert_eq!(files, vec!["avocado.yaml".to_string()]);
     }
 
@@ -1615,7 +1489,12 @@ sdk:\n  \
 
         // Pass empty full config since we're not testing compile script extraction
         let empty_full_config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
-        let files = cmd.get_package_files(&merged_config, Some(&raw_config), &empty_full_config);
+        let files = cmd.get_package_files(
+            &merged_config,
+            Some(&raw_config),
+            &empty_full_config,
+            "avocado.yaml",
+        );
 
         // Should include avocado.yaml and both target-specific overlays
         assert!(files.contains(&"avocado.yaml".to_string()));

--- a/src/commands/ext/package.rs
+++ b/src/commands/ext/package.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use base64::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -568,6 +569,56 @@ impl ExtPackageCommand {
             _ => "Provides: avocado-target(*)".to_string(),
         };
 
+        // Resolve package-time-only fields in the avocado.yaml that ships in the
+        // package payload. Today that is just `version`: the in-source program
+        // extensions declare `version: '{{ env.AVOCADO_EXT_VERSION }}'` so the
+        // packaged version tracks Cargo.toml, but that template only resolves
+        // while AVOCADO_EXT_VERSION is set (package time). If it survives into the
+        // published package, a downstream runtime build — which has no such env in
+        // scope — interpolates it to '' and fails semver validation. We bake just
+        // the resolved value (`metadata.version`, already interpolated + validated)
+        // and leave every other template (e.g. `{{ avocado.target }}`,
+        // `{{ env.AVOCADO_DISTRO_RELEASE }}`) for the consumer to resolve at their
+        // build time. Additional required fields can be folded in here later.
+        let version_bake_section = {
+            let cfg_basename = std::path::Path::new(ext_config_path)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| "avocado.yaml".to_string());
+            match fs::read_to_string(ext_config_path) {
+                Ok(text) => {
+                    let baked =
+                        bake_extension_version(&text, &self.extension, &metadata.version)
+                            .with_context(|| {
+                                format!(
+                                    "Failed to bake resolved version '{}' into the packaged \
+                                     config for extension '{}'",
+                                    metadata.version, self.extension
+                                )
+                            })?;
+                    let b64 = BASE64_STANDARD.encode(baked.as_bytes());
+                    format!(
+                        r#"
+# Bake the resolved extension version into the packaged config so the published
+# avocado.yaml carries a concrete semver instead of an env-only template that
+# would interpolate to '' during a downstream runtime build.
+if [ -f "$STAGING_DIR/{basename}" ]; then
+    printf '%s' '{b64}' | base64 -d > "$STAGING_DIR/{basename}"
+    echo "Baked resolved version '{version}' into {basename}"
+fi
+"#,
+                        basename = cfg_basename,
+                        b64 = b64,
+                        version = metadata.version,
+                    )
+                }
+                // Remote/unreadable source (e.g. packaging a fetched remote ext
+                // whose config lives in the container volume): leave the payload
+                // untouched rather than fail the package.
+                Err(_) => String::new(),
+            }
+        };
+
         // Create RPM using rpmbuild in container
         // Package root (/) maps to the extension's src_dir contents
         let rpm_build_script = format!(
@@ -630,7 +681,7 @@ for pattern in $PACKAGE_FILES; do
     done
 done
 cd "$TMPDIR"
-
+{version_bake_section}
 echo "Creating RPM with $FILE_COUNT files from source directory..."
 
 if [ "$FILE_COUNT" -eq 0 ]; then
@@ -722,6 +773,7 @@ rm -rf "$TMPDIR"
             rpm_filename = rpm_filename,
             container_src_dir = container_src_dir,
             package_files_str = package_files_str,
+            version_bake_section = version_bake_section,
         );
 
         // Run the RPM build in the container
@@ -893,6 +945,100 @@ rm -rf "$TMPDIR"
     }
 }
 
+/// Rewrite `extensions.<ext_name>.version` in an avocado.yaml document to a
+/// concrete, resolved `version`, preserving the rest of the file verbatim —
+/// comments and every other templated value stay intact.
+///
+/// This is the package-time resolution of a "required field": the in-source
+/// program extensions declare `version: '{{ env.AVOCADO_EXT_VERSION }}'` so the
+/// packaged version tracks Cargo.toml, but that template only resolves while the
+/// env var is set. Baking the resolved value makes the published config
+/// self-contained while leaving other templates (e.g. `{{ avocado.target }}`)
+/// for the consumer to resolve at their build time.
+///
+/// A deliberate line-scoped edit rather than a serde round-trip: round-tripping
+/// would drop comments and could re-quote/normalize the surviving template
+/// strings. Only the `version:` key that is a direct child of the named
+/// extension is touched (a nested `version:` under, say, `packages:` is left
+/// alone). Returns an error if that key can't be located — the caller has
+/// already proven a valid version exists, so a miss means an unexpected layout.
+fn bake_extension_version(text: &str, ext_name: &str, version: &str) -> Result<String> {
+    // Key portion of a `key: value` line (handles optional quoting of the key).
+    fn line_key(trimmed: &str) -> &str {
+        trimmed
+            .split(':')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .trim_matches(|c| c == '"' || c == '\'')
+    }
+
+    let mut out: Vec<String> = Vec::with_capacity(text.lines().count() + 1);
+    let mut in_extensions = false; // inside the top-level `extensions:` map
+    let mut ext_indent: Option<usize> = None; // indent of the `<ext_name>:` key
+    let mut child_indent: Option<usize> = None; // indent of the ext's direct children
+    let mut replaced = false;
+
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        // Blank/comment lines are kept verbatim and don't affect block tracking.
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            out.push(line.to_string());
+            continue;
+        }
+        let indent = line.len() - trimmed.len();
+
+        // A line at or above the extension key's indent ends the ext block; a
+        // top-level line also toggles whether we're inside `extensions:`. Fall
+        // through so the same line can re-open a sibling extension block.
+        if let Some(ei) = ext_indent {
+            if indent <= ei {
+                ext_indent = None;
+                child_indent = None;
+            }
+        }
+
+        if indent == 0 {
+            in_extensions = trimmed.starts_with("extensions:");
+            out.push(line.to_string());
+            continue;
+        }
+
+        if in_extensions && ext_indent.is_none() {
+            if line_key(trimmed) == ext_name {
+                ext_indent = Some(indent);
+            }
+            out.push(line.to_string());
+            continue;
+        }
+
+        if ext_indent.is_some() {
+            // Inside the ext block. The first child line fixes the direct-child
+            // indent; only a `version:` at that exact indent is the field we bake.
+            let ci = *child_indent.get_or_insert(indent);
+            if !replaced && indent == ci && line_key(trimmed) == "version" {
+                out.push(format!("{}version: '{version}'", " ".repeat(indent)));
+                replaced = true;
+                continue;
+            }
+        }
+
+        out.push(line.to_string());
+    }
+
+    if !replaced {
+        anyhow::bail!(
+            "could not locate `version:` for extension '{ext_name}' in its avocado.yaml"
+        );
+    }
+
+    let mut result = out.join("\n");
+    if text.ends_with('\n') {
+        result.push('\n');
+    }
+    Ok(result)
+}
+
 /// RPM metadata structure
 #[derive(Debug)]
 struct RpmMetadata {
@@ -911,6 +1057,72 @@ struct RpmMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_bake_extension_version_replaces_only_version_keeps_other_templates() {
+        let src = "supported_targets: '*'\n\
+extensions:\n  \
+  avocado-ext-cli:\n    \
+    # tracks Cargo.toml at package time\n    \
+    version: '{{ env.AVOCADO_EXT_VERSION }}'\n    \
+    release: r0\n    \
+    sdk:\n      \
+      packages:\n        \
+        packagegroup-rust-cross-canadian-avocado-{{ avocado.target }}: '*'\n\
+sdk:\n  \
+  image: docker.io/avocadolinux/sdk:{{ env.AVOCADO_DISTRO_RELEASE }}\n";
+
+        let out = bake_extension_version(src, "avocado-ext-cli", "1.2.3").unwrap();
+
+        // The version field is resolved...
+        assert!(out.contains("    version: '1.2.3'"));
+        assert!(!out.contains("AVOCADO_EXT_VERSION"));
+        // ...the explanatory comment is preserved...
+        assert!(out.contains("# tracks Cargo.toml at package time"));
+        // ...and every other template is left for the consumer to resolve.
+        assert!(out.contains("packagegroup-rust-cross-canadian-avocado-{{ avocado.target }}"));
+        assert!(out.contains("docker.io/avocadolinux/sdk:{{ env.AVOCADO_DISTRO_RELEASE }}"));
+        assert!(out.ends_with('\n'));
+    }
+
+    #[test]
+    fn test_bake_extension_version_ignores_nested_version_keys() {
+        // A `version:` nested under packages must NOT be mistaken for the field.
+        let src = "extensions:\n  \
+  my-ext:\n    \
+    packages:\n      \
+      some-dep:\n        \
+        version: '9.9.9'\n    \
+    version: '{{ env.AVOCADO_EXT_VERSION }}'\n";
+
+        let out = bake_extension_version(src, "my-ext", "0.4.0").unwrap();
+        assert!(out.contains("        version: '9.9.9'")); // nested untouched
+        assert!(out.contains("    version: '0.4.0'")); // direct child baked
+    }
+
+    #[test]
+    fn test_bake_extension_version_only_named_extension() {
+        let src = "extensions:\n  \
+  ext-a:\n    \
+    version: '{{ env.AVOCADO_EXT_VERSION }}'\n  \
+  ext-b:\n    \
+    version: '{{ env.AVOCADO_EXT_VERSION }}'\n";
+
+        let out = bake_extension_version(src, "ext-b", "2.0.0").unwrap();
+        // ext-a's template is preserved; only ext-b is baked.
+        let a_idx = out.find("ext-a:").unwrap();
+        let b_idx = out.find("ext-b:").unwrap();
+        assert!(out[a_idx..b_idx].contains("'{{ env.AVOCADO_EXT_VERSION }}'"));
+        assert!(out[b_idx..].contains("version: '2.0.0'"));
+        assert!(!out[b_idx..].contains("AVOCADO_EXT_VERSION"));
+    }
+
+    #[test]
+    fn test_bake_extension_version_errors_when_absent() {
+        let src = "extensions:\n  my-ext:\n    release: r0\n";
+        let err = bake_extension_version(src, "my-ext", "1.0.0").unwrap_err();
+        assert!(err.to_string().contains("could not locate `version:`"));
+    }
 
     #[test]
     fn test_generate_summary_from_name() {

--- a/src/utils/config_edit.rs
+++ b/src/utils/config_edit.rs
@@ -1197,9 +1197,272 @@ fn scope_label(scope: &PackageScope) -> String {
     }
 }
 
+/// Rewrite `extensions.<ext_name>.version` in an avocado.yaml document to a
+/// concrete, resolved `version`, preserving the rest of the file verbatim —
+/// comments and every other templated value stay intact.
+///
+/// This is the package-time resolution of a "required field": the in-source
+/// program extensions declare `version: '{{ env.AVOCADO_EXT_VERSION }}'` so the
+/// packaged version tracks Cargo.toml, but that template only resolves while the
+/// env var is set. Baking the resolved value makes the published config
+/// self-contained while leaving other templates (e.g. `{{ avocado.target }}`)
+/// for the consumer to resolve at their build time.
+///
+/// A deliberate line-scoped edit rather than a serde round-trip: round-tripping
+/// would drop comments and could re-quote/normalize the surviving template
+/// strings.
+///
+/// Matching mirrors [`super::find_ext_in_mapping`] — the extension key is
+/// matched directly *and* via `{{ avocado.target }}` interpolation, so a
+/// template-keyed extension (e.g. `avocado-bsp-{{ avocado.target }}`) resolves
+/// the same way the merged config that produced `version` did. The resolved
+/// value is baked into:
+///   - the extension's direct-child `version:` (inserted if absent — e.g. when
+///     the merged version originated from a `target-<name>:` override block), and
+///   - any `version:` that is a direct child of a `target-*:` / `kernel-*:`
+///     override sub-block of the extension (so a surviving template there can't
+///     interpolate to `''` downstream).
+///
+/// A `version:` nested deeper (e.g. under `packages:`) is left untouched.
+///
+/// Errors only if the extension block itself can't be located, which means the
+/// raw text doesn't match the merged config the caller already resolved against.
+pub fn bake_extension_version(
+    text: &str,
+    ext_name: &str,
+    target: &str,
+    version: &str,
+) -> Result<String> {
+    use crate::utils::interpolation::interpolate_name;
+
+    let lines: Vec<&str> = text.lines().collect();
+    let extensions_idx = find_top_level_key(&lines, "extensions").with_context(|| {
+        format!("could not locate `extensions:` block while baking version for '{ext_name}'")
+    })?;
+
+    // Does a top-level `extensions:` child key name `ext_name`, directly or
+    // after `{{ avocado.target }}` interpolation? (Same rule as find_ext_in_mapping.)
+    let key_matches = |key: &str| -> bool {
+        key == ext_name || (key.contains("{{") && interpolate_name(key, target) == ext_name)
+    };
+
+    let mut out: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+
+    // Walk the extension block. Indents: 0 = top level, `ext_indent` = the
+    // matched extension key, `child_indent` = its direct children, and a
+    // `target-*`/`kernel-*` direct child opens an override sub-block whose own
+    // direct children we also bake.
+    let mut ext_key_idx: Option<usize> = None;
+    let mut ext_indent = 0usize;
+    let mut child_indent: Option<usize> = None;
+    let mut baked_direct = false;
+    let mut in_extensions = false;
+    let mut in_override = false; // current direct child is a target-/kernel- block
+    let mut override_child_indent: Option<usize> = None;
+
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = leading_spaces(line);
+
+        // Before we've matched the extension, just track whether we're inside
+        // `extensions:` and look for the matching key at any depth-1 child.
+        if ext_key_idx.is_none() {
+            if indent == 0 {
+                in_extensions = i == extensions_idx;
+                continue;
+            }
+            if in_extensions {
+                if let Some(key) = extract_package_name(line) {
+                    if key_matches(&key) {
+                        ext_key_idx = Some(i);
+                        ext_indent = indent;
+                    }
+                }
+            }
+            continue;
+        }
+
+        // We're past the matched extension key. The block ends at the first
+        // line indented at or above the extension key itself.
+        if indent <= ext_indent {
+            break;
+        }
+
+        let ci = *child_indent.get_or_insert(indent);
+        let key = extract_package_name(line);
+
+        if indent == ci {
+            // Direct child of the extension.
+            in_override = key
+                .as_deref()
+                .is_some_and(|k| k.starts_with("target-") || k.starts_with("kernel-"));
+            override_child_indent = None;
+            if key.as_deref() == Some("version") {
+                out[i] = format!("{}version: '{version}'", " ".repeat(indent));
+                baked_direct = true;
+            }
+        } else if in_override {
+            // Inside a target-/kernel- override block; bake only its direct
+            // `version:` child (not anything nested deeper, e.g. its packages).
+            let oci = *override_child_indent.get_or_insert(indent);
+            if indent == oci && key.as_deref() == Some("version") {
+                out[i] = format!("{}version: '{version}'", " ".repeat(indent));
+            }
+        }
+        // Any other line (deeper non-override nesting, e.g. packages.*.version)
+        // is left exactly as-is.
+    }
+
+    let ext_key_idx = ext_key_idx.with_context(|| {
+        format!("could not locate extension '{ext_name}' in the packaged avocado.yaml")
+    })?;
+
+    // No direct-child `version:` existed (e.g. the merged version came solely
+    // from a `target-<name>:` block). Insert a concrete one so the published
+    // config always carries a base version instead of relying on an override.
+    if !baked_direct {
+        let indent = child_indent.unwrap_or(ext_indent + 2);
+        out.insert(
+            ext_key_idx + 1,
+            format!("{}version: '{version}'", " ".repeat(indent)),
+        );
+    }
+
+    let mut result = out.join("\n");
+    if text.ends_with('\n') {
+        result.push('\n');
+    }
+    Ok(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_bake_extension_version_replaces_only_version_keeps_other_templates() {
+        let src = "supported_targets: '*'\n\
+extensions:\n  \
+  avocado-ext-cli:\n    \
+    # tracks Cargo.toml at package time\n    \
+    version: '{{ env.AVOCADO_EXT_VERSION }}'\n    \
+    release: r0\n    \
+    sdk:\n      \
+      packages:\n        \
+        packagegroup-rust-cross-canadian-avocado-{{ avocado.target }}: '*'\n\
+sdk:\n  \
+  image: docker.io/avocadolinux/sdk:{{ env.AVOCADO_DISTRO_RELEASE }}\n";
+
+        let out = bake_extension_version(src, "avocado-ext-cli", "qemux86-64", "1.2.3").unwrap();
+
+        // The version field is resolved...
+        assert!(out.contains("    version: '1.2.3'"));
+        assert!(!out.contains("AVOCADO_EXT_VERSION"));
+        // ...the explanatory comment is preserved...
+        assert!(out.contains("# tracks Cargo.toml at package time"));
+        // ...and every other template is left for the consumer to resolve.
+        assert!(out.contains("packagegroup-rust-cross-canadian-avocado-{{ avocado.target }}"));
+        assert!(out.contains("docker.io/avocadolinux/sdk:{{ env.AVOCADO_DISTRO_RELEASE }}"));
+        assert!(out.ends_with('\n'));
+    }
+
+    #[test]
+    fn test_bake_extension_version_ignores_nested_version_keys() {
+        // A `version:` nested under packages must NOT be mistaken for the field.
+        let src = "extensions:\n  \
+  my-ext:\n    \
+    packages:\n      \
+      some-dep:\n        \
+        version: '9.9.9'\n    \
+    version: '{{ env.AVOCADO_EXT_VERSION }}'\n";
+
+        let out = bake_extension_version(src, "my-ext", "qemux86-64", "0.4.0").unwrap();
+        assert!(out.contains("        version: '9.9.9'")); // nested untouched
+        assert!(out.contains("    version: '0.4.0'")); // direct child baked
+    }
+
+    #[test]
+    fn test_bake_extension_version_only_named_extension() {
+        let src = "extensions:\n  \
+  ext-a:\n    \
+    version: '{{ env.AVOCADO_EXT_VERSION }}'\n  \
+  ext-b:\n    \
+    version: '{{ env.AVOCADO_EXT_VERSION }}'\n";
+
+        let out = bake_extension_version(src, "ext-b", "qemux86-64", "2.0.0").unwrap();
+        // ext-a's template is preserved; only ext-b is baked.
+        let a_idx = out.find("ext-a:").unwrap();
+        let b_idx = out.find("ext-b:").unwrap();
+        assert!(out[a_idx..b_idx].contains("'{{ env.AVOCADO_EXT_VERSION }}'"));
+        assert!(out[b_idx..].contains("version: '2.0.0'"));
+        assert!(!out[b_idx..].contains("AVOCADO_EXT_VERSION"));
+    }
+
+    #[test]
+    fn test_bake_extension_version_errors_when_extension_absent() {
+        let src = "extensions:\n  other-ext:\n    version: '1.0.0'\n";
+        let err = bake_extension_version(src, "my-ext", "qemux86-64", "1.0.0").unwrap_err();
+        assert!(err.to_string().contains("locate extension 'my-ext'"));
+    }
+
+    #[test]
+    fn test_bake_extension_version_matches_template_keyed_extension() {
+        // The on-disk key is a `{{ avocado.target }}` template; the resolved
+        // extension name is what `ext package` operates on. Literal comparison
+        // would never match and would have hard-failed before.
+        let src = "extensions:\n  \
+  avocado-bsp-{{ avocado.target }}:\n    \
+    version: '{{ env.AVOCADO_EXT_VERSION }}'\n    \
+    release: r0\n";
+
+        let out = bake_extension_version(src, "avocado-bsp-raspberrypi5", "raspberrypi5", "3.1.4")
+            .unwrap();
+        // The template key itself is preserved; only its version is baked.
+        assert!(out.contains("avocado-bsp-{{ avocado.target }}:"));
+        assert!(out.contains("    version: '3.1.4'"));
+        assert!(!out.contains("AVOCADO_EXT_VERSION"));
+    }
+
+    #[test]
+    fn test_bake_extension_version_inserts_when_only_in_target_block() {
+        // The merged version originated from a `target-<name>:` override and
+        // there is no direct-child `version:`. We bake the override's version
+        // AND insert a concrete base version so the published config is
+        // self-contained for every target.
+        let src = "extensions:\n  \
+  my-ext:\n    \
+    release: r0\n    \
+    target-imx8mp:\n      \
+      version: '{{ env.AVOCADO_EXT_VERSION }}'\n";
+
+        let out = bake_extension_version(src, "my-ext", "imx8mp", "1.5.0").unwrap();
+        // Override-block template is resolved...
+        assert!(out.contains("      version: '1.5.0'"));
+        // ...and a base version is inserted as a direct child.
+        let ext_idx = out.find("my-ext:").unwrap();
+        let target_idx = out.find("target-imx8mp:").unwrap();
+        assert!(out[ext_idx..target_idx].contains("    version: '1.5.0'"));
+        assert!(!out.contains("AVOCADO_EXT_VERSION"));
+    }
+
+    #[test]
+    fn test_bake_extension_version_bakes_base_and_target_block() {
+        // Both a base template and a target-block template exist: bake both so
+        // neither survives to interpolate to '' downstream (the half-bake case).
+        let src = "extensions:\n  \
+  my-ext:\n    \
+    version: '{{ env.AVOCADO_EXT_VERSION }}'\n    \
+    target-imx8mp:\n      \
+      version: '{{ env.AVOCADO_EXT_VERSION }}'\n";
+
+        let out = bake_extension_version(src, "my-ext", "imx8mp", "2.2.2").unwrap();
+        assert!(!out.contains("AVOCADO_EXT_VERSION"));
+        assert!(out.contains("    version: '2.2.2'")); // base
+        assert!(out.contains("      version: '2.2.2'")); // target block
+    }
 
     const SAMPLE_CONFIG: &str = r#"default_target: "qemux86-64"
 


### PR DESCRIPTION
## Problem

The in-source program extensions (`avocado-ext-cli`, `avocado-ext-connect`, `avocado-ext-tunnels`) keep the extension version in sync with `Cargo.toml` by templating it from an env var:

```yaml
extensions:
  avocado-ext-connect:
    version: '{{ env.AVOCADO_EXT_VERSION }}'   # CI exports it from [package] version
```

That template only resolves while `AVOCADO_EXT_VERSION` is set — i.e. at **package / PR-test time**. The `ext package` RPM payload copied the **raw on-disk `avocado.yaml`**, so the literal template survived into the published package. Later, a **runtime build** consuming that extension has no `AVOCADO_EXT_VERSION` in scope, so it interpolated to `''` and failed:

```
Extension 'avocado-ext-connect' has invalid version ''. Version must be in
semantic versioning format (e.g., '1.0.0', '2.1.3')
```

## Fix

Resolve the required `version` field **at package time** and bake the concrete semver into the `avocado.yaml` that ships in the RPM payload. The resolved value is `metadata.version` — already interpolated through the normal config pipeline and semver-validated before packaging — so no new resolution logic, just persistence.

Only `extensions.<ext>.version` is rewritten, via a comment-preserving, indentation-scoped line edit (no serde round-trip, so comments and quoting are untouched). **Every other template** (`{{ avocado.target }}`, `{{ env.AVOCADO_DISTRO_RELEASE }}`, …) is intentionally left for the consumer to resolve at their build time — matching the "interpolate the required fields, defer the rest" model.

Implementation notes:
- The bake rewrites the single small staged `avocado.yaml` (≈1 KB) that's already in the staging dir — it adds **no** copy of the (potentially large) source tree.
- Remote/unreadable source configs (e.g. packaging a fetched remote ext) are left untouched rather than failing the package.

## Tests

New unit tests for the `bake_extension_version` helper:
- version-only replacement, with other templates **and** comments preserved
- nested `version:` keys (e.g. under `packages:`) left untouched
- multi-extension files bake only the named extension
- not-found error path

Local: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all green (17 package tests, incl. 4 new).

## Follow-up (not in this PR)

`ext package` currently copies the selected files twice (src → staging → rpmbuild buildroot). A separate refactor can have `%install` copy straight from the source into the buildroot (dropping the intermediate staging dir) to cut one copy for large source trees; it touches the rpmbuild flow so it should be validated against a real `avocado ext package` run.