### PR TITLE
release: 0.41.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocado-cli"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.41.1"
+version = "0.41.2"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]


### PR DESCRIPTION
## Release 0.41.2

Patch release bumping `avocado-cli` from 0.41.1 to 0.41.2.

### Changes

**`ext package`: bake the resolved extension version into the published `avocado.yaml`** (#161)

The in-source program extensions template `version: '{{ env.AVOCADO_EXT_VERSION }}'` so the packaged version tracks `Cargo.toml`, but that env only exists at package time. The literal template survived into the RPM payload, so a downstream runtime build (no `AVOCADO_EXT_VERSION` in scope) interpolated it to `''` and failed semver validation. `ext package` now resolves and bakes the concrete semver into the shipped config while leaving every other template (`{{ avocado.target }}`, etc.) for the consumer to resolve at build time.

The bake is robust to how the version is actually resolved (from the merged config):

- **Template-keyed extensions** (`avocado-bsp-{{ avocado.target }}`) are matched the same way `find_ext_in_mapping` resolves them — direct key, then `{{ avocado.target }}` interpolation — instead of a literal compare that would hard-fail.
- **Version from a `target-<name>:` override block** no longer aborts the package: a concrete base `version:` is inserted, and `version:` inside `target-*`/`kernel-*` override blocks is baked too, so no template survives to interpolate to `''` downstream. Deeper `packages.*.version` is left untouched.
- **`.yml` configs** stage and bake under their real on-disk name rather than a hardcoded `avocado.yaml`.
- The resolved version is carried only through the base64 payload — it is no longer interpolated into the rpmbuild shell, closing a potential injection path via pre-release/build metadata.

The bake helper lives in `utils/config_edit.rs` alongside the other comment-preserving `avocado.yaml` editors, with unit coverage for the template-key, nested-version, multi-extension, and target-block cases.

### Verification
`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all green.
