### PR TITLE
deploy: surface the signing-key prerequisite for --connect-sign

### DIFF
--- a/src/commands/runtime/deploy.rs
+++ b/src/commands/runtime/deploy.rs
@@ -670,6 +670,10 @@ fi
 ROOT_JSON_FILE="$VAR_STAGING/lib/avocado/metadata/root.json"
 if [ ! -f "$ROOT_JSON_FILE" ]; then
     echo "ERROR: No root.json found at $ROOT_JSON_FILE" >&2
+    echo "       The runtime has no update-authority (root.json) baked into its build." >&2
+    echo "       This usually means no signing key is configured. Set 'signing.key' for" >&2
+    echo "       the runtime (for a Connect project, run 'avocado connect trust promote-root')" >&2
+    echo "       and rebuild. --connect-sign requires a local signing key for this reason." >&2
     exit 1
 fi
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -443,6 +443,9 @@ enum Commands {
         dnf_args: Option<Vec<String>>,
         /// Sign TUF metadata via the Connect platform instead of locally.
         /// Use this when deploying to a device that has received a Connect OTA update.
+        /// Requires a local signing key configured for the runtime (Level 2:
+        /// `signing.key` + `avocado connect trust promote-root`); without one no
+        /// root.json is baked and the deploy fails during Phase 1 hash collection.
         #[arg(long)]
         connect_sign: bool,
         /// Output format. JSON skips TUI rendering and emits NDJSON events.
@@ -1788,6 +1791,9 @@ enum RuntimeCommands {
         dnf_args: Option<Vec<String>>,
         /// Sign TUF metadata via the Connect platform instead of locally.
         /// Use this when deploying to a device that has received a Connect OTA update.
+        /// Requires a local signing key configured for the runtime (Level 2:
+        /// `signing.key` + `avocado connect trust promote-root`); without one no
+        /// root.json is baked and the deploy fails during Phase 1 hash collection.
         #[arg(long)]
         connect_sign: bool,
         /// Output format. JSON skips TUI rendering and emits NDJSON events.


### PR DESCRIPTION
## Problem

Follow-up to the review of #158 (raised by @lee-reinhardt, non-blocking).

`avocado deploy --connect-sign` runs Phase 1 hash collection, which requires a
`root.json` in the build output. A runtime configured with only a Connect
server key and **no local signing key** (Level 0) bakes no `root.json`, so the
deploy fails during Phase 1 with a bare:

```
ERROR: No root.json found at <path>
```

before it ever reaches the Connect signing step — with no indication that a
signing key is the missing piece. In practice `--connect-sign` requires a local
signing key (Level 2).

## Fix

- Note the signing-key prerequisite in the `--connect-sign` help text (both
  `avocado deploy` and `avocado runtime deploy`).
- Expand the Phase 1 "No root.json found" error to explain the cause and point
  at `signing.key` / `avocado connect trust promote-root`.

No behavior change — help text + error message only.

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, deploy unit tests: clean.