### PR TITLE
kernel/image: fix standalone `avocado kernel image` on non-arm targets

### DIFF
--- a/src/commands/kernel/image.rs
+++ b/src/commands/kernel/image.rs
@@ -4,10 +4,10 @@
 //! kernel binary is just a file dropped into the rootfs sysroot by the
 //! `kernel-image-*` package. This command:
 //!
-//!   1. Locates the uncompressed kernel binary under
-//!      `$AVOCADO_PREFIX/rootfs/boot/` (preferring `Image-<kver>` over
-//!      compressed `*.gz`, skipping the metadata `System.map-*` and
-//!      `config-*` siblings).
+//!   1. Locates the kernel image staged by `rootfs install` at
+//!      `$AVOCADO_PREFIX/kernel/<kver>/Image` — a normalized symlink to the
+//!      arch's real kernel (Image on arm64, bzImage on x86-64, …), the same
+//!      location the runtime build reads.
 //!   2. When `kernel.image.type: kab` is set in avocado.yaml, wraps it
 //!      into a signed `.kab` using the SDK's `kabtool` — same recipe
 //!      `runtime build` uses, via the shared helper in `utils::kab_wrap`.
@@ -148,30 +148,22 @@ impl KernelImageCommand {
             String::new()
         };
 
-        // Locate the uncompressed kernel binary in the rootfs sysroot
-        // boot directory and copy it into $OUTPUT_DIR. Skip System.map /
-        // config metadata + .gz variants. Mirrors how runtime/build.rs
-        // computes AVOCADO_KERNEL_IMAGE for the wrap step.
+        // Resolve the kernel image staged by `rootfs install` at
+        // $AVOCADO_PREFIX/kernel/<kver>/Image — a normalized symlink to the
+        // arch's real kernel (Image on arm64, bzImage on x86-64, …). This is
+        // the SAME location runtime/build.rs reads, so standalone
+        // `avocado kernel image` locates the kernel identically across arches.
+        // (The raw rootfs/boot/ file keeps its arch-specific name, so scanning
+        // it only ever matched arm64's `Image`.)
         let internal_output_dir = "$AVOCADO_PREFIX/output/images";
         let locate_section = r#"
-ROOTFS_BOOT="$AVOCADO_PREFIX/rootfs/boot"
-if [ ! -d "$ROOTFS_BOOT" ]; then
-    echo "ERROR: rootfs sysroot has no /boot — run 'avocado rootfs install' first" >&2
-    exit 1
-fi
-KERNEL_SRC=""
-for f in "$ROOTFS_BOOT"/Image "$ROOTFS_BOOT"/Image-*; do
-    [ -f "$f" ] || continue
-    case "$f" in
-        *.gz|*/System.map-*|*/config-*) continue ;;
-    esac
-    KERNEL_SRC="$f"
-    break
-done
+KERNEL_SRC=$(ls "$AVOCADO_PREFIX"/kernel/*/Image 2>/dev/null | head -1)
 if [ -z "$KERNEL_SRC" ]; then
-    echo "ERROR: no uncompressed kernel image found in $ROOTFS_BOOT" >&2
+    echo "ERROR: no staged kernel image at $AVOCADO_PREFIX/kernel/*/Image — run 'avocado rootfs install' first" >&2
     exit 1
 fi
+# cp follows the Image symlink, copying the real kernel content under the
+# normalized name (same as the runtime build).
 KERNEL_BASENAME=$(basename "$KERNEL_SRC")
 AVOCADO_KERNEL_IMAGE="$OUTPUT_DIR/$KERNEL_BASENAME"
 cp -f "$KERNEL_SRC" "$AVOCADO_KERNEL_IMAGE"

--- a/src/commands/kernel/image.rs
+++ b/src/commands/kernel/image.rs
@@ -157,7 +157,17 @@ impl KernelImageCommand {
         // it only ever matched arm64's `Image`.)
         let internal_output_dir = "$AVOCADO_PREFIX/output/images";
         let locate_section = r#"
-KERNEL_SRC=$(ls "$AVOCADO_PREFIX"/kernel/*/Image 2>/dev/null | head -1)
+# Take the first staged kernel (bash sorts the glob, matching how
+# runtime/build.rs resolves this path). The for-glob idiom leaves
+# KERNEL_SRC empty on no match instead of failing the pipeline, so the
+# actionable error below fires rather than `set -euo pipefail` aborting
+# the script on the bare `ls` exit code.
+KERNEL_SRC=""
+for f in "$AVOCADO_PREFIX"/kernel/*/Image; do
+    [ -e "$f" ] || continue
+    KERNEL_SRC="$f"
+    break
+done
 if [ -z "$KERNEL_SRC" ]; then
     echo "ERROR: no staged kernel image at $AVOCADO_PREFIX/kernel/*/Image — run 'avocado rootfs install' first" >&2
     exit 1


### PR DESCRIPTION
## Problem

Standalone `avocado kernel image` failed on non-arm targets. It located the kernel by scanning the rootfs sysroot boot dir for `Image` / `Image-*`:

```sh
for f in "$ROOTFS_BOOT"/Image "$ROOTFS_BOOT"/Image-*; do ...
```

That only matches arm64's kernel name. On x86-64 the real kernel is `bzImage`, so the scan found nothing and the command errored out — even though `rootfs install` had staged a perfectly good kernel. `runtime build` worked on those targets because it reads the kernel from a different, arch-normalized location.

## Fix

Resolve the kernel from the same place `runtime/build.rs` does: the arch-normalized symlink `rootfs install` stages at `$AVOCADO_PREFIX/kernel/<kver>/Image` (points at `Image` on arm64, `bzImage` on x86-64, …). `cp` follows the symlink and copies the real kernel content under the normalized name, so standalone `avocado kernel image` now locates and stages the kernel identically across architectures.

Also honor per-target `target-<name>:` overrides inside the `kernel:` section (e.g. a custom `--tag`), resolved on the already-composed value so path-based sources are preserved. `kernel-<spec>:` overrides can't be applied here — the kernel version isn't known until inside the container — so the helper warns rather than silently dropping them.

## Follow-up (review fix, 3f09f5a)

The first cut resolved the kernel with `ls "$AVOCADO_PREFIX"/kernel/*/Image | head -1`. Under the script's `set -euo pipefail`, an empty glob makes `ls` exit non-zero, `pipefail` propagates it, and the assignment aborts the whole script **before** the `if [ -z "$KERNEL_SRC" ]` check — so a user with no staged kernel got an opaque non-zero exit instead of the actionable "run `avocado rootfs install` first" message.

Reverted to the for-glob idiom the old `rootfs/boot` scan used: it leaves `KERNEL_SRC` empty on no match without failing, so the friendly error fires. Selection is unchanged (first sorted glob entry == the old `ls | head -1`, since bash sorts the glob), keeping parity with how `runtime/build.rs` resolves the same path.

## Test

- `cargo build` clean.
- Shell idiom verified under `set -euo pipefail`: no-match → friendly error + `exit 1`; multi-kernel → same selection as `ls | head -1`.
- Not run here: full container `avocado kernel image` on an x86-64 target (needs the SDK container + a staged rootfs) — worth a manual smoke before merge.