### PR TITLE
overlay: opt-in build-time preprocessing of overlay files

### DIFF
--- a/src/commands/ext/build.rs
+++ b/src/commands/ext/build.rs
@@ -21,6 +21,8 @@ use crate::utils::tui::{TaskId, TuiGuard};
 struct OverlayConfig {
     dir: String,
     mode: OverlayMode,
+    /// Opt-in `{{ }}` preprocessing of overlay file contents.
+    preprocess: crate::utils::overlay_preprocess::PreprocessSpec,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -292,8 +294,14 @@ impl ExtBuildCommand {
             // is matched against the entry for its (component, command) pair.
             let project_root = config.project_root(&self.config_path);
             let install_inputs = compute_ext_install_input_hash(parsed, &self.extension).ok();
-            let build_inputs =
-                compute_ext_build_input_hash(parsed, &self.extension, &project_root).ok();
+            let build_inputs = compute_ext_build_input_hash(
+                parsed,
+                &self.extension,
+                &project_root,
+                Some(target.as_str()),
+                self.runtime.as_deref(),
+            )
+            .ok();
             let mut current_inputs: Vec<crate::utils::stamps::CurrentInput<'_>> = Vec::new();
             if let Some(ref i) = install_inputs {
                 current_inputs.push((StampComponent::Extension, StampCommand::Install, i));
@@ -554,12 +562,14 @@ impl ExtBuildCommand {
             })?;
 
         // Get overlay configuration
-        let overlay_config = ext_config.get("overlay").map(|v| {
+        let mut overlay_config = ext_config.get("overlay").map(|v| {
+            use crate::utils::overlay_preprocess::PreprocessSpec;
             if let Some(dir_str) = v.as_str() {
                 // Simple string format: overlay = "directory"
                 OverlayConfig {
                     dir: dir_str.to_string(),
                     mode: OverlayMode::Merge, // Default to merge mode
+                    preprocess: PreprocessSpec::None,
                 }
             } else if let Some(table) = v.as_mapping() {
                 // Table format: overlay = {dir = "directory", mode = "opaque"}
@@ -574,12 +584,17 @@ impl ExtBuildCommand {
                     _ => OverlayMode::Merge, // Default to merge mode
                 };
 
-                OverlayConfig { dir, mode }
+                OverlayConfig {
+                    dir,
+                    mode,
+                    preprocess: PreprocessSpec::from_overlay_value(v),
+                }
             } else {
                 // Fallback for invalid format
                 OverlayConfig {
                     dir: "overlay".to_string(),
                     mode: OverlayMode::Merge,
+                    preprocess: PreprocessSpec::None,
                 }
             }
         });
@@ -615,6 +630,65 @@ impl ExtBuildCommand {
             }
             ExtensionLocation::Local { .. } => "/opt/src".to_string(),
         };
+
+        // Opt-in overlay preprocessing (local extensions only). Materialize an
+        // interpolated copy of the overlay on the host under
+        // `.avocado/overlay-staging/` and redirect the in-container copy to it,
+        // so `{{ ... }}` in overlay files is substituted without mutating the
+        // working tree. Remote-extension overlays live in the SDK volume (not on
+        // the host), so they can't be preprocessed here — warn and skip.
+        if let Some(oc) = overlay_config.as_mut() {
+            if oc.preprocess.is_enabled() {
+                match &extension_location {
+                    ExtensionLocation::Local { .. } => {
+                        let project_root = config.project_root(&self.config_path);
+                        let mut context =
+                            crate::utils::interpolation::AvocadoContext::from_main_config(
+                                parsed,
+                                Some(target.as_str()),
+                            );
+                        // The selected runtime drives `{{ avocado.runtime }}` and
+                        // the runtime-scoped target board; from_main_config only
+                        // sees env/default, so override it when one was chosen.
+                        if let Some(rt) = self.runtime.as_deref() {
+                            context.runtime = Some(rt.to_string());
+                        }
+                        let label = format!(
+                            "ext-{}",
+                            self.extension
+                                .chars()
+                                .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' {
+                                    c
+                                } else {
+                                    '_'
+                                })
+                                .collect::<String>()
+                        );
+                        if let Some(staging_rel_dir) =
+                            crate::utils::overlay_preprocess::materialize_preprocessed_overlay(
+                                &project_root,
+                                &oc.dir,
+                                &label,
+                                &oc.preprocess,
+                                parsed,
+                                &context,
+                            )?
+                        {
+                            oc.dir = staging_rel_dir;
+                        }
+                    }
+                    ExtensionLocation::Remote { name, .. } => {
+                        print_warning(
+                            &format!(
+                                "Overlay preprocessing is not supported for remote extension \
+                                 '{name}'; copying overlay verbatim."
+                            ),
+                            OutputLevel::Normal,
+                        );
+                    }
+                }
+            }
+        }
 
         // Run the post_build hook before sealing any .raw images. By this
         // point the ext sysroot has been populated by `avocado install` and
@@ -736,6 +810,8 @@ impl ExtBuildCommand {
                 parsed,
                 &self.extension,
                 &config.project_root(&self.config_path),
+                Some(target.as_str()),
+                self.runtime.as_deref(),
             )?;
             let outputs = StampOutputs::default();
             let stamp = Stamp::ext_build(&self.extension, &target, inputs, outputs);
@@ -1913,6 +1989,7 @@ mod tests {
         let overlay_config = OverlayConfig {
             dir: "peridio".to_string(),
             mode: OverlayMode::Merge,
+            preprocess: crate::utils::overlay_preprocess::PreprocessSpec::None,
         };
         let script = cmd.create_sysext_build_script(
             "1.0",
@@ -1955,6 +2032,7 @@ mod tests {
         let overlay_config = OverlayConfig {
             dir: "peridio".to_string(),
             mode: OverlayMode::Merge,
+            preprocess: crate::utils::overlay_preprocess::PreprocessSpec::None,
         };
         let script = cmd.create_confext_build_script(
             "1.0",
@@ -1997,6 +2075,7 @@ mod tests {
         let overlay_config = OverlayConfig {
             dir: "peridio".to_string(),
             mode: OverlayMode::Opaque,
+            preprocess: crate::utils::overlay_preprocess::PreprocessSpec::None,
         };
         let script = cmd.create_sysext_build_script(
             "1.0",
@@ -2040,6 +2119,7 @@ mod tests {
         let overlay_config = OverlayConfig {
             dir: "peridio".to_string(),
             mode: OverlayMode::Opaque,
+            preprocess: crate::utils::overlay_preprocess::PreprocessSpec::None,
         };
         let script = cmd.create_confext_build_script(
             "1.0",

--- a/src/commands/ext/image.rs
+++ b/src/commands/ext/image.rs
@@ -289,13 +289,21 @@ impl ExtImageCommand {
             // against the matching step's hash.
             let project_root = config.project_root(&self.config_path);
             let install_inputs = compute_ext_install_input_hash(parsed, &self.extension).ok();
-            let build_inputs =
-                compute_ext_build_input_hash(parsed, &self.extension, &project_root).ok();
+            let build_inputs = compute_ext_build_input_hash(
+                parsed,
+                &self.extension,
+                &project_root,
+                Some(target.as_str()),
+                self.runtime.as_deref(),
+            )
+            .ok();
             let image_inputs = compute_ext_image_input_hash(
                 parsed,
                 &self.extension,
                 Some(effective_fs),
                 &project_root,
+                Some(target.as_str()),
+                self.runtime.as_deref(),
             )
             .ok();
             let mut current_inputs: Vec<CurrentInput<'_>> = Vec::new();
@@ -668,6 +676,8 @@ impl ExtImageCommand {
                     &self.extension,
                     Some(filesystem),
                     &config.project_root(&self.config_path),
+                    Some(target.as_str()),
+                    self.runtime.as_deref(),
                 )?;
                 let outputs = StampOutputs::default();
                 let stamp = Stamp::ext_image(&self.extension, &target, inputs, outputs);

--- a/src/commands/rootfs/install.rs
+++ b/src/commands/rootfs/install.rs
@@ -656,21 +656,46 @@ pub async fn install_sysroot(params: &mut SysrootInstallParams<'_>) -> Result<()
 
     // Build optional overlay snippet — appended to the install command so it
     // runs in the same container invocation immediately after DNF finishes.
-    let overlay_snippet = params
-        .parsed
-        .and_then(|parsed| {
+    let overlay_snippet = {
+        let overlay_value = params.parsed.and_then(|parsed| {
             let key = match params.sysroot_type {
                 SysrootType::Rootfs => "rootfs",
                 SysrootType::Initramfs => "initramfs",
                 _ => return None,
             };
-            parsed.get(key)?.get("overlay")
-        })
-        .map(|v| {
-            let (dir, opaque) = parse_overlay_config(v);
-            build_overlay_script(&dir, opaque, sysroot_dir)
-        })
-        .unwrap_or_default();
+            parsed.get(key)?.get("overlay").cloned()
+        });
+        if let (Some(v), Some(parsed)) = (overlay_value, params.parsed) {
+            let (dir, opaque) = parse_overlay_config(&v);
+            // Opt-in preprocessing: materialize an interpolated copy of the
+            // overlay on the host under `.avocado/overlay-staging/` and copy
+            // from there, so `{{ ... }}` in overlay files is substituted without
+            // mutating the working tree.
+            let spec = crate::utils::overlay_preprocess::PreprocessSpec::from_overlay_value(&v);
+            let effective_dir = if spec.is_enabled() {
+                let context = crate::utils::interpolation::AvocadoContext::from_main_config(
+                    parsed,
+                    Some(params.target),
+                );
+                match crate::utils::overlay_preprocess::materialize_preprocessed_overlay(
+                    params.src_dir,
+                    &dir,
+                    sysroot_dir,
+                    &spec,
+                    parsed,
+                    &context,
+                )? {
+                    Some(staging_rel_dir) => staging_rel_dir,
+                    None => dir,
+                }
+            } else {
+                dir
+            };
+            build_overlay_script(&effective_dir, opaque, sysroot_dir)
+        } else {
+            String::new()
+        }
+    };
 
     let exclude_str = if off_kernel_excludes.is_empty() {
         String::new()

--- a/src/utils/interpolation/mod.rs
+++ b/src/utils/interpolation/mod.rs
@@ -194,6 +194,35 @@ pub fn interpolate_config_with_context(
     Ok(())
 }
 
+/// Preprocess `{{ ... }}` templates inside arbitrary file contents (e.g. an
+/// overlay file), using the same `env.`/`config.`/`avocado.` resolution as the
+/// YAML interpolator.
+///
+/// `root` is the composed config tree (for `{{ config.* }}`); `context` carries
+/// the resolved target/board/distro values (for `{{ avocado.* }}`). Missing
+/// `env.*` variables warn and resolve to an empty string, identical to
+/// `avocado.yaml` interpolation. Input that contains no templates is returned
+/// unchanged.
+///
+/// Runs in *lenient* mode: a `{{ ... }}` whose context isn't one of ours (e.g.
+/// Go/Jinja/Helm template syntax an overlay file legitimately ships) is left
+/// untouched instead of aborting the build. Only `env`/`config`/`avocado`
+/// templates are substituted.
+pub fn preprocess_text(input: &str, root: &Value, context: &AvocadoContext) -> Result<String> {
+    let mut resolving_stack = HashSet::new();
+    let path: Vec<String> = Vec::new();
+    Ok(interpolate_string(
+        input,
+        root,
+        context,
+        &mut resolving_stack,
+        &path,
+        &YamlLocation::Value,
+        true,
+    )?
+    .unwrap_or_else(|| input.to_string()))
+}
+
 /// Represents where in the YAML structure a template was found.
 #[derive(Clone, Debug)]
 enum YamlLocation {
@@ -243,7 +272,7 @@ fn interpolate_value(
         Value::String(s) => {
             let location = YamlLocation::Value;
             if let Some(new_value) =
-                interpolate_string(s, root, context, resolving_stack, path, &location)?
+                interpolate_string(s, root, context, resolving_stack, path, &location, false)?
             {
                 *s = new_value;
                 changed = true;
@@ -264,6 +293,7 @@ fn interpolate_value(
                         resolving_stack,
                         path,
                         &location,
+                        false,
                     )? {
                         keys_to_replace.push((k.clone(), Value::String(new_key), v.clone()));
                     }
@@ -326,6 +356,7 @@ fn interpolate_string(
     resolving_stack: &mut HashSet<String>,
     path: &[String],
     location: &YamlLocation,
+    lenient: bool,
 ) -> Result<Option<String>> {
     // Regex to match {{ ... }} templates
     let re = Regex::new(r"\{\{\s*([^}]+)\s*\}\}").unwrap();
@@ -342,7 +373,7 @@ fn interpolate_string(
         let full_match = capture.get(0).unwrap().as_str();
         let template = capture.get(1).unwrap().as_str().trim();
 
-        match resolve_template(template, root, context, resolving_stack) {
+        match resolve_template(template, root, context, resolving_stack, lenient) {
             Ok(Some(replacement)) => {
                 result = result.replace(full_match, &replacement);
                 any_replaced = true;
@@ -380,6 +411,7 @@ fn resolve_template(
     root: &Value,
     context: &AvocadoContext,
     resolving_stack: &mut HashSet<String>,
+    lenient: bool,
 ) -> Result<Option<String>> {
     // Check for circular reference
     if resolving_stack.contains(template) {
@@ -430,9 +462,17 @@ fn resolve_template(
             avocado::resolve(path, root, Some(context))
         }
         _ => {
-            anyhow::bail!(
-                "Unknown template context: {context_name}. Expected 'env', 'config', or 'avocado'"
-            );
+            if lenient {
+                // Overlay preprocessing: a `{{ ... }}` whose context isn't one of
+                // ours (e.g. Go/Jinja/Helm template syntax like `{{ .Values.x }}`
+                // or `{{ range }}`) is left untouched rather than aborting the
+                // build. Only our env/config/avocado templates are substituted.
+                Ok(None)
+            } else {
+                anyhow::bail!(
+                    "Unknown template context: {context_name}. Expected 'env', 'config', or 'avocado'"
+                );
+            }
         }
     };
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -16,6 +16,7 @@ pub mod lockfile;
 pub mod nfs_server;
 pub mod output;
 pub mod output_format;
+pub mod overlay_preprocess;
 pub mod permissions;
 pub mod pkcs11_devices;
 pub mod prerequisites;

--- a/src/utils/overlay_preprocess.rs
+++ b/src/utils/overlay_preprocess.rs
@@ -1,0 +1,539 @@
+//! Host-side materialization of preprocessed overlay trees.
+//!
+//! Overlay files are normally copied verbatim into the rootfs / initramfs /
+//! extension sysroot by a shell `cp` that runs inside the SDK container,
+//! reading the project tree bind-mounted at `/opt/src`. When an overlay opts
+//! into preprocessing (`overlay: { dir, preprocess: ... }`), we must apply
+//! `{{ ... }}` substitution to file contents *without* mutating the user's
+//! working tree. To do that we materialize a processed copy on the host into a
+//! scratch dir under the project root (`.avocado/overlay-staging/<label>/`,
+//! already inside the `/opt/src` bind mount) and point the `cp` at that copy.
+//!
+//! Only local overlays (those living in the project tree on the host) can be
+//! preprocessed; remote-extension overlays live inside the SDK volume and are
+//! copied verbatim (callers warn + skip).
+
+use anyhow::{Context, Result};
+use serde_yaml::Value;
+use std::path::Path;
+
+use crate::utils::interpolation::{preprocess_text, AvocadoContext};
+
+/// Scratch directory (relative to the project root) that holds materialized,
+/// preprocessed overlay trees. Lives under `.avocado/`, which is gitignored
+/// scratch after the lock file moved to the top-level `avocado.lock`.
+const STAGING_SUBDIR: &str = ".avocado/overlay-staging";
+
+/// Which overlay files to run the `{{ }}` preprocessor over.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreprocessSpec {
+    /// No preprocessing — copy the overlay verbatim (default, today's behavior).
+    None,
+    /// Preprocess every UTF-8 file in the overlay.
+    All,
+    /// Preprocess only files whose overlay-relative path matches one of these
+    /// globs (`*` within a segment, `**` across segments, `?` a single char).
+    Globs(Vec<String>),
+}
+
+impl PreprocessSpec {
+    /// True when any preprocessing is requested.
+    pub fn is_enabled(&self) -> bool {
+        !matches!(self, PreprocessSpec::None)
+    }
+
+    /// Parse the `preprocess` key from an `overlay:` mapping value. A bare
+    /// overlay string (no mapping) or an absent/false `preprocess` yields
+    /// [`PreprocessSpec::None`].
+    pub fn from_overlay_value(overlay: &Value) -> Self {
+        let Some(table) = overlay.as_mapping() else {
+            return PreprocessSpec::None;
+        };
+        match table.get("preprocess") {
+            Some(Value::Bool(true)) => PreprocessSpec::All,
+            Some(Value::Sequence(seq)) => {
+                let globs: Vec<String> = seq
+                    .iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect();
+                if globs.is_empty() {
+                    PreprocessSpec::None
+                } else {
+                    PreprocessSpec::Globs(globs)
+                }
+            }
+            _ => PreprocessSpec::None,
+        }
+    }
+
+    /// Whether the file at `rel_path` (overlay-relative, forward slashes) should
+    /// be preprocessed.
+    fn matches(&self, rel_path: &str) -> bool {
+        match self {
+            PreprocessSpec::None => false,
+            PreprocessSpec::All => true,
+            PreprocessSpec::Globs(globs) => globs.iter().any(|g| glob_matches(g, rel_path)),
+        }
+    }
+}
+
+/// Minimal glob matcher against a forward-slash relative path.
+/// `**` matches across separators, `*` matches within a segment, `?` matches a
+/// single non-separator character; all other characters match literally.
+fn glob_matches(pattern: &str, path: &str) -> bool {
+    let mut re = String::from("^");
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '*' => {
+                if chars.peek() == Some(&'*') {
+                    chars.next();
+                    re.push_str(".*");
+                    // Swallow an immediately-following '/' so `**/x` also matches `x`.
+                    if chars.peek() == Some(&'/') {
+                        chars.next();
+                    }
+                } else {
+                    re.push_str("[^/]*");
+                }
+            }
+            '?' => re.push_str("[^/]"),
+            c if "\\.+()|[]{}^$".contains(c) => {
+                re.push('\\');
+                re.push(c);
+            }
+            c => re.push(c),
+        }
+    }
+    re.push('$');
+    regex::Regex::new(&re)
+        .map(|r| r.is_match(path))
+        .unwrap_or(false)
+}
+
+/// Bytes to emit for one overlay file: preprocessed when the spec selects it and
+/// the content is valid UTF-8, otherwise the raw bytes unchanged. Binary files
+/// (non-UTF-8) are never templated, so ELF/images/certs pass through intact.
+fn process_file_bytes(
+    rel_path: &str,
+    raw: Vec<u8>,
+    spec: &PreprocessSpec,
+    root: &Value,
+    context: &AvocadoContext,
+) -> Result<Vec<u8>> {
+    if !spec.matches(rel_path) {
+        return Ok(raw);
+    }
+    match std::str::from_utf8(&raw) {
+        Ok(text) => Ok(preprocess_text(text, root, context)
+            .with_context(|| format!("Failed to preprocess overlay file '{rel_path}'"))?
+            .into_bytes()),
+        // Selected but not UTF-8 → copy verbatim (can't safely template).
+        Err(_) => Ok(raw),
+    }
+}
+
+/// Walk `overlay_src`, invoking `visit(rel_path, entry)` for every file and
+/// symlink in a deterministic (sorted) order. Directories are visited via their
+/// contained entries only.
+fn sorted_entries(overlay_src: &Path) -> Vec<walkdir::DirEntry> {
+    let mut entries: Vec<_> = walkdir::WalkDir::new(overlay_src)
+        .sort_by_file_name()
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .collect();
+    entries.sort_by(|a, b| a.path().cmp(b.path()));
+    entries
+}
+
+/// Overlay-relative, forward-slash path. `Ok(None)` for the overlay root
+/// itself. Errors on a non-UTF-8 path: staging and the digest are string-based,
+/// so `to_string_lossy` would mangle a non-UTF-8 name to U+FFFD (and two such
+/// names could collide / hash equal), unlike the byte-preserving verbatim `cp -a`
+/// path. Reject explicitly rather than silently corrupt.
+fn rel_str(overlay_src: &Path, path: &Path) -> Result<Option<String>> {
+    let rel = match path.strip_prefix(overlay_src) {
+        Ok(r) => r,
+        Err(_) => return Ok(None),
+    };
+    if rel.as_os_str().is_empty() {
+        return Ok(None);
+    }
+    match rel.to_str() {
+        Some(s) => Ok(Some(s.replace('\\', "/"))),
+        None => anyhow::bail!(
+            "Overlay contains a non-UTF-8 path ({}); overlay preprocessing requires UTF-8 \
+             filenames. Scope `preprocess` to specific globs or disable it for this overlay.",
+            path.display()
+        ),
+    }
+}
+
+/// Compute a deterministic digest of the overlay tree *after* preprocessing,
+/// without materializing it to disk. Returns `None` when preprocessing is
+/// disabled or the overlay dir does not exist (so stamps are unchanged for the
+/// verbatim path). Folded into the rootfs/initramfs/ext build input hashes so a
+/// changed template value (e.g. a new claim token) or an edited overlay file
+/// forces a rebuild. Only the SHA-256 is retained — never the plaintext.
+pub fn overlay_content_digest(
+    project_root: &Path,
+    overlay_rel_dir: &str,
+    spec: &PreprocessSpec,
+    root: &Value,
+    context: &AvocadoContext,
+) -> Result<Option<String>> {
+    if !spec.is_enabled() {
+        return Ok(None);
+    }
+    let overlay_src = project_root.join(overlay_rel_dir);
+    if !overlay_src.is_dir() {
+        return Ok(None);
+    }
+
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    for entry in sorted_entries(&overlay_src) {
+        let Some(rel) = rel_str(&overlay_src, entry.path())? else {
+            continue;
+        };
+        let ft = entry.file_type();
+        if ft.is_dir() {
+            // Fold directory modes so a permission drift (e.g. 0700 .ssh widened
+            // to 0755) invalidates the stamp — materialize preserves dir modes.
+            let mode = file_mode(entry.path());
+            hasher.update(format!("D\0{rel}\0{mode:o}\0").as_bytes());
+        } else if ft.is_symlink() {
+            // Fail the same way `materialize` does on an unreadable link, so the
+            // stamp check and the build can't disagree.
+            let target = std::fs::read_link(entry.path()).with_context(|| {
+                format!("Failed to read overlay symlink: {}", entry.path().display())
+            })?;
+            hasher.update(format!("L\0{rel}\0{}\0", target.to_string_lossy()).as_bytes());
+        } else if ft.is_file() {
+            // Propagate read/preprocess errors rather than silently dropping the
+            // digest, which would let a broken overlay skip rebuild invalidation.
+            let raw = std::fs::read(entry.path()).with_context(|| {
+                format!("Failed to read overlay file: {}", entry.path().display())
+            })?;
+            let mode = file_mode(entry.path());
+            let bytes = process_file_bytes(&rel, raw, spec, root, context)?;
+            let file_hash = Sha256::digest(&bytes);
+            hasher.update(format!("F\0{rel}\0{mode:o}\0").as_bytes());
+            hasher.update(file_hash);
+        }
+    }
+    let out = hasher.finalize();
+    let mut hex = String::with_capacity(out.len() * 2);
+    for b in out.iter() {
+        use std::fmt::Write;
+        let _ = write!(hex, "{b:02x}");
+    }
+    Ok(Some(format!("sha256:{hex}")))
+}
+
+#[cfg(unix)]
+fn file_mode(path: &Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|m| m.permissions().mode())
+        .unwrap_or(0o644)
+}
+
+#[cfg(not(unix))]
+fn file_mode(_path: &Path) -> u32 {
+    0o644
+}
+
+/// Materialize a preprocessed copy of `overlay_rel_dir` under
+/// `.avocado/overlay-staging/<label>/` in the project root, returning the
+/// staging dir *relative to the project root* (forward slashes) to hand the
+/// in-container copy — joined onto `/opt/src`.
+///
+/// Returns `Ok(None)` when preprocessing is disabled or the overlay dir is
+/// absent — callers then fall back to copying the original overlay verbatim.
+/// The staging dir is recreated fresh on every call (previous contents are
+/// removed), bounding secret residency to the most recent build; `.avocado/` is
+/// gitignored scratch and cleared by `avocado clean`.
+pub fn materialize_preprocessed_overlay(
+    project_root: &Path,
+    overlay_rel_dir: &str,
+    label: &str,
+    spec: &PreprocessSpec,
+    root: &Value,
+    context: &AvocadoContext,
+) -> Result<Option<String>> {
+    if !spec.is_enabled() {
+        return Ok(None);
+    }
+    let overlay_src = project_root.join(overlay_rel_dir);
+    if !overlay_src.is_dir() {
+        // Missing overlay dir is reported by the copy script itself; nothing to stage.
+        return Ok(None);
+    }
+
+    // Sanitize the label to a single safe path component (defense-in-depth):
+    // the staging dir is later removed with `remove_dir_all`, so never let a
+    // label containing path separators, `..`, or an absolute path escape the
+    // staging root.
+    let safe_label: String = label
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let rel_dir = format!("{STAGING_SUBDIR}/{safe_label}");
+    let staging_dir = project_root.join(&rel_dir);
+
+    // Fresh staging tree each build.
+    if staging_dir.exists() {
+        std::fs::remove_dir_all(&staging_dir).with_context(|| {
+            format!(
+                "Failed to clear overlay staging dir: {}",
+                staging_dir.display()
+            )
+        })?;
+    }
+    std::fs::create_dir_all(&staging_dir).with_context(|| {
+        format!(
+            "Failed to create overlay staging dir: {}",
+            staging_dir.display()
+        )
+    })?;
+
+    for entry in sorted_entries(&overlay_src) {
+        let Some(rel) = rel_str(&overlay_src, entry.path())? else {
+            continue;
+        };
+        let dest = staging_dir.join(&rel);
+        let ft = entry.file_type();
+
+        if ft.is_dir() {
+            std::fs::create_dir_all(&dest)
+                .with_context(|| format!("Failed to create staging dir: {}", dest.display()))?;
+            // Preserve the source directory mode (bare create_dir_all uses the
+            // process umask, which would silently widen e.g. a 0700 dir to 0755).
+            copy_mode(entry.path(), &dest);
+        } else if ft.is_symlink() {
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent).with_context(|| {
+                    format!("Failed to create staging dir: {}", parent.display())
+                })?;
+            }
+            let target = std::fs::read_link(entry.path()).with_context(|| {
+                format!("Failed to read overlay symlink: {}", entry.path().display())
+            })?;
+            recreate_symlink(&target, &dest)?;
+        } else if ft.is_file() {
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent).with_context(|| {
+                    format!("Failed to create staging dir: {}", parent.display())
+                })?;
+            }
+            let raw = std::fs::read(entry.path()).with_context(|| {
+                format!("Failed to read overlay file: {}", entry.path().display())
+            })?;
+            let bytes = process_file_bytes(&rel, raw, spec, root, context)?;
+            std::fs::write(&dest, &bytes)
+                .with_context(|| format!("Failed to write staged file: {}", dest.display()))?;
+            copy_mode(entry.path(), &dest);
+        }
+    }
+
+    Ok(Some(rel_dir))
+}
+
+#[cfg(unix)]
+fn recreate_symlink(target: &Path, dest: &Path) -> Result<()> {
+    std::os::unix::fs::symlink(target, dest)
+        .with_context(|| format!("Failed to create staged symlink: {}", dest.display()))
+}
+
+#[cfg(not(unix))]
+fn recreate_symlink(_target: &Path, _dest: &Path) -> Result<()> {
+    anyhow::bail!("Overlay preprocessing with symlinks is only supported on unix")
+}
+
+#[cfg(unix)]
+fn copy_mode(src: &Path, dest: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(meta) = std::fs::metadata(src) {
+        let _ = std::fs::set_permissions(
+            dest,
+            std::fs::Permissions::from_mode(meta.permissions().mode()),
+        );
+    }
+}
+
+#[cfg(not(unix))]
+fn copy_mode(_src: &Path, _dest: &Path) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> AvocadoContext {
+        AvocadoContext::from_main_config(&Value::Null, Some("qemux86-64"))
+    }
+
+    #[test]
+    fn spec_parsing() {
+        let all: Value = serde_yaml::from_str("dir: overlay\npreprocess: true").unwrap();
+        assert_eq!(
+            PreprocessSpec::from_overlay_value(&all),
+            PreprocessSpec::All
+        );
+
+        let globs: Value =
+            serde_yaml::from_str("dir: overlay\npreprocess:\n  - etc/x.toml").unwrap();
+        assert_eq!(
+            PreprocessSpec::from_overlay_value(&globs),
+            PreprocessSpec::Globs(vec!["etc/x.toml".to_string()])
+        );
+
+        let off: Value = serde_yaml::from_str("dir: overlay").unwrap();
+        assert_eq!(
+            PreprocessSpec::from_overlay_value(&off),
+            PreprocessSpec::None
+        );
+
+        let bare: Value = serde_yaml::from_str("\"overlay\"").unwrap();
+        assert_eq!(
+            PreprocessSpec::from_overlay_value(&bare),
+            PreprocessSpec::None
+        );
+    }
+
+    #[test]
+    fn glob_matching() {
+        assert!(glob_matches(
+            "etc/avocado-conn/config.toml",
+            "etc/avocado-conn/config.toml"
+        ));
+        assert!(glob_matches("etc/*.toml", "etc/config.toml"));
+        assert!(!glob_matches("etc/*.toml", "etc/sub/config.toml"));
+        assert!(glob_matches("**/*.toml", "etc/sub/config.toml"));
+        assert!(glob_matches("**/config.toml", "config.toml"));
+        assert!(!glob_matches("etc/*.toml", "etc/config.yaml"));
+    }
+
+    #[test]
+    fn materialize_templates_selected_utf8_only_and_preserves_binary() {
+        std::env::set_var("OVL_TEST_TOKEN", "s3cret");
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let overlay = root.join("overlay/etc");
+        std::fs::create_dir_all(&overlay).unwrap();
+        std::fs::write(
+            overlay.join("config.toml"),
+            "token = \"{{ env.OVL_TEST_TOKEN }}\"\n",
+        )
+        .unwrap();
+        // A non-selected file keeps its literal braces.
+        std::fs::write(
+            overlay.join("keep.txt"),
+            "literal {{ env.OVL_TEST_TOKEN }}\n",
+        )
+        .unwrap();
+        // A "binary" (invalid UTF-8) file, even if selected, is copied verbatim.
+        std::fs::write(overlay.join("blob.bin"), [0xff, 0xfe, 0x00, 0x01]).unwrap();
+
+        let spec = PreprocessSpec::Globs(vec!["etc/config.toml".into(), "etc/blob.bin".into()]);
+        let out = materialize_preprocessed_overlay(
+            root,
+            "overlay",
+            "rootfs",
+            &spec,
+            &Value::Null,
+            &ctx(),
+        )
+        .unwrap()
+        .expect("staging produced");
+
+        let staged = root.join(&out);
+        assert_eq!(
+            std::fs::read_to_string(staged.join("etc/config.toml")).unwrap(),
+            "token = \"s3cret\"\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(staged.join("etc/keep.txt")).unwrap(),
+            "literal {{ env.OVL_TEST_TOKEN }}\n"
+        );
+        assert_eq!(
+            std::fs::read(staged.join("etc/blob.bin")).unwrap(),
+            vec![0xff, 0xfe, 0x00, 0x01]
+        );
+    }
+
+    #[test]
+    fn foreign_templates_are_left_literal_not_aborted() {
+        // A `preprocess: true` overlay may contain foreign `{{ }}` (Go/Jinja/
+        // Helm) that isn't our env/config/avocado context. Those must pass
+        // through untouched rather than aborting the build; only our templates
+        // are substituted.
+        std::env::set_var("OVL_KEEP_TOKEN", "resolved");
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("overlay/etc")).unwrap();
+        std::fs::write(
+            root.join("overlay/etc/tmpl.conf"),
+            "a={{ .Values.name }} b={{ range .x }} c={{ env.OVL_KEEP_TOKEN }}\n",
+        )
+        .unwrap();
+
+        let spec = PreprocessSpec::All;
+        let out = materialize_preprocessed_overlay(
+            root,
+            "overlay",
+            "rootfs",
+            &spec,
+            &Value::Null,
+            &ctx(),
+        )
+        .unwrap()
+        .expect("staging produced");
+
+        // Foreign templates preserved verbatim; our `{{ env.* }}` substituted.
+        assert_eq!(
+            std::fs::read_to_string(root.join(&out).join("etc/tmpl.conf")).unwrap(),
+            "a={{ .Values.name }} b={{ range .x }} c=resolved\n"
+        );
+    }
+
+    #[test]
+    fn digest_changes_with_template_value() {
+        std::env::set_var("OVL_DIGEST_TOKEN", "aaa");
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("overlay/etc")).unwrap();
+        std::fs::write(
+            root.join("overlay/etc/config.toml"),
+            "token = \"{{ env.OVL_DIGEST_TOKEN }}\"\n",
+        )
+        .unwrap();
+        let spec = PreprocessSpec::Globs(vec!["etc/config.toml".into()]);
+
+        let h1 = overlay_content_digest(root, "overlay", &spec, &Value::Null, &ctx())
+            .unwrap()
+            .unwrap();
+        std::env::set_var("OVL_DIGEST_TOKEN", "bbb");
+        let h2 = overlay_content_digest(root, "overlay", &spec, &Value::Null, &ctx())
+            .unwrap()
+            .unwrap();
+        assert_ne!(h1, h2, "digest must change when a templated value changes");
+
+        // Disabled spec yields no digest (verbatim path unchanged).
+        assert!(overlay_content_digest(
+            root,
+            "overlay",
+            &PreprocessSpec::None,
+            &Value::Null,
+            &ctx()
+        )
+        .unwrap()
+        .is_none());
+    }
+}

--- a/src/utils/stamps.rs
+++ b/src/utils/stamps.rs
@@ -892,6 +892,57 @@ fn script_hash_value(project_root: &Path, rel_path: &str) -> serde_yaml::Value {
     serde_yaml::Value::Mapping(m)
 }
 
+/// Fold a digest of an overlay's post-preprocessing tree into `hash_data` under
+/// `key`, but only when the overlay opts into preprocessing
+/// (`overlay: { ..., preprocess: ... }`). For verbatim overlays this is a no-op,
+/// preserving today's hashing (which keys only on the overlay config value, not
+/// file contents). When enabled, a changed template value (e.g. a new claim
+/// token) or an edited overlay file changes the digest and forces a rebuild.
+/// Only the SHA-256 is stored — never the resolved plaintext.
+fn fold_overlay_content_hash(
+    hash_data: &mut serde_yaml::Mapping,
+    key: &str,
+    overlay: &serde_yaml::Value,
+    config: &serde_yaml::Value,
+    project_root: &Path,
+    target: Option<&str>,
+    runtime: Option<&str>,
+) -> Result<()> {
+    use crate::utils::overlay_preprocess::PreprocessSpec;
+    let spec = PreprocessSpec::from_overlay_value(overlay);
+    if !spec.is_enabled() {
+        return Ok(());
+    }
+    let dir = overlay
+        .get("dir")
+        .and_then(|d| d.as_str())
+        .unwrap_or("overlay");
+    // Build the same interpolation context the build's materialize step uses, so
+    // the digest reflects the exact rendered overlay content. `target` keeps
+    // `{{ avocado.target/board }}` accurate; `runtime` (for the ext path) makes
+    // `{{ avocado.runtime }}`-dependent content invalidate the stamp when the
+    // selected runtime changes — the ext-build stamp isn't otherwise runtime-keyed.
+    let mut context = crate::utils::interpolation::AvocadoContext::from_main_config(config, target);
+    if let Some(rt) = runtime {
+        context.runtime = Some(rt.to_string());
+    }
+    // Propagate digest errors rather than dropping the content hash, which would
+    // let a broken overlay silently skip rebuild invalidation.
+    if let Some(digest) = crate::utils::overlay_preprocess::overlay_content_digest(
+        project_root,
+        dir,
+        &spec,
+        config,
+        &context,
+    )? {
+        hash_data.insert(
+            serde_yaml::Value::String(key.to_string()),
+            serde_yaml::Value::String(digest),
+        );
+    }
+    Ok(())
+}
+
 /// Compute input hash for SDK install
 ///
 /// Includes only inputs that affect the SDK toolchain install itself:
@@ -1037,8 +1088,10 @@ pub fn compute_ext_build_input_hash(
     config: &serde_yaml::Value,
     ext_name: &str,
     project_root: &Path,
+    target: Option<&str>,
+    runtime: Option<&str>,
 ) -> Result<StampInputs> {
-    let hash_data = ext_build_hash_data(config, ext_name, project_root);
+    let hash_data = ext_build_hash_data(config, ext_name, project_root, target, runtime)?;
     let config_hash = compute_config_hash(&serde_yaml::Value::Mapping(hash_data))?;
     Ok(StampInputs::new(config_hash))
 }
@@ -1052,8 +1105,10 @@ pub fn compute_ext_image_input_hash(
     ext_name: &str,
     filesystem: Option<&str>,
     project_root: &Path,
+    target: Option<&str>,
+    runtime: Option<&str>,
 ) -> Result<StampInputs> {
-    let mut hash_data = ext_build_hash_data(config, ext_name, project_root);
+    let mut hash_data = ext_build_hash_data(config, ext_name, project_root, target, runtime)?;
 
     if let Some(ext) = config.get("extensions").and_then(|e| e.get(ext_name)) {
         if let Some(var_files) = ext.get("var_files") {
@@ -1087,7 +1142,9 @@ fn ext_build_hash_data(
     config: &serde_yaml::Value,
     ext_name: &str,
     project_root: &Path,
-) -> serde_yaml::Mapping {
+    target: Option<&str>,
+    runtime: Option<&str>,
+) -> Result<serde_yaml::Mapping> {
     let mut hash_data = serde_yaml::Mapping::new();
 
     if let Some(ext) = config.get("extensions").and_then(|e| e.get(ext_name)) {
@@ -1123,6 +1180,15 @@ fn ext_build_hash_data(
                 serde_yaml::Value::String(format!("ext.{ext_name}.overlay")),
                 overlay.clone(),
             );
+            fold_overlay_content_hash(
+                &mut hash_data,
+                &format!("ext.{ext_name}.overlay_content"),
+                overlay,
+                config,
+                project_root,
+                target,
+                runtime,
+            )?;
         }
         if let Some(post_build) = ext.get("post_build").and_then(|v| v.as_str()) {
             hash_data.insert(
@@ -1132,7 +1198,7 @@ fn ext_build_hash_data(
         }
     }
 
-    hash_data
+    Ok(hash_data)
 }
 
 /// Compute input hash for **rootfs install**.
@@ -1160,6 +1226,15 @@ pub fn compute_rootfs_input_hash(
                 serde_yaml::Value::String("rootfs.overlay".to_string()),
                 overlay.clone(),
             );
+            fold_overlay_content_hash(
+                &mut hash_data,
+                "rootfs.overlay_content",
+                overlay,
+                config,
+                project_root,
+                None,
+                None,
+            )?;
         }
         if let Some(post_install) = rootfs.get("post_install").and_then(|v| v.as_str()) {
             hash_data.insert(
@@ -1202,6 +1277,15 @@ pub fn compute_initramfs_input_hash(
                 serde_yaml::Value::String("initramfs.overlay".to_string()),
                 overlay.clone(),
             );
+            fold_overlay_content_hash(
+                &mut hash_data,
+                "initramfs.overlay_content",
+                overlay,
+                config,
+                project_root,
+                None,
+                None,
+            )?;
         }
         if let Some(post_install) = initramfs.get("post_install").and_then(|v| v.as_str()) {
             hash_data.insert(
@@ -2968,11 +3052,19 @@ extensions:
             "my-ext",
             None,
             std::path::Path::new("."),
+            None,
+            None,
         )
         .unwrap();
-        let hash_with =
-            compute_ext_image_input_hash(&config_with, "my-ext", None, std::path::Path::new("."))
-                .unwrap();
+        let hash_with = compute_ext_image_input_hash(
+            &config_with,
+            "my-ext",
+            None,
+            std::path::Path::new("."),
+            None,
+            None,
+        )
+        .unwrap();
 
         assert_ne!(
             hash_without.config_hash, hash_with.config_hash,
@@ -3115,11 +3207,19 @@ extensions:
             "my-ext",
             None,
             std::path::Path::new("."),
+            None,
+            None,
         )
         .unwrap();
-        let hash_with =
-            compute_ext_image_input_hash(&config_with, "my-ext", None, std::path::Path::new("."))
-                .unwrap();
+        let hash_with = compute_ext_image_input_hash(
+            &config_with,
+            "my-ext",
+            None,
+            std::path::Path::new("."),
+            None,
+            None,
+        )
+        .unwrap();
 
         assert_ne!(
             hash_without.config_hash, hash_with.config_hash,
@@ -3202,13 +3302,13 @@ extensions:
     }
 
     fn ext_build_hash(value: &serde_yaml::Value) -> String {
-        compute_ext_build_input_hash(value, "my-ext", std::path::Path::new("."))
+        compute_ext_build_input_hash(value, "my-ext", std::path::Path::new("."), None, None)
             .unwrap()
             .config_hash
     }
 
     fn ext_image_hash(value: &serde_yaml::Value) -> String {
-        compute_ext_image_input_hash(value, "my-ext", None, std::path::Path::new("."))
+        compute_ext_image_input_hash(value, "my-ext", None, std::path::Path::new("."), None, None)
             .unwrap()
             .config_hash
     }
@@ -3279,12 +3379,12 @@ extensions:
         std::fs::write(&script, b"#!/bin/sh\necho original\n").unwrap();
 
         let config = ext_with_extras("    post_build: build.sh");
-        let h1 = compute_ext_build_input_hash(&config, "my-ext", tmp.path())
+        let h1 = compute_ext_build_input_hash(&config, "my-ext", tmp.path(), None, None)
             .unwrap()
             .config_hash;
 
         std::fs::write(&script, b"#!/bin/sh\necho edited\n").unwrap();
-        let h2 = compute_ext_build_input_hash(&config, "my-ext", tmp.path())
+        let h2 = compute_ext_build_input_hash(&config, "my-ext", tmp.path(), None, None)
             .unwrap()
             .config_hash;
 
@@ -3523,6 +3623,118 @@ rootfs:
             .config_hash;
 
         assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn rootfs_preprocessed_overlay_value_change_invalidates() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("overlay/etc")).unwrap();
+        std::fs::write(
+            tmp.path().join("overlay/etc/config.toml"),
+            "token = \"{{ env.STAMP_OVL_TOKEN }}\"\n",
+        )
+        .unwrap();
+
+        let config: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+rootfs:
+  packages:
+    avocado-pkg-rootfs: "*"
+  overlay:
+    dir: overlay
+    preprocess:
+      - etc/config.toml
+"#,
+        )
+        .unwrap();
+
+        std::env::set_var("STAMP_OVL_TOKEN", "aaa");
+        let h1 = compute_rootfs_input_hash(&config, tmp.path())
+            .unwrap()
+            .config_hash;
+        std::env::set_var("STAMP_OVL_TOKEN", "bbb");
+        let h2 = compute_rootfs_input_hash(&config, tmp.path())
+            .unwrap()
+            .config_hash;
+
+        // Changing a value referenced by a preprocessed overlay file must
+        // invalidate the rootfs install hash so the image rebuilds.
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn ext_build_hash_reflects_selected_runtime_for_preprocessed_overlay() {
+        // An ext overlay whose content depends on `{{ avocado.runtime }}` must
+        // produce different build hashes per selected runtime, so switching
+        // runtimes doesn't reuse a stale artifact (the ext-build stamp isn't
+        // otherwise runtime-keyed).
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("overlay/etc")).unwrap();
+        std::fs::write(
+            tmp.path().join("overlay/etc/r.conf"),
+            "runtime = {{ avocado.runtime }}\n",
+        )
+        .unwrap();
+        let config: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions:
+  my-ext:
+    overlay:
+      dir: overlay
+      preprocess:
+        - etc/r.conf
+"#,
+        )
+        .unwrap();
+
+        let h_dev = compute_ext_build_input_hash(
+            &config,
+            "my-ext",
+            tmp.path(),
+            Some("qemux86-64"),
+            Some("dev"),
+        )
+        .unwrap()
+        .config_hash;
+        let h_prod = compute_ext_build_input_hash(
+            &config,
+            "my-ext",
+            tmp.path(),
+            Some("qemux86-64"),
+            Some("prod"),
+        )
+        .unwrap()
+        .config_hash;
+        assert_ne!(h_dev, h_prod);
+    }
+
+    #[test]
+    fn rootfs_verbatim_overlay_ignores_file_contents() {
+        // Without `preprocess`, the hash keys only on the overlay config value,
+        // not file contents (today's behavior) — no content digest is folded in.
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("overlay/etc")).unwrap();
+        std::fs::write(tmp.path().join("overlay/etc/f.txt"), "v1").unwrap();
+
+        let config: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+rootfs:
+  packages:
+    avocado-pkg-rootfs: "*"
+  overlay:
+    dir: overlay
+"#,
+        )
+        .unwrap();
+
+        let h1 = compute_rootfs_input_hash(&config, tmp.path())
+            .unwrap()
+            .config_hash;
+        std::fs::write(tmp.path().join("overlay/etc/f.txt"), "v2-different").unwrap();
+        let h2 = compute_rootfs_input_hash(&config, tmp.path())
+            .unwrap()
+            .config_hash;
+        assert_eq!(h1, h2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds opt-in `{{ … }}` preprocessing of overlay file *contents* at build time,
so values (e.g. a secret such as an API/claim token) can be templated into
overlay files without mutating the working tree.

## Usage

```yaml
overlay:
  dir: overlay
  preprocess:                 # opt-in; default off = byte-identical to today
    - "etc/some/config.toml"  # globs, or `preprocess: true` for all UTF-8 files
```

The committed overlay file holds e.g. `token = "{{ env.SOME_TOKEN }}"`; the
value is substituted only into the built image, never back into the tree.

## Details

- Reuses the existing `env.` / `config.` / `avocado.` interpolation engine via a
  new `preprocess_text` (no new templating language).
- Overlay files are copied verbatim inside the SDK container, so a processed
  copy is materialized on the host into `.avocado/overlay-staging/<label>/`
  (gitignored scratch, inside the `/opt/src` bind mount) and the copy is pointed
  there.
- Binary (non-UTF-8) files pass through verbatim; symlinks and mode bits are
  preserved.
- Wired into the rootfs/initramfs and sysext/confext overlay copy sites. Local
  overlays only; remote-extension overlays warn + skip.
- Stamps fold a post-preprocess content digest into the rootfs/initramfs/ext
  input hashes when preprocessing is enabled, so a changed template value or an
  edited overlay file invalidates the build. Verbatim overlays are unchanged.

## Testing

- Unit tests for `preprocess_text`, glob matching, binary passthrough, and stamp
  invalidation on a changed template value.
- `cargo build`, `cargo test`, and `cargo clippy` are green.
