### PR TITLE
release: ship RCs as latest releases, not prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
+          # RCs ship as full "latest" releases so the update tooling and Homebrew
+          # present them to users. alpha/beta remain internal-only prereleases.
+          prerelease: ${{ contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
 
   release:
     permissions:
@@ -203,7 +205,8 @@ jobs:
     name: Bump Homebrew tap formula
     runs-on: ubuntu-latest
     needs: [sha256sums]
-    if: ${{ !contains(github.ref_name, '-') }}
+    # Bump the tap for stable releases and RCs, but not alpha/beta.
+    if: ${{ !contains(github.ref_name, '-') || contains(github.ref_name, '-rc') }}
     steps:
       - name: Download per-tarball SHA256 files
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,9 @@ jobs:
         with:
           generate_release_notes: true
           # RCs ship as full "latest" releases so the update tooling and Homebrew
-          # present them to users. alpha/beta remain internal-only prereleases.
-          prerelease: ${{ contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
+          # present them to users. Every other prerelease label (alpha, beta,
+          # preview, ...) stays an internal-only prerelease.
+          prerelease: ${{ contains(github.ref_name, '-') && !contains(github.ref_name, '-rc') }}
 
   release:
     permissions:


### PR DESCRIPTION
## What

Publish `-rc` tags as **full (non-prerelease) GitHub releases** so that release candidates are presented to users as the latest version across every install path:

- **Update notice** (`utils/update_check.rs`) and **`avocado upgrade`** (`commands/upgrade.rs`) both resolve "latest" via GitHub's `/releases/latest`, which excludes prereleases. Dropping the prerelease flag on `-rc` tags makes RCs show up there.
- **Homebrew tap** now bumps for `-rc` tags too, so `brew upgrade` tracks RCs.

`-alpha`/`-beta` tags stay flagged as prereleases and continue to skip the tap, preserving a genuinely internal-only channel.

## Why

We want to cut release candidates (e.g. `1.0.0-rc.0`) and have real users update to and install them as the latest version for field testing — not hide them behind the prerelease gate.

## No CLI code change needed

`/releases/latest` returns the RC once it is not a prerelease, and the existing semver comparison in `is_newer` already orders prerelease versions correctly:
- `1.0.0-rc.1 > 1.0.0-rc.0` — RC users roll forward
- `1.0.0 > 1.0.0-rc.5` — final supersedes the RC
- `1.1.0-rc.0 > 1.0.0` — **note:** stable users are offered the next line's RCs too (everyone rides the RC train; there is no stable-only opt-out under this model)

## Verify before first RC ships

- [ ] Homebrew formula resolves the `-rc.0` version string + tarball name (`avocado-linux/homebrew-tap`) on a dry run.
- [ ] First RC release lands with `prerelease: false` (confirm the later `action-gh-release` upload steps don't reset the flag).