### PR TITLE
release: 1.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes to `avocado-cli` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0-rc.1]
+
+Release candidate for 1.0.0.
+
+**Stability commitment.** Starting with 1.0.0, the `avocado.yaml` configuration
+schema and the generated runtime manifest are a stable contract. Within the
+1.x series, changes to both are **additive only** — new optional keys and new
+manifest fields may be introduced, but existing keys, their meaning, and the
+shape of a produced manifest will not change in a backwards-incompatible way.
+Breaking changes are reserved for the next major version. This release candidate
+exists to exercise that contract in the field before it is frozen at 1.0.0.
+
+The breaking cleanups that land the 1.0 baseline (see **Changed**/**Removed**)
+are made now, in the RC, precisely so 1.0.0 can commit to the contract above.
+
+### Added
+- **Connect-signed TUF deploy.** A new `--connect-sign` flag on the deploy
+  commands routes TUF metadata signing through Avocado Connect (`sign-for-deploy`
+  API client + types, Connect-signed metadata path, `runtime_uuid` sent in the
+  sign request). The prerequisite signing-key requirement is surfaced up front.
+- **Per-target section overrides.** `rootfs`, `initramfs`, and `kernel` sections
+  now honor `target-<name>:` override blocks, resolved on the composed config so
+  path-based image sources are preserved.
+- **Opt-in overlay preprocessing.** Overlay files can now be preprocessed at
+  build time (opt-in).
+- **`config show` signing state.** Per-runtime `signing_enabled` is now exposed
+  in `avocado config show`.
+- **VM software TPM.** VMs now provide a software TPM so tpm2-enabled images boot
+  without stalling.
+
+### Changed
+- **Lockfile relocated to top-level `avocado.lock`.** The resolved lockfile now
+  lives at the project root. Update any tooling or ignore rules that referenced
+  the previous location.
+- **Extension `type: path` mounts derived from config.** Path mounts are now
+  computed directly from `avocado.yaml`; the separate `ext-paths.json` sidecar is
+  gone (see **Removed**).
+- **Release candidates ship as latest.** `-rc` tags now publish as full
+  (non-prerelease) GitHub releases, so the CLI update check, `avocado upgrade`,
+  and the Homebrew tap present release candidates to users as the latest version.
+  `-alpha`/`-beta` tags remain internal-only prereleases. (#170)
+- **VM guest networking.** VMs use `virtio-net-pci` so the guest NIC binds on the
+  q35 machine type.
+
+### Fixed
+- **Standalone `avocado kernel image` on non-arm targets.** The command located
+  the kernel by its arm64 `Image` name under `rootfs/boot/`, so it failed on
+  x86-64 (where the kernel is `bzImage`). It now resolves the arch-normalized
+  symlink `rootfs install` stages at `$AVOCADO_PREFIX/kernel/<kver>/Image` — the
+  same path `runtime build` reads — so it works across architectures. (#171)
+- **Deploy repo server startup race.** Fixed a race in the deploy repo server
+  startup.
+- **`cli_requirement` gating on pre-release builds.** A project's
+  `cli_requirement` is now matched against the running version with any
+  pre-release/build metadata stripped, so pre-release CLI builds (e.g. this
+  release candidate) satisfy ordinary requirements like `>=0.25` or `^1` instead
+  of being spuriously rejected by semver's pre-release matching rule.
+
+### Removed
+- **`ext-paths.json`.** Extension path mounts are now derived from config; the
+  sidecar file is no longer written or read.
+
+[1.0.0-rc.1]: https://github.com/avocado-linux/avocado-cli/releases/tag/1.0.0-rc.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocado-cli"
-version = "0.41.2"
+version = "1.0.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocado-cli"
-version = "0.41.2"
+version = "1.0.0-rc.1"
 edition = "2021"
 description = "Command line interface for Avocado."
 authors = ["Avocado"]

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -51,7 +51,16 @@ pub fn check_cli_requirement(requirement: &str) -> Result<()> {
         )
     })?;
 
-    if !req.matches(&running) {
+    // First try the exact running version, so a requirement that explicitly
+    // pins a pre-release (e.g. "=1.0.0-rc.1") is still satisfiable when running
+    // that build. Then fall back to the running version with pre-release/build
+    // metadata stripped: semver only lets a pre-release satisfy a comparator
+    // that carries a matching pre-release tag, so without this fallback an
+    // ordinary requirement like ">=0.25" or "^1" would spuriously reject every
+    // RC build. The full version is still shown in the error message below.
+    let running_release = Version::new(running.major, running.minor, running.patch);
+
+    if !req.matches(&running) && !req.matches(&running_release) {
         anyhow::bail!(
             "This project requires avocado CLI version '{requirement}', \
              but you are running version {running}.\n\n\
@@ -87,11 +96,15 @@ mod tests {
 
     #[test]
     fn test_check_cli_requirement_satisfied() {
-        // Current version is 0.25.1, so >=0.0.1 should pass
+        // Any released version is >= 0.0.1. This also covers pre-release builds
+        // (e.g. `1.0.0-rc.0`), which are matched as their release version.
         assert!(check_cli_requirement(">=0.0.1").is_ok());
         // Exact current version
         let current = env!("CARGO_PKG_VERSION");
         assert!(check_cli_requirement(&format!(">={current}")).is_ok());
+        // A requirement that explicitly pins the exact running version —
+        // including a pre-release tag — must still match that build.
+        assert!(check_cli_requirement(&format!("={current}")).is_ok());
     }
 
     #[test]
@@ -106,8 +119,10 @@ mod tests {
 
     #[test]
     fn test_check_cli_requirement_complex() {
-        // Caret requirement that should match
-        assert!(check_cli_requirement("^0").is_ok());
+        // Caret requirement on the running major should match (derived so the
+        // test doesn't rot across major bumps).
+        let major = Version::parse(env!("CARGO_PKG_VERSION")).unwrap().major;
+        assert!(check_cli_requirement(&format!("^{major}")).is_ok());
         // Wildcard that matches anything
         assert!(check_cli_requirement("*").is_ok());
     }


### PR DESCRIPTION
Cuts a release candidate for **1.0.0**. (Supersedes #173, which GitHub auto-closed when its branch was renamed `-rc.0` → `-rc.1`.)

## Contents
- Bump `version` `0.41.2` → `1.0.0-rc.1` (Cargo.toml + Cargo.lock).
- Add `CHANGELOG.md` (Keep a Changelog format) covering everything since 0.41.2.
- Fix `cli_requirement` gating so pre-release CLI builds (this RC) satisfy ordinary requirements instead of being rejected by semver's pre-release rule.

## What 1.0 means
From 1.0.0 on, the `avocado.yaml` config schema and the generated runtime manifest are a **stable, additive-only contract** within the 1.x series — new optional keys / manifest fields may be added, but nothing existing changes incompatibly. Breaking changes are reserved for the next major. The RC exists to exercise that contract in the field before it's frozen at 1.0.0.

The breaking cleanups that establish the baseline (top-level `avocado.lock`, `ext-paths.json` removal) land in this RC on purpose, so 1.0.0 can commit to the contract.

## Release highlights (full list in CHANGELOG.md)
- **Added:** Connect-signed TUF deploy (`--connect-sign`); per-target `target-<name>:` overrides for rootfs/initramfs/kernel; opt-in overlay preprocessing; `signing_enabled` in `config show`; VM software TPM.
- **Changed:** lockfile → top-level `avocado.lock`; ext `type: path` mounts derived from config; RCs publish as latest (#170); VM `virtio-net-pci`.
- **Fixed:** standalone `avocado kernel image` on non-arm targets (#171); deploy repo server startup race; `cli_requirement` gating on pre-release builds.
- **Removed:** `ext-paths.json`.

## Tagging
The release workflow fires on a pushed tag. After this merges to `main`, tag `1.0.0-rc.1` on the merge commit and push the tag to trigger the build/publish. #170 (RCs publish as full non-prerelease "latest") is already on `main`, so the `-rc` tag will be presented to users as the latest version.

No tag is pushed by this PR — tagging is the manual release trigger.