### PR TITLE
vm: Fix q35 guest NIC binding and tpm2 boot stall

### DIFF
--- a/src/utils/vm/lifecycle.rs
+++ b/src/utils/vm/lifecycle.rs
@@ -227,6 +227,16 @@ pub async fn start(opts: StartOptions) -> Result<VmStatus> {
     // than owning the process — that decoupling keeps the CLI usable on
     // its own and avoids the IPC stall we used to hit when `vm stop` had
     // to round-trip through the app.
+    // Provide a software TPM before qemu when swtpm is available; the
+    // avocado-vm image's tpm2 feature makes systemd wait for /dev/tpm0. When
+    // swtpm is absent the guest cmdline gets systemd.tpm2_wait=false instead
+    // (see qemu::build_qemu_args), so this is a soft enhancement, not a gate.
+    if super::tpm::swtpm_available() {
+        if let Err(e) = super::tpm::spawn_swtpm(&paths) {
+            eprintln!("warning: swtpm setup failed ({e}); booting the VM without a TPM");
+        }
+    }
+
     let pid = {
         let p = qemu::spawn_detached(&manifest, &paths, &cfg).await?;
         // qemu's -pidfile flag will (re)write the pid; give it a moment, then
@@ -358,6 +368,7 @@ async fn stop_inner(force: bool) -> Result<()> {
     #[cfg(unix)]
     stop_supervisor(&paths);
     let _ = super::forward::stop(&paths).await;
+    super::tpm::stop_swtpm(&paths);
 
     let pid = match state::read_pid(&paths)? {
         Some(pid) if state::pid_alive(pid) => pid,

--- a/src/utils/vm/mod.rs
+++ b/src/utils/vm/mod.rs
@@ -41,3 +41,4 @@ pub mod staging;
 pub mod state;
 #[cfg(unix)]
 pub mod supervisor;
+pub mod tpm;

--- a/src/utils/vm/qemu.rs
+++ b/src/utils/vm/qemu.rs
@@ -167,7 +167,12 @@ pub fn build_qemu_args(
         cfg.ssh_port
     ));
     args.push("-device".into());
-    args.push("virtio-net-device,netdev=net0".into());
+    // virtio-net-pci, not virtio-net-device: the x86 `q35` machine exposes
+    // PCIe, not the virtio-mmio bus that `virtio-net-device` binds to, so the
+    // mmio variant aborts qemu at startup with "No 'virtio-bus' bus found for
+    // device 'virtio-net-device'" and `vm start` never boots. arm64 `virt`
+    // also has PCIe, so -pci is correct for both arches (matches virtio-9p-pci).
+    args.push("virtio-net-pci,netdev=net0".into());
 
     // USB host controller (empty; USB devices are attached at runtime via QMP)
     args.push("-device".into());

--- a/src/utils/vm/qemu.rs
+++ b/src/utils/vm/qemu.rs
@@ -110,6 +110,16 @@ pub fn build_qemu_args(
         cmdline.push_str(extra.trim());
     }
 
+    // The avocado-vm image ships the `tpm2` distro feature, so systemd waits
+    // for /dev/tpm0 at boot. When no swtpm-backed TPM is wired (its control
+    // socket is absent because swtpm is not installed or failed to start),
+    // tell systemd not to wait so the guest doesn't block ~90s on the missing
+    // device. When the socket IS present the TPM device args below satisfy the
+    // wait instead.
+    if !paths.tpm_socket().exists() {
+        cmdline.push_str(" systemd.tpm2_wait=false");
+    }
+
     let mut args: Vec<String> = Vec::new();
 
     args.push("-machine".into());
@@ -218,6 +228,15 @@ pub fn build_qemu_args(
     ));
     args.push("-device".into());
     args.push("virtserialport,chardev=avocadoctl,name=avocado.control".into());
+
+    // Software TPM (swtpm), wired only when the lifecycle layer started it and
+    // its control socket exists. Mirrors meta-avocado's run-qemux86-64-swtpm so
+    // the guest's tpm2 feature finds /dev/tpm0 instead of blocking on it.
+    if paths.tpm_socket().exists() {
+        for a in super::tpm::qemu_tpm_args(paths, &arch) {
+            args.push(a);
+        }
+    }
 
     // Serial console -> logfile
     args.push("-serial".into());

--- a/src/utils/vm/state.rs
+++ b/src/utils/vm/state.rs
@@ -143,6 +143,12 @@ impl VmPaths {
     pub fn pid_file(&self) -> PathBuf {
         self.root.join("qemu.pid")
     }
+    pub fn tpm_dir(&self) -> PathBuf {
+        self.root.join("tpm")
+    }
+    pub fn tpm_socket(&self) -> PathBuf {
+        self.root.join("tpm").join("swtpm-sock")
+    }
     pub fn lock_file(&self) -> PathBuf {
         self.root.join("lock")
     }

--- a/src/utils/vm/tpm.rs
+++ b/src/utils/vm/tpm.rs
@@ -1,0 +1,94 @@
+//! Software TPM (swtpm) provisioning for the avocado-vm.
+//!
+//! The avocado-vm image is built with the `tpm2` distro feature
+//! (meta-avocado `kas/feature/tpm.yml`), so systemd waits for `/dev/tpm0` at
+//! boot. Provide a swtpm-backed TPM 2.0 the same way meta-avocado's
+//! `meta-avocado-qemu/scripts/run-qemux86-64-swtpm` script does; without it
+//! the guest blocks ~90s on the missing TPM device before boot continues.
+//!
+//! When `swtpm` is not installed the caller instead appends
+//! `systemd.tpm2_wait=false` to the kernel cmdline (see
+//! [`super::qemu::build_qemu_args`]) so the guest still boots promptly, just
+//! without a TPM.
+
+use std::process::Command;
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+
+use super::state::VmPaths;
+
+/// True when a usable `swtpm` binary is on `PATH`.
+pub fn swtpm_available() -> bool {
+    Command::new("swtpm")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// QEMU args wiring the guest TPM to the running swtpm control socket. Mirrors
+/// meta-avocado's `run-qemux86-64-swtpm`: `tpm-tis` on x86 (the `q35` machine
+/// exposes the LPC bus it needs); arm64 `virt` uses the sysbus
+/// `tpm-tis-device`.
+pub fn qemu_tpm_args(paths: &VmPaths, arch: &str) -> Vec<String> {
+    let device = match arch {
+        "arm64" | "aarch64" => "tpm-tis-device,tpmdev=tpm0",
+        _ => "tpm-tis,tpmdev=tpm0",
+    };
+    vec![
+        "-chardev".into(),
+        format!("socket,id=chrtpm,path={}", paths.tpm_socket().display()),
+        "-tpmdev".into(),
+        "emulator,id=tpm0,chardev=chrtpm".into(),
+        "-device".into(),
+        device.into(),
+    ]
+}
+
+/// Start swtpm as a daemon with a unix control socket under the VM state dir,
+/// blocking until the socket appears (up to ~10s). Kills any leftover swtpm
+/// for this state dir first so a stale daemon can't hold the socket.
+pub fn spawn_swtpm(paths: &VmPaths) -> Result<()> {
+    let dir = paths.tpm_dir();
+    let sock = paths.tpm_socket();
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("create tpm state dir {}", dir.display()))?;
+    stop_swtpm(paths);
+    let _ = std::fs::remove_file(&sock);
+
+    let status = Command::new("swtpm")
+        .arg("socket")
+        .arg("--tpmstate")
+        .arg(format!("dir={}", dir.display()))
+        .arg("--ctrl")
+        .arg(format!("type=unixio,path={}", sock.display()))
+        .arg("--log")
+        .arg(format!("file={},level=1", dir.join("swtpm.log").display()))
+        .arg("--tpm2")
+        .arg("--daemon")
+        .status()
+        .context("spawn swtpm")?;
+    if !status.success() {
+        bail!("swtpm exited with {:?}", status.code());
+    }
+
+    for _ in 0..100 {
+        if sock.exists() {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    bail!("swtpm control socket {} never appeared", sock.display());
+}
+
+/// Best-effort teardown of the swtpm daemon backing this VM's TPM. Matches on
+/// the state-dir path so only this VM's swtpm is killed, mirroring the
+/// `pkill -f "swtpm socket.*${TPM_DIR}"` cleanup in the meta-avocado script.
+pub fn stop_swtpm(paths: &VmPaths) {
+    let dir = paths.tpm_dir();
+    let _ = Command::new("pkill")
+        .arg("-f")
+        .arg(format!("swtpm socket.*{}", dir.display()))
+        .status();
+}


### PR DESCRIPTION
Two fixes to `avocado vm start` that block the local avocado-vm from booting on the `q35` (x86_64) and arm64 `virt` machines.

## virtio-net-pci for the guest NIC

`vm start` assembled the guest NIC as `virtio-net-device` (the virtio-mmio transport). `q35` and `virt` expose PCIe, not a virtio-mmio bus, so QEMU aborts at startup with:

```
No 'virtio-bus' bus found for device 'virtio-net-device'
```

The VM never boots - the serial log stays empty and the boot-sync wait times out. Emit `virtio-net-pci` instead, matching the sibling `virtio-9p-pci` device already used for the workspace share. PCIe is present on every supported architecture, so the pci transport is correct everywhere.

## Software TPM for the tpm2 image

The avocado-vm image ships the `tpm2` distro feature, so systemd waits for `/dev/tpm0` at boot. `vm start` provided no TPM device, so the guest blocked ~90s on the missing `/dev/tpm0` / `/dev/tpmrm0` device units and overran the guest-ready timeout - `vm start` reported a false "guest never became ready" failure even though the VM eventually came up.

Spawn `swtpm` before QEMU and wire the `tpm-tis` backend to its control socket so the guest gets a real TPM 2.0 and boots promptly. When `swtpm` is not installed, fall back to appending `systemd.tpm2_wait=false` to the kernel cmdline so the guest still boots (without a TPM). The swtpm daemon is reaped on `vm stop`.

## Test

`cargo build --all-targets` clean; `cargo test vm` green (93 vm tests pass).
