### PR TITLE
Fix avocado deploy repo-server startup race (getfqdn hang)

### DIFF
--- a/src/commands/runtime/deploy.rs
+++ b/src/commands/runtime/deploy.rs
@@ -701,8 +701,19 @@ echo "TUF repository assembled at $REPO_DIR"
 ls -la "$REPO_DIR/metadata/"
 ls -la "$REPO_DIR/targets/"
 
-# Start HTTP server bound to all interfaces so the device can reach it
-python3 -m http.server "$PORT" --bind 0.0.0.0 --directory "$REPO_DIR" &
+# Start HTTP server bound to all interfaces so the device can reach it.
+# Use an inline server rather than `python3 -m http.server`: the latter calls
+# socket.getfqdn() in server_bind() BEFORE listen(), and on hosts with slow
+# reverse DNS (e.g. a container resolver with no PTR record) that lookup blocks
+# ~10s, so the socket accepts no connections until it returns -- long past the
+# readiness wait below, making the device fetch fail with "connection refused".
+# Neutralizing getfqdn makes the server listen immediately.
+python3 -c '
+import sys, socket, functools, http.server
+socket.getfqdn = lambda *a: ""
+handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=sys.argv[2])
+http.server.HTTPServer(("0.0.0.0", int(sys.argv[1])), handler).serve_forever()
+' "$PORT" "$REPO_DIR" &
 HTTP_PID=$!
 
 cleanup() {{
@@ -712,7 +723,27 @@ cleanup() {{
 }}
 trap cleanup EXIT
 
-sleep 1
+# Wait until the repo server actually accepts connections before pointing the
+# device at it. A fixed sleep races server startup latency; poll the port so
+# any bind delay is tolerated (bounded to ~30s). The server is backgrounded, so
+# `set -e` cannot catch a bind failure -- check the process is still alive each
+# iteration and fail fast with an actionable message if it dies or never binds.
+REPO_READY=
+for _ in $(seq 1 60); do
+    if ! kill -0 "$HTTP_PID" 2>/dev/null; then
+        echo "ERROR: repo server (pid $HTTP_PID) exited before listening on port $PORT" >&2
+        exit 1
+    fi
+    if python3 -c 'import socket,sys; s=socket.socket(); s.settimeout(0.5); sys.exit(0 if s.connect_ex(("127.0.0.1", int(sys.argv[1])))==0 else 1)' "$PORT" 2>/dev/null; then
+        REPO_READY=1
+        break
+    fi
+    sleep 0.5
+done
+if [ -z "$REPO_READY" ]; then
+    echo "ERROR: repo server did not become reachable on port $PORT within 30s" >&2
+    exit 1
+fi
 
 # Determine the IP the device should use to reach this HTTP server.
 # AVOCADO_DEPLOY_REPO_HOST overrides all auto-detection (useful for QEMU
@@ -1111,7 +1142,7 @@ mod tests {
         assert!(script.contains("SSH_DEST=\"root@device.local\""));
         assert!(script.contains("DEVICE_HOST=\"device.local\""));
         assert!(script.contains("SSH_PORT_ARGS=\"\""));
-        assert!(script.contains("python3 -m http.server"));
+        assert!(script.contains("http.server.HTTPServer((\"0.0.0.0\", int(sys.argv[1]))"));
         assert!(script.contains("avocadoctl runtime add --url"));
         assert!(script.contains("ssh -o StrictHostKeyChecking=no"));
         assert!(script.contains("delegations/runtime-${RUNTIME_UUID}.json"));
@@ -1328,7 +1359,8 @@ mod tests {
 
         let script = cmd.create_deploy_script("x86_64", "test-uuid").unwrap();
 
-        assert!(script.contains("--bind 0.0.0.0"));
+        // The inline repo server binds all interfaces so the device can reach it.
+        assert!(script.contains("(\"0.0.0.0\", int(sys.argv[1]))"));
     }
 
     #[test]


### PR DESCRIPTION
This PR includes the fix for the deploy repo-server startup race.

## Problem

`avocado deploy` (any signing mode) intermittently fails in Phase 3 with the
device reporting:

```
Failed to fetch http://<host>:<port>/metadata/timestamp.json: connection refused
```

Root cause: the deploy starts the local TUF repo server with
`python3 -m http.server` and waits a fixed `sleep 1` before triggering the
device fetch. `http.server`'s `server_bind()` calls `socket.getfqdn()` **before**
`listen()`. On a host with slow reverse DNS — e.g. an SDK container whose
resolver (`127.0.0.53`) has no PTR record — `getfqdn("0.0.0.0")` blocks ~10s,
so the socket is bound but not accepting connections until long after the
one-second wait. The device connects during that dead window and gets
connection refused.

Confirmed by instrumentation: `getfqdn("0.0.0.0")` took **10.02s** in the SDK
container (0.4s on the host); the socket began `listen()`ing only at **+10.01s**,
while the deploy fires the device fetch at **+1s**.

## Fix

- Start the repo server inline with `socket.getfqdn` neutralized so it
  `listen()`s immediately.
- Replace the fixed `sleep 1` with a readiness poll that waits (bounded to
  ~30s) for the port to actually accept connections, so any startup latency is
  tolerated rather than raced.

## Static checks

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo build --release`: clean.

## End-to-end validation (device-side `--connect-sign`)

The bug was found while validating device-side Connect-signed deploys, and the
fix was verified by running that full flow against a real QEMU device. The
`--connect-sign` path exercises the exact Phase-3 repo-serve code this PR fixes.

1. **Connect-enabled QEMU project** — `avocado init --target qemux86-64`, then
   `avocado connect init` against a staging org (writes `connect.org`,
   `connect.server_key`, claim token, device config).
2. **Level 2 trust** — `avocado signing-keys create root-test` →
   `avocado connect keys register --type root --key root-test` →
   `avocado connect keys approve <keyid>` →
   `avocado connect trust promote-root --key root-test`. Org reports
   `Security level: 2 (user-controlled root)`.
3. **Build bakes the trust anchor** — `avocado build` logs
   `Generating root.json with Connect server key trust (keyid 40e6b09b…)`;
   `avocado provision -r dev` produces the QEMU image.
4. **Device trusts the Connect key** — boot the VM
   (`avocado sdk run -iE vm dev --host-fwd "2222-:22"`); on the device,
   `avocadoctl root-authority` shows the Connect server key
   (`40e6b09b…`) trusted for `signing, freshness, metadata` and the local root
   key for `authority`.
5. **Deploy and apply** — `avocado deploy --connect-sign -r dev -d root@localhost:2222`:
   Phase 2 signs via Connect, Phase 3 serves the repo and the device fetches,
   verifies, and applies it. On the device, `avocadoctl status` then shows
   `Runtime: dev 88a902f9` active with all 7 extensions merged.

**Before this fix**, step 5 failed at `metadata/timestamp.json` with
connection refused (the `getfqdn` startup race). **After it**, the device
fetches and applies the Connect-signed runtime:
`Device update completed successfully`.