### PR TITLE
honor target-<name>: overrides for rootfs/initramfs/kernel sections

### DIFF
--- a/src/commands/initramfs/image.rs
+++ b/src/commands/initramfs/image.rs
@@ -218,7 +218,16 @@ impl InitramfsImageCommand {
         print_info("Building initramfs image.", OutputLevel::Normal);
 
         let initramfs_filesystem = config.get_initramfs_filesystem();
-        let initramfs_node = composed.merged_value.get("initramfs");
+        // Honor per-target `target-<name>:` overrides inside the `initramfs:`
+        // section (e.g. a custom `--tag`). Apply the same override merge
+        // extensions use, but on the already-composed value so path-based
+        // sources (merge_path_based_image_sections) are preserved.
+        let initramfs_merged = composed
+            .merged_value
+            .get("initramfs")
+            .cloned()
+            .map(|v| config.resolve_overrides_in_value(v, &target_arch, None, "initramfs"));
+        let initramfs_node = initramfs_merged.as_ref();
         let post_install = get_post_install(initramfs_node);
         let permissions_section = config
             .initramfs_default()

--- a/src/commands/initramfs/image.rs
+++ b/src/commands/initramfs/image.rs
@@ -219,14 +219,11 @@ impl InitramfsImageCommand {
 
         let initramfs_filesystem = config.get_initramfs_filesystem();
         // Honor per-target `target-<name>:` overrides inside the `initramfs:`
-        // section (e.g. a custom `--tag`). Apply the same override merge
-        // extensions use, but on the already-composed value so path-based
-        // sources (merge_path_based_image_sections) are preserved.
-        let initramfs_merged = composed
-            .merged_value
-            .get("initramfs")
-            .cloned()
-            .map(|v| config.resolve_overrides_in_value(v, &target_arch, None, "initramfs"));
+        // section (e.g. a custom `--tag`). Resolved on the already-composed
+        // value so path-based sources (merge_path_based_image_sections) are
+        // preserved.
+        let initramfs_merged =
+            config.resolve_image_section(&composed.merged_value, "initramfs", &target_arch);
         let initramfs_node = initramfs_merged.as_ref();
         let post_install = get_post_install(initramfs_node);
         let permissions_section = config

--- a/src/commands/kernel/image.rs
+++ b/src/commands/kernel/image.rs
@@ -106,7 +106,16 @@ impl KernelImageCommand {
 
         print_info("Building kernel image.", OutputLevel::Normal);
 
-        let kernel_node = composed.merged_value.get("kernel");
+        // Honor per-target `target-<name>:` overrides inside the `kernel:`
+        // section (e.g. a custom `--tag`). Apply the same override merge
+        // extensions use, but on the already-composed value so path-based
+        // sources (merge_path_based_image_sections) are preserved.
+        let kernel_merged = composed
+            .merged_value
+            .get("kernel")
+            .cloned()
+            .map(|v| config.resolve_overrides_in_value(v, &target_arch, None, "kernel"));
+        let kernel_node = kernel_merged.as_ref();
         let image_type = kernel_node
             .and_then(get_ext_image_type)
             .unwrap_or_else(|| "raw".to_string());

--- a/src/commands/kernel/image.rs
+++ b/src/commands/kernel/image.rs
@@ -107,14 +107,13 @@ impl KernelImageCommand {
         print_info("Building kernel image.", OutputLevel::Normal);
 
         // Honor per-target `target-<name>:` overrides inside the `kernel:`
-        // section (e.g. a custom `--tag`). Apply the same override merge
-        // extensions use, but on the already-composed value so path-based
-        // sources (merge_path_based_image_sections) are preserved.
-        let kernel_merged = composed
-            .merged_value
-            .get("kernel")
-            .cloned()
-            .map(|v| config.resolve_overrides_in_value(v, &target_arch, None, "kernel"));
+        // section (e.g. a custom `--tag`). Resolved on the already-composed
+        // value so path-based sources (merge_path_based_image_sections) are
+        // preserved. `kernel-<spec>:` overrides can't be applied here (the
+        // kernel version isn't known until inside the container), so the helper
+        // warns rather than silently dropping them.
+        let kernel_merged =
+            config.resolve_image_section(&composed.merged_value, "kernel", &target_arch);
         let kernel_node = kernel_merged.as_ref();
         let image_type = kernel_node
             .and_then(get_ext_image_type)

--- a/src/commands/rootfs/image.rs
+++ b/src/commands/rootfs/image.rs
@@ -287,7 +287,16 @@ impl RootfsImageCommand {
         print_info("Building rootfs image.", OutputLevel::Normal);
 
         let rootfs_filesystem = config.get_rootfs_filesystem();
-        let rootfs_node = composed.merged_value.get("rootfs");
+        // Honor per-target `target-<name>:` overrides inside the `rootfs:`
+        // section (e.g. a custom `--tag`). Apply the same override merge
+        // extensions use, but on the already-composed value so path-based
+        // rootfs sources (merge_path_based_image_sections) are preserved.
+        let rootfs_merged = composed
+            .merged_value
+            .get("rootfs")
+            .cloned()
+            .map(|v| config.resolve_overrides_in_value(v, &target_arch, None, "rootfs"));
+        let rootfs_node = rootfs_merged.as_ref();
         let post_install = get_post_install(rootfs_node);
         let permissions_section = config
             .rootfs_default()

--- a/src/commands/rootfs/image.rs
+++ b/src/commands/rootfs/image.rs
@@ -288,14 +288,11 @@ impl RootfsImageCommand {
 
         let rootfs_filesystem = config.get_rootfs_filesystem();
         // Honor per-target `target-<name>:` overrides inside the `rootfs:`
-        // section (e.g. a custom `--tag`). Apply the same override merge
-        // extensions use, but on the already-composed value so path-based
-        // rootfs sources (merge_path_based_image_sections) are preserved.
-        let rootfs_merged = composed
-            .merged_value
-            .get("rootfs")
-            .cloned()
-            .map(|v| config.resolve_overrides_in_value(v, &target_arch, None, "rootfs"));
+        // section (e.g. a custom `--tag`). Resolved on the already-composed
+        // value so path-based rootfs sources (merge_path_based_image_sections)
+        // are preserved.
+        let rootfs_merged =
+            config.resolve_image_section(&composed.merged_value, "rootfs", &target_arch);
         let rootfs_node = rootfs_merged.as_ref();
         let post_install = get_post_install(rootfs_node);
         let permissions_section = config

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -1389,27 +1389,28 @@ fi"#
                 .join(" ")
         };
 
-        // Resolve `image:` config for rootfs / initramfs / kernel. Same
-        // dynamic accessors as extensions — the helpers don't care about
-        // the parent yaml node's identity.
-        let resolve_img = |yaml_key: &str| -> (String, Option<String>) {
-            // Honor per-target `target-<name>:` overrides (e.g. a custom
-            // `--tag`) inside the rootfs/initramfs/kernel section, matching the
-            // standalone `avocado <role> image` commands.
-            let merged = parsed
-                .get(yaml_key)
-                .cloned()
-                .map(|v| config.resolve_overrides_in_value(v, target_arch, None, yaml_key));
-            let node = merged.as_ref();
-            let t = node
+        // Resolve the rootfs / initramfs / kernel sections once, folding in
+        // per-target `target-<name>:` overrides (e.g. a custom `--tag`) to match
+        // the standalone `avocado <role> image` commands. Resolving once here
+        // means every reader below (image type/args *and* `post_install`) sees
+        // the same per-target node instead of the raw section.
+        let rootfs_section = config.resolve_image_section(parsed, "rootfs", target_arch);
+        let initramfs_section = config.resolve_image_section(parsed, "initramfs", target_arch);
+        let kernel_section = config.resolve_image_section(parsed, "kernel", target_arch);
+
+        // Extract `image:` type/args from an already-resolved section. Same
+        // dynamic accessors as extensions — the helpers don't care about the
+        // parent yaml node's identity.
+        let resolve_img = |section: Option<&serde_yaml::Value>| -> (String, Option<String>) {
+            let t = section
                 .and_then(crate::utils::config::get_ext_image_type)
                 .unwrap_or_else(|| "raw".to_string());
-            let a = node.and_then(crate::utils::config::get_ext_image_args);
+            let a = section.and_then(crate::utils::config::get_ext_image_args);
             (t, a)
         };
-        let (rootfs_image_type, rootfs_image_args) = resolve_img("rootfs");
-        let (initramfs_image_type, initramfs_image_args) = resolve_img("initramfs");
-        let (kernel_image_type, kernel_image_args) = resolve_img("kernel");
+        let (rootfs_image_type, rootfs_image_args) = resolve_img(rootfs_section.as_ref());
+        let (initramfs_image_type, initramfs_image_args) = resolve_img(initramfs_section.as_ref());
+        let (kernel_image_type, kernel_image_args) = resolve_img(kernel_section.as_ref());
 
         // Default kabtool args mirror ext/image.rs:879. Used when the
         // config provides `image: { type: kab }` without an explicit `args`.
@@ -2268,7 +2269,10 @@ echo "Docker image priming complete.""#,
             .resolve_runtime_initramfs(&self.runtime_name)
             .or_else(|| config.initramfs_default());
 
-        let rootfs_post_install = get_post_install(parsed.get("rootfs"));
+        // Read `post_install` from the per-target-resolved section (not raw
+        // `parsed`) so a `target-<name>:` override's script is honored, matching
+        // how the image tag override is applied above.
+        let rootfs_post_install = get_post_install(rootfs_section.as_ref());
         let rootfs_permissions_section = render_perms(resolved_rootfs, "$ROOTFS_WORK/etc");
         let rootfs_build_section = generate_rootfs_build_script(
             NAMESPACE_UUID,
@@ -2277,7 +2281,7 @@ echo "Docker image priming complete.""#,
             &rootfs_permissions_section,
         );
 
-        let initramfs_post_install = get_post_install(parsed.get("initramfs"));
+        let initramfs_post_install = get_post_install(initramfs_section.as_ref());
         let initramfs_permissions_section = render_perms(resolved_initramfs, "$INITRAMFS_WORK/etc");
         let initramfs_build_section = generate_initramfs_build_script(
             NAMESPACE_UUID,

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -1393,7 +1393,14 @@ fi"#
         // dynamic accessors as extensions — the helpers don't care about
         // the parent yaml node's identity.
         let resolve_img = |yaml_key: &str| -> (String, Option<String>) {
-            let node = parsed.get(yaml_key);
+            // Honor per-target `target-<name>:` overrides (e.g. a custom
+            // `--tag`) inside the rootfs/initramfs/kernel section, matching the
+            // standalone `avocado <role> image` commands.
+            let merged = parsed
+                .get(yaml_key)
+                .cloned()
+                .map(|v| config.resolve_overrides_in_value(v, target_arch, None, yaml_key));
+            let node = merged.as_ref();
             let t = node
                 .and_then(crate::utils::config::get_ext_image_type)
                 .unwrap_or_else(|| "raw".to_string());

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -60,11 +60,13 @@ mod named_or_single_deserializer {
                 .map(|s| s.starts_with("target-") || s.starts_with("kernel-"))
                 .unwrap_or(false)
         };
+        let original_len = mapping.len();
         let mapping: serde_yaml::Mapping = mapping
             .iter()
             .filter(|(k, _)| !is_override_key(k))
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
+        let had_override_keys = mapping.len() != original_len;
 
         let known: std::collections::HashSet<&str> = field_names.iter().copied().collect();
         let total = mapping.len();
@@ -77,7 +79,19 @@ mod named_or_single_deserializer {
         let value = serde_yaml::Value::Mapping(mapping);
 
         if field_key_count == 0 {
-            // Named-map form.
+            // Named-map form. `target-<name>:`/`kernel-<spec>:` overrides only
+            // make sense inside singleton form (they override the singleton's
+            // config fields), so their presence here means the section has no
+            // recognized config fields to override — most likely a mis-indented
+            // or misplaced override. Reject it rather than silently dropping it.
+            if had_override_keys {
+                return Err(de::Error::custom(format!(
+                    "{kind_label}: `target-<name>:`/`kernel-<spec>:` override keys are only valid \
+                     in singleton form (alongside config field keys like `{}`), not in named-map \
+                     form",
+                    field_names.join("`, `")
+                )));
+            }
             let named: HashMap<String, T> =
                 serde_yaml::from_value(value).map_err(de::Error::custom)?;
             return Ok(Some(named));
@@ -10850,6 +10864,74 @@ rootfs:
         // neither singleton fields nor named-map entries in the typed struct.
         assert!(rootfs.contains_key("default"));
         assert_eq!(rootfs.len(), 1);
+    }
+
+    #[test]
+    fn test_initramfs_target_override_keys_do_not_trip_mixed_form() {
+        // Same as the rootfs case, but for the `initramfs:` section.
+        let yaml = r#"
+initramfs:
+  image:
+    type: kab
+    args: '-b -t kos.layer.initramfs --tag base'
+  target-qemux86-64:
+    image:
+      args: '-b -t kos.layer.initramfs --tag qemu-x64'
+  target-qemuarm64:
+    image:
+      args: '-b -t kos.layer.initramfs --tag qemu-arm64'
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let initramfs = config.initramfs.as_ref().unwrap();
+        assert!(initramfs.contains_key("default"));
+        assert_eq!(initramfs.len(), 1);
+    }
+
+    #[test]
+    fn test_kernel_target_override_keys_do_not_trip_mixed_form() {
+        // The `kernel:` section honors both `target-<name>:` and `kernel-<spec>:`
+        // override sub-keys; neither must trip the mix-of-forms guard.
+        let yaml = r#"
+kernel:
+  image:
+    type: kab
+    args: '-b -t kos.layer.kernel --tag base'
+  target-qemux86-64:
+    image:
+      args: '-b -t kos.layer.kernel --tag qemu-x64'
+  kernel-6.6:
+    image:
+      args: '-b -t kos.layer.kernel --tag kernel-6-6'
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let kernel = config.kernel.as_ref().unwrap();
+        assert!(kernel.contains_key("default"));
+        assert_eq!(kernel.len(), 1);
+    }
+
+    #[test]
+    fn test_override_keys_in_named_map_form_are_rejected() {
+        // Override sub-keys only make sense in singleton form. When a section is
+        // in named-map form (no recognized config fields at the top level), a
+        // stray `target-*`/`kernel-*` key is almost certainly a mistake and must
+        // be rejected rather than silently dropped.
+        let yaml = r#"
+rootfs:
+  main:
+    image:
+      type: kab
+      args: '-b -t kos.layer.rootfs'
+  target-qemux86-64:
+    image:
+      args: '-b -t kos.layer.rootfs --tag qemu-x64'
+"#;
+        let err = serde_yaml::from_str::<Config>(yaml)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("override keys are only valid") && err.contains("rootfs"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -50,6 +50,22 @@ mod named_or_single_deserializer {
             }
         };
 
+        // Per-target / per-kernel override sub-keys (`target-<name>:`,
+        // `kernel-<spec>:`) are resolved later by the image commands on the raw
+        // composed value. Drop them before shape inference and the typed
+        // deserialize below, so a `rootfs: { image: ..., target-qemux86-64: ... }`
+        // isn't mistaken for a mix of singleton + named-map forms.
+        let is_override_key = |k: &serde_yaml::Value| {
+            k.as_str()
+                .map(|s| s.starts_with("target-") || s.starts_with("kernel-"))
+                .unwrap_or(false)
+        };
+        let mapping: serde_yaml::Mapping = mapping
+            .iter()
+            .filter(|(k, _)| !is_override_key(k))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
         let known: std::collections::HashSet<&str> = field_names.iter().copied().collect();
         let total = mapping.len();
         let field_key_count = mapping
@@ -57,6 +73,8 @@ mod named_or_single_deserializer {
             .filter_map(|(k, _)| k.as_str())
             .filter(|s| known.contains(s))
             .count();
+
+        let value = serde_yaml::Value::Mapping(mapping);
 
         if field_key_count == 0 {
             // Named-map form.
@@ -10807,6 +10825,31 @@ rootfs:
             err.contains("cannot mix") && err.contains("rootfs"),
             "got: {err}"
         );
+    }
+
+    #[test]
+    fn test_rootfs_target_override_keys_do_not_trip_mixed_form() {
+        // Per-target override sub-keys inside a singleton rootfs must not trip
+        // the mix-of-forms guard; they are stripped from the typed struct
+        // (the image command resolves them on the raw composed value for the tag).
+        let yaml = r#"
+rootfs:
+  image:
+    type: kab
+    args: '-b -t kos.layer.rootfs --tag base'
+  target-qemux86-64:
+    image:
+      args: '-b -t kos.layer.rootfs --tag qemu-x64'
+  target-qemuarm64:
+    image:
+      args: '-b -t kos.layer.rootfs --tag qemu-arm64'
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let rootfs = config.rootfs.as_ref().unwrap();
+        // Only the synthesized `default` singleton entry; override keys are
+        // neither singleton fields nor named-map entries in the typed struct.
+        assert!(rootfs.contains_key("default"));
+        assert_eq!(rootfs.len(), 1);
     }
 
     #[test]

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -41,7 +41,7 @@ mod named_or_single_deserializer {
         if value.is_null() {
             return Ok(None);
         }
-        let mapping = match &value {
+        let mut mapping = match value {
             serde_yaml::Value::Mapping(m) => m,
             _ => {
                 return Err(de::Error::custom(format!(
@@ -50,52 +50,46 @@ mod named_or_single_deserializer {
             }
         };
 
-        // Per-target / per-kernel override sub-keys (`target-<name>:`,
-        // `kernel-<spec>:`) are resolved later by the image commands on the raw
-        // composed value. Drop them before shape inference and the typed
-        // deserialize below, so a `rootfs: { image: ..., target-qemux86-64: ... }`
-        // isn't mistaken for a mix of singleton + named-map forms.
-        let is_override_key = |k: &serde_yaml::Value| {
-            k.as_str()
-                .map(|s| s.starts_with("target-") || s.starts_with("kernel-"))
-                .unwrap_or(false)
-        };
-        let original_len = mapping.len();
-        let mapping: serde_yaml::Mapping = mapping
-            .iter()
-            .filter(|(k, _)| !is_override_key(k))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-        let had_override_keys = mapping.len() != original_len;
-
         let known: std::collections::HashSet<&str> = field_names.iter().copied().collect();
-        let total = mapping.len();
         let field_key_count = mapping
             .iter()
             .filter_map(|(k, _)| k.as_str())
             .filter(|s| known.contains(s))
             .count();
 
-        let value = serde_yaml::Value::Mapping(mapping);
-
         if field_key_count == 0 {
-            // Named-map form. `target-<name>:`/`kernel-<spec>:` overrides only
-            // make sense inside singleton form (they override the singleton's
-            // config fields), so their presence here means the section has no
-            // recognized config fields to override — most likely a mis-indented
-            // or misplaced override. Reject it rather than silently dropping it.
-            if had_override_keys {
-                return Err(de::Error::custom(format!(
-                    "{kind_label}: `target-<name>:`/`kernel-<spec>:` override keys are only valid \
-                     in singleton form (alongside config field keys like `{}`), not in named-map \
-                     form",
-                    field_names.join("`, `")
-                )));
-            }
+            // Named-map form: none of the top-level keys are config fields, so
+            // every key is an entry name — including names that happen to start
+            // with `target-`/`kernel-` (e.g. a `kernel: { kernel-lts: ... }` map
+            // referenced elsewhere by name). Don't treat those as overrides here;
+            // that reserved-prefix handling only applies inside singleton form.
             let named: HashMap<String, T> =
-                serde_yaml::from_value(value).map_err(de::Error::custom)?;
+                serde_yaml::from_value(serde_yaml::Value::Mapping(mapping))
+                    .map_err(de::Error::custom)?;
             return Ok(Some(named));
         }
+
+        // Singleton form. Per-target / per-kernel override sub-keys
+        // (`target-<name>:`, `kernel-<spec>:`) are resolved later by the image
+        // commands on the raw composed value; strip them here so they don't
+        // count as unknown singleton fields and falsely trip the mixed-form
+        // guard below. Probe first so the common override-free config skips the
+        // mutation entirely.
+        let is_override_key = |k: &serde_yaml::Value| {
+            k.as_str()
+                .map(|s| s.starts_with("target-") || s.starts_with("kernel-"))
+                .unwrap_or(false)
+        };
+        if mapping.keys().any(is_override_key) {
+            mapping.retain(|k, _| !is_override_key(k));
+        }
+
+        let total = mapping.len();
+        let field_key_count = mapping
+            .iter()
+            .filter_map(|(k, _)| k.as_str())
+            .filter(|s| known.contains(s))
+            .count();
 
         if field_key_count != total {
             return Err(de::Error::custom(format!(
@@ -106,7 +100,8 @@ mod named_or_single_deserializer {
         }
 
         // Singleton form — wrap as the implicit `default` entry.
-        let single: T = serde_yaml::from_value(value).map_err(de::Error::custom)?;
+        let single: T = serde_yaml::from_value(serde_yaml::Value::Mapping(mapping))
+            .map_err(de::Error::custom)?;
         let mut result = HashMap::new();
         result.insert("default".to_string(), single);
         Ok(Some(result))
@@ -2986,6 +2981,42 @@ impl Config {
     ) -> serde_yaml::Value {
         let cleaned = self.resolve_overrides_in_value(base, current_target, None, "<override>");
         self.merge_values(cleaned, target_override)
+    }
+
+    /// Pull a top-level image section (`rootfs` / `initramfs` / `kernel`) out of
+    /// a composed value and fold in its `target-<name>:` overrides for `target`.
+    ///
+    /// Shared by the standalone `avocado <role> image` commands and
+    /// `runtime build` so every reader of the section (image tag/type *and*
+    /// `post_install`) sees the same per-target-resolved node. Returns `None`
+    /// when the section is absent.
+    ///
+    /// These build paths don't know the kernel version at CLI time (it's only
+    /// discovered inside the container from the `Image-*` glob), so
+    /// `kernel-<spec>:` overrides can't be resolved here. Rather than dropping
+    /// them silently, warn: only `target-<name>:` overrides are honored for
+    /// image builds.
+    pub fn resolve_image_section(
+        &self,
+        composed: &serde_yaml::Value,
+        section: &str,
+        target: &str,
+    ) -> Option<serde_yaml::Value> {
+        let node = composed.get(section)?.clone();
+        if node.as_mapping().is_some_and(|m| {
+            m.keys()
+                .any(|k| k.as_str().is_some_and(|s| s.starts_with("kernel-")))
+        }) {
+            print_warning(
+                &format!(
+                    "`kernel-<spec>:` overrides in `{section}:` are ignored when building images \
+                     (the kernel version isn't known at build time); only `target-<name>:` \
+                     overrides are honored here."
+                ),
+                OutputLevel::Normal,
+            );
+        }
+        Some(self.resolve_overrides_in_value(node, target, None, section))
     }
 
     /// Apply prefix-dispatched override sub-sections in `value`. Supports:
@@ -10910,28 +10941,44 @@ kernel:
     }
 
     #[test]
-    fn test_override_keys_in_named_map_form_are_rejected() {
-        // Override sub-keys only make sense in singleton form. When a section is
-        // in named-map form (no recognized config fields at the top level), a
-        // stray `target-*`/`kernel-*` key is almost certainly a mistake and must
-        // be rejected rather than silently dropped.
+    fn test_named_map_entries_with_reserved_prefixes_are_not_stripped() {
+        // Reserved-prefix stripping only applies inside singleton form. A
+        // named-map section whose *entry names* start with `kernel-`/`target-`
+        // (e.g. a `kernel:` map referenced elsewhere by name) must round-trip as
+        // named entries, not be mistaken for overrides and dropped/rejected.
+        let yaml = r#"
+kernel:
+  kernel-lts:
+    version: '6.6'
+  kernel-mainline:
+    version: '6.12'
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let kernel = config.kernel.as_ref().unwrap();
+        assert_eq!(kernel.len(), 2);
+        assert!(kernel.contains_key("kernel-lts"));
+        assert!(kernel.contains_key("kernel-mainline"));
+    }
+
+    #[test]
+    fn test_per_target_only_section_parses() {
+        // A section with only `target-<name>:` sub-keys and no shared base field
+        // has no recognized config fields, so it parses as a named map (matching
+        // pre-override behavior) rather than hard-erroring. The image commands
+        // still resolve the per-target override on the raw composed value.
         let yaml = r#"
 rootfs:
-  main:
-    image:
-      type: kab
-      args: '-b -t kos.layer.rootfs'
   target-qemux86-64:
     image:
       args: '-b -t kos.layer.rootfs --tag qemu-x64'
+  target-qemuarm64:
+    image:
+      args: '-b -t kos.layer.rootfs --tag qemu-arm64'
 "#;
-        let err = serde_yaml::from_str::<Config>(yaml)
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err.contains("override keys are only valid") && err.contains("rootfs"),
-            "got: {err}"
-        );
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let rootfs = config.rootfs.as_ref().unwrap();
+        assert_eq!(rootfs.len(), 2);
+        assert!(rootfs.contains_key("target-qemux86-64"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Per-target overrides declared as `target-<name>:` inside the `rootfs:`, `initramfs:`, and `kernel:` sections are now honored by the image/build commands — most importantly for image settings such as a custom `--tag`. This matches the override behavior already used in extension image flows.

Before this change, adding a `target-<name>:` sub-key to one of these singleton sections would trip the "cannot mix singleton and named-map form" guard in the deserializer, and even where it parsed, the override was never applied when composing the image node.

## Changes

- **`src/utils/config.rs`** — `named_or_single_deserializer` strips `target-*` / `kernel-*` override sub-keys before inferring singleton-vs-named shape, so a singleton section with overrides isn't mistaken for a mixed form. The overrides are resolved later by the image commands on the raw composed value.
- **`src/commands/rootfs/image.rs`, `initramfs/image.rs`, `kernel/image.rs`** — apply `resolve_overrides_in_value(...)` to the composed section node before reading the image type/args, so per-target overrides take effect. This runs on the already-composed value, preserving path-based image sources.
- **`src/commands/runtime/build.rs`** — merge per-target overrides before extracting image type/args for runtime manifest/build script generation, matching the standalone `avocado <role> image` commands.

### Example

```yaml
rootfs:
  image:
    type: kab
    args: '-b -t kos.layer.rootfs --tag base'
  target-qemux86-64:
    image:
      args: '-b -t kos.layer.rootfs --tag qemu-x64'
  target-qemuarm64:
    image:
      args: '-b -t kos.layer.rootfs --tag qemu-arm64'
```

## Review follow-ups (Copilot)

- **Named-map form + override keys**: the deserializer no longer silently drops `target-*` / `kernel-*` keys when a section is in named-map form. Since overrides only make sense in singleton form (they override the singleton's config fields), their presence in named-map form is treated as a misplaced/mis-indented override and rejected with a clear error.
- **Test coverage**: added regression tests for `target-<name>` overrides in the `initramfs:` and `kernel:` sections (including a `kernel-<spec>:` example), plus a test asserting the named-map rejection above. Previously only `rootfs:` was covered.

## Testing

- `cargo test --lib` — all config tests pass (220 passed), including the 4 new tests.
- `cargo clippy --lib` — clean.
