### PR TITLE
ext/package: emit RPM-safe Version for pre-release semver

### DIFF
--- a/docs/features/extension-versioning-redesign.md
+++ b/docs/features/extension-versioning-redesign.md
@@ -14,6 +14,19 @@ The `version` field in an extension's `avocado.yaml` IS the version. Always. For
 
 Keep semver — unified versioning across all output artifacts. Distro extensions use `YYYY.S.PATCH` convention (e.g., `2024.0.0`).
 
+#### One deliberate exception: the RPM `Version:` field
+
+RPM's grammar forbids `-`, so a semver pre-release cannot be an RPM `Version:` verbatim — `rpmbuild` rejects `1.0.0-rc.1` with `Illegal char '-'`. Pre-release versions are therefore stored in the RPM as `1.0.0~rc.1` (and build metadata as `^`), which is the form that also gives RPM the right ordering: `1.0.0~rc.1` sorts before `1.0.0`, matching semver precedence.
+
+This is the one place a version is *not* the config's string, so it is confined as tightly as possible:
+
+- Only the spec's `Version:` field and the NVR filename use the RPM form. `utils::version::to_rpm_version` is the single place it is produced.
+- Everything else stays semver — config, the `avocado.yaml` baked into the package payload, the version the platform records for a published extension.
+- The mapping is injective, so `from_rpm_version` inverts it exactly. Any version read back *out* of rpm (an rpmdb query, a parsed NVR) must go through it, or it will not match the config it came from.
+- A `-` *inside* a pre-release identifier (`1.0.0-rc-1`) is rejected rather than mapped: `~` is a precedence operator to RPM, so mapping it would invert ordering and dnf would refuse the upgrade. Use `.` to separate identifiers.
+
+So config remains the source of truth; the RPM form is a representation of it at one boundary, not a second version.
+
 ### Rename `distro.version` → `distro.release`
 
 `distro.version` was overloaded — it was used as a repo path component, a package version spec, an extension version source, and passed as runtime env vars. It should only be the **release family identifier** (feed year).

--- a/src/commands/connect/ext.rs
+++ b/src/commands/connect/ext.rs
@@ -104,7 +104,14 @@ impl ExtPublishCommand {
 
         let (pn, pv, pr, pa) = parse_nevra(path).unwrap_or_default();
         let name = self.name.clone().unwrap_or(pn);
-        let version = self.version.clone().unwrap_or(pv);
+        // The version comes off the RPM's filename, so it is in RPM form. Invert
+        // it back to semver before recording it: clients compare the platform's
+        // version against the `avocado.yaml` baked into the payload, which is
+        // deliberately kept as semver. An explicit `--version` is taken as given.
+        let version = self
+            .version
+            .clone()
+            .unwrap_or_else(|| crate::utils::version::from_rpm_version(&pv));
         let release = self
             .release
             .clone()

--- a/src/commands/ext/package.rs
+++ b/src/commands/ext/package.rs
@@ -525,6 +525,188 @@ impl ExtPackageCommand {
         format!("System extension package for {name}")
     }
 
+    /// Generate the `rpmbuild` shell script for this extension.
+    ///
+    /// Split out of [`Self::create_rpm_package_in_container`] so the two places
+    /// the RPM-form version lands — the spec's `Version:` line and the NVR
+    /// filename — are assertable without running a container. Mirrors
+    /// `sdk::package`'s `generate_rpm_build_script`.
+    #[allow(clippy::too_many_arguments)]
+    fn generate_rpm_build_script(
+        &self,
+        metadata: &RpmMetadata,
+        rpm_version: &str,
+        rpm_filename: &str,
+        target_provides: &str,
+        container_src_dir: &str,
+        package_files_str: &str,
+        version_bake_section: &str,
+    ) -> String {
+        format!(
+            r#"
+set -e
+
+# Extension source directory
+EXT_SRC_DIR="{container_src_dir}"
+
+# Package files patterns (may contain globs like * and **)
+PACKAGE_FILES="{package_files_str}"
+
+# Ensure output directory exists
+mkdir -p $AVOCADO_PREFIX/output/extensions
+
+# Check if extension source directory exists
+if [ ! -d "$EXT_SRC_DIR" ]; then
+echo "Extension source directory not found: $EXT_SRC_DIR"
+exit 1
+fi
+
+# Check for avocado config file
+if [ ! -f "$EXT_SRC_DIR/avocado.yaml" ] && [ ! -f "$EXT_SRC_DIR/avocado.yml" ]; then
+echo "No avocado.yaml/yml found in $EXT_SRC_DIR"
+exit 1
+fi
+
+# Create temporary directory for RPM build
+TMPDIR=$(mktemp -d)
+STAGING_DIR="$TMPDIR/staging"
+mkdir -p "$STAGING_DIR"
+cd "$TMPDIR"
+
+# Create directory structure for rpmbuild
+mkdir -p BUILD RPMS SOURCES SPECS SRPMS
+
+# Enable globstar for ** pattern support
+shopt -s globstar nullglob
+
+# Copy files matching patterns to staging directory
+cd "$EXT_SRC_DIR"
+FILE_COUNT=0
+for pattern in $PACKAGE_FILES; do
+# Expand the glob pattern
+for file in $pattern; do
+    if [ -e "$file" ]; then
+        # Create parent directory in staging and copy
+        parent_dir=$(dirname "$file")
+        if [ "$parent_dir" != "." ]; then
+            mkdir -p "$STAGING_DIR/$parent_dir"
+        fi
+        cp -r "$file" "$STAGING_DIR/$file"
+        if [ -f "$file" ]; then
+            FILE_COUNT=$((FILE_COUNT + 1))
+        elif [ -d "$file" ]; then
+            dir_files=$(find "$file" -type f | wc -l)
+            FILE_COUNT=$((FILE_COUNT + dir_files))
+        fi
+    fi
+done
+done
+cd "$TMPDIR"
+{version_bake_section}
+echo "Creating RPM with $FILE_COUNT files from source directory..."
+
+if [ "$FILE_COUNT" -eq 0 ]; then
+echo "No files matched the package_files patterns: $PACKAGE_FILES"
+exit 1
+fi
+
+# Create spec file
+# The extension's src_dir maps to a top-level /<ext_name>/ directory in the package, so
+# that installing into a SHARED includes installroot lands its content at
+# includes/<ext_name>/ without colliding with other extensions' files (and one rpmdb
+# tracks all installed extensions).
+cat > SPECS/package.spec << SPEC_EOF
+%define _buildhost reproducible
+# The payload is already-built target content, so rpm has to package it verbatim.
+# Two stock behaviours get in the way: the build-root policy scripts run the
+# container's host toolchain (strip and friends) over target binaries, and the
+# noarch guard rejects a payload carrying target ELF. These packages are noarch
+# by design - a target routes on the avocado-target provides below, not on the
+# package arch - so both checks are false positives here.
+# Comments must stay macro-free; rpm expands macros inside spec comments.
+%define __os_install_post %{{nil}}
+%define _binaries_in_noarch_packages_terminate_build 0
+AutoReqProv: no
+
+Name: {name}
+Version: {version}
+Release: {release}
+Summary: {summary}
+License: {license}
+Vendor: {vendor}
+Group: {group}{url_line}
+# Self-describe the on-disk layout so the CLI knows how to install this package: content
+# is nested under /<ext_name>/, so it installs into the SHARED includes installroot.
+# Legacy packages (content at /) lack this provide and use the per-ext installroot.
+Provides: avocado-ext-layout(nested)
+# Self-describe which targets this extension supports, derived from avocado.yaml
+# supported_targets. Surfaced in the feed's repo metadata (primary.xml) so the CLI can
+# query target compatibility without downloading the RPM, and so the feed server can route
+# it to the correct per-target -ext feed(s). "*" means all targets (cross-target).
+{target_provides}
+
+%description
+{description}
+
+%files
+/{name}
+
+%prep
+# No prep needed
+
+%build
+# No build needed
+
+%install
+# Nest the staged files under /<ext_name>/ so a shared includes installroot yields
+# includes/<ext_name>/... (collision-free, one rpmdb per includes root).
+mkdir -p %{{buildroot}}/{name}
+cp -r "$STAGING_DIR"/* %{{buildroot}}/{name}/
+
+%clean
+# Skip clean section - not needed for our use case
+
+%changelog
+SPEC_EOF
+
+# Build the RPM with custom architecture target
+rpmbuild --define "_topdir $TMPDIR" --define "_arch {arch}" --target {arch} -bb SPECS/package.spec
+
+# Move RPM to output directory
+mv RPMS/{arch}/*.rpm $AVOCADO_PREFIX/output/extensions/{rpm_filename} || {{
+mv RPMS/*/*.rpm $AVOCADO_PREFIX/output/extensions/{rpm_filename} 2>/dev/null || {{
+    echo "Failed to find built RPM"
+    exit 1
+}}
+}}
+
+echo "RPM created successfully: $AVOCADO_PREFIX/output/extensions/{rpm_filename}"
+
+# Cleanup
+rm -rf "$TMPDIR"
+"#,
+            name = metadata.name,
+            version = rpm_version,
+            release = metadata.release,
+            summary = metadata.summary,
+            license = metadata.license,
+            vendor = metadata.vendor,
+            group = metadata.group,
+            url_line = if let Some(url) = &metadata.url {
+                format!("\nURL: {url}")
+            } else {
+                String::new()
+            },
+            description = metadata.description,
+            arch = metadata.arch,
+            target_provides = target_provides,
+            rpm_filename = rpm_filename,
+            container_src_dir = container_src_dir,
+            package_files_str = package_files_str,
+            version_bake_section = version_bake_section,
+        )
+    }
+
     /// Create the RPM package containing the extension's src_dir
     ///
     /// The package root (/) maps to the extension's src_dir contents.
@@ -576,7 +758,8 @@ impl ExtPackageCommand {
         // the semver version to its RPM form (`1.0.0-rc.1` -> `1.0.0~rc.1`). Used
         // for the spec `Version:` and the built RPM's name; the semver form is kept
         // for the avocado.yaml baked into the payload (consumers validate semver).
-        let rpm_version = crate::utils::version::to_rpm_version(&metadata.version);
+        let rpm_version = crate::utils::version::to_rpm_version(&metadata.version)
+            .with_context(|| format!("Extension '{}' cannot be packaged", self.extension))?;
 
         // Create the RPM filename (matches the built RPM's NVR, so it uses the
         // RPM-form version, not the semver form).
@@ -656,168 +839,14 @@ fi
 
         // Create RPM using rpmbuild in container
         // Package root (/) maps to the extension's src_dir contents
-        let rpm_build_script = format!(
-            r#"
-set -e
-
-# Extension source directory
-EXT_SRC_DIR="{container_src_dir}"
-
-# Package files patterns (may contain globs like * and **)
-PACKAGE_FILES="{package_files_str}"
-
-# Ensure output directory exists
-mkdir -p $AVOCADO_PREFIX/output/extensions
-
-# Check if extension source directory exists
-if [ ! -d "$EXT_SRC_DIR" ]; then
-    echo "Extension source directory not found: $EXT_SRC_DIR"
-    exit 1
-fi
-
-# Check for avocado config file
-if [ ! -f "$EXT_SRC_DIR/avocado.yaml" ] && [ ! -f "$EXT_SRC_DIR/avocado.yml" ]; then
-    echo "No avocado.yaml/yml found in $EXT_SRC_DIR"
-    exit 1
-fi
-
-# Create temporary directory for RPM build
-TMPDIR=$(mktemp -d)
-STAGING_DIR="$TMPDIR/staging"
-mkdir -p "$STAGING_DIR"
-cd "$TMPDIR"
-
-# Create directory structure for rpmbuild
-mkdir -p BUILD RPMS SOURCES SPECS SRPMS
-
-# Enable globstar for ** pattern support
-shopt -s globstar nullglob
-
-# Copy files matching patterns to staging directory
-cd "$EXT_SRC_DIR"
-FILE_COUNT=0
-for pattern in $PACKAGE_FILES; do
-    # Expand the glob pattern
-    for file in $pattern; do
-        if [ -e "$file" ]; then
-            # Create parent directory in staging and copy
-            parent_dir=$(dirname "$file")
-            if [ "$parent_dir" != "." ]; then
-                mkdir -p "$STAGING_DIR/$parent_dir"
-            fi
-            cp -r "$file" "$STAGING_DIR/$file"
-            if [ -f "$file" ]; then
-                FILE_COUNT=$((FILE_COUNT + 1))
-            elif [ -d "$file" ]; then
-                dir_files=$(find "$file" -type f | wc -l)
-                FILE_COUNT=$((FILE_COUNT + dir_files))
-            fi
-        fi
-    done
-done
-cd "$TMPDIR"
-{version_bake_section}
-echo "Creating RPM with $FILE_COUNT files from source directory..."
-
-if [ "$FILE_COUNT" -eq 0 ]; then
-    echo "No files matched the package_files patterns: $PACKAGE_FILES"
-    exit 1
-fi
-
-# Create spec file
-# The extension's src_dir maps to a top-level /<ext_name>/ directory in the package, so
-# that installing into a SHARED includes installroot lands its content at
-# includes/<ext_name>/ without colliding with other extensions' files (and one rpmdb
-# tracks all installed extensions).
-cat > SPECS/package.spec << SPEC_EOF
-%define _buildhost reproducible
-# The payload is already-built target content, so rpm has to package it verbatim.
-# Two stock behaviours get in the way: the build-root policy scripts run the
-# container's host toolchain (strip and friends) over target binaries, and the
-# noarch guard rejects a payload carrying target ELF. These packages are noarch
-# by design - a target routes on the avocado-target provides below, not on the
-# package arch - so both checks are false positives here.
-# Comments must stay macro-free; rpm expands macros inside spec comments.
-%define __os_install_post %{{nil}}
-%define _binaries_in_noarch_packages_terminate_build 0
-AutoReqProv: no
-
-Name: {name}
-Version: {version}
-Release: {release}
-Summary: {summary}
-License: {license}
-Vendor: {vendor}
-Group: {group}{url_line}
-# Self-describe the on-disk layout so the CLI knows how to install this package: content
-# is nested under /<ext_name>/, so it installs into the SHARED includes installroot.
-# Legacy packages (content at /) lack this provide and use the per-ext installroot.
-Provides: avocado-ext-layout(nested)
-# Self-describe which targets this extension supports, derived from avocado.yaml
-# supported_targets. Surfaced in the feed's repo metadata (primary.xml) so the CLI can
-# query target compatibility without downloading the RPM, and so the feed server can route
-# it to the correct per-target -ext feed(s). "*" means all targets (cross-target).
-{target_provides}
-
-%description
-{description}
-
-%files
-/{name}
-
-%prep
-# No prep needed
-
-%build
-# No build needed
-
-%install
-# Nest the staged files under /<ext_name>/ so a shared includes installroot yields
-# includes/<ext_name>/... (collision-free, one rpmdb per includes root).
-mkdir -p %{{buildroot}}/{name}
-cp -r "$STAGING_DIR"/* %{{buildroot}}/{name}/
-
-%clean
-# Skip clean section - not needed for our use case
-
-%changelog
-SPEC_EOF
-
-# Build the RPM with custom architecture target
-rpmbuild --define "_topdir $TMPDIR" --define "_arch {arch}" --target {arch} -bb SPECS/package.spec
-
-# Move RPM to output directory
-mv RPMS/{arch}/*.rpm $AVOCADO_PREFIX/output/extensions/{rpm_filename} || {{
-    mv RPMS/*/*.rpm $AVOCADO_PREFIX/output/extensions/{rpm_filename} 2>/dev/null || {{
-        echo "Failed to find built RPM"
-        exit 1
-    }}
-}}
-
-echo "RPM created successfully: $AVOCADO_PREFIX/output/extensions/{rpm_filename}"
-
-# Cleanup
-rm -rf "$TMPDIR"
-"#,
-            name = metadata.name,
-            version = rpm_version,
-            release = metadata.release,
-            summary = metadata.summary,
-            license = metadata.license,
-            vendor = metadata.vendor,
-            group = metadata.group,
-            url_line = if let Some(url) = &metadata.url {
-                format!("\nURL: {url}")
-            } else {
-                String::new()
-            },
-            description = metadata.description,
-            arch = metadata.arch,
-            target_provides = target_provides,
-            rpm_filename = rpm_filename,
-            container_src_dir = container_src_dir,
-            package_files_str = package_files_str,
-            version_bake_section = version_bake_section,
+        let rpm_build_script = self.generate_rpm_build_script(
+            metadata,
+            &rpm_version,
+            &rpm_filename,
+            &target_provides,
+            &container_src_dir,
+            &package_files_str,
+            &version_bake_section,
         );
 
         // Run the RPM build in the container
@@ -1007,6 +1036,101 @@ struct RpmMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_cmd() -> ExtPackageCommand {
+        ExtPackageCommand::new(
+            "test.yaml".to_string(),
+            "test-ext".to_string(),
+            Some("x86_64-unknown-linux-gnu".to_string()),
+            None,
+            false,
+            None,
+            None,
+        )
+    }
+
+    fn metadata_with_version(version: &str) -> RpmMetadata {
+        RpmMetadata {
+            name: "my-ext".to_string(),
+            version: version.to_string(),
+            release: "r0".to_string(),
+            summary: "s".to_string(),
+            description: "d".to_string(),
+            license: "MIT".to_string(),
+            arch: "noarch".to_string(),
+            vendor: "v".to_string(),
+            group: "g".to_string(),
+            url: None,
+        }
+    }
+
+    /// The spec `Version:` line and the NVR filename must both carry the RPM
+    /// form. `rpmbuild` aborts with `Illegal char '-'` on the semver form, so a
+    /// refactor that interpolated `metadata.version` into either would break
+    /// packaging for every pre-release — and, before this test, do it with a
+    /// fully green suite.
+    #[test]
+    fn test_generate_rpm_build_script_uses_rpm_form_version() {
+        let cmd = test_cmd();
+        let metadata = metadata_with_version("1.0.0-rc.1");
+        let rpm_version = crate::utils::version::to_rpm_version(&metadata.version).unwrap();
+        let rpm_filename = format!(
+            "{}-{}-{}.{}.rpm",
+            metadata.name, rpm_version, metadata.release, metadata.arch
+        );
+
+        let script = cmd.generate_rpm_build_script(
+            &metadata,
+            &rpm_version,
+            &rpm_filename,
+            "Provides: avocado-target(*)",
+            "/opt/src",
+            "avocado.yaml",
+            "",
+        );
+
+        // The spec field rpmbuild parses.
+        assert!(
+            script.contains("Version: 1.0.0~rc.1"),
+            "spec Version: must be the RPM form"
+        );
+        assert!(
+            !script.contains("Version: 1.0.0-rc.1"),
+            "spec Version: must not carry the semver hyphen"
+        );
+        // The built artifact's name.
+        assert!(
+            script.contains("my-ext-1.0.0~rc.1-r0.noarch.rpm"),
+            "RPM filename must be the RPM form"
+        );
+        assert!(
+            !script.contains("my-ext-1.0.0-rc.1-r0.noarch.rpm"),
+            "RPM filename must not carry the semver hyphen"
+        );
+    }
+
+    /// A plain release version is passed through untouched, so the common path
+    /// is unaffected by the mapping.
+    #[test]
+    fn test_generate_rpm_build_script_release_version_unchanged() {
+        let cmd = test_cmd();
+        let metadata = metadata_with_version("1.2.3");
+        let rpm_version = crate::utils::version::to_rpm_version(&metadata.version).unwrap();
+
+        let script = cmd.generate_rpm_build_script(
+            &metadata,
+            &rpm_version,
+            "my-ext-1.2.3-r0.noarch.rpm",
+            "Provides: avocado-target(*)",
+            "/opt/src",
+            "avocado.yaml",
+            "",
+        );
+
+        assert!(script.contains("Version: 1.2.3"));
+        assert!(script.contains("my-ext-1.2.3-r0.noarch.rpm"));
+        assert!(!script.contains('~'), "no `~` for a release version");
+    }
 
     /// A `target-<name>:` override on a remote/path-sourced extension must reach
     /// [`ExtPackageCommand::extract_rpm_metadata`], so the RPM is built at the

--- a/src/commands/ext/package.rs
+++ b/src/commands/ext/package.rs
@@ -572,10 +572,17 @@ impl ExtPackageCommand {
             format!("/opt/src/{ext_src_dir}")
         };
 
-        // Create the RPM filename
+        // RPM forbids `-` in Version (it is the Version/Release separator), so map
+        // the semver version to its RPM form (`1.0.0-rc.1` -> `1.0.0~rc.1`). Used
+        // for the spec `Version:` and the built RPM's name; the semver form is kept
+        // for the avocado.yaml baked into the payload (consumers validate semver).
+        let rpm_version = crate::utils::version::to_rpm_version(&metadata.version);
+
+        // Create the RPM filename (matches the built RPM's NVR, so it uses the
+        // RPM-form version, not the semver form).
         let rpm_filename = format!(
             "{}-{}-{}.{}.rpm",
-            metadata.name, metadata.version, metadata.release, metadata.arch
+            metadata.name, rpm_version, metadata.release, metadata.arch
         );
 
         // Convert package_files to a space-separated string for the shell script
@@ -793,7 +800,7 @@ echo "RPM created successfully: $AVOCADO_PREFIX/output/extensions/{rpm_filename}
 rm -rf "$TMPDIR"
 "#,
             name = metadata.name,
-            version = metadata.version,
+            version = rpm_version,
             release = metadata.release,
             summary = metadata.summary,
             license = metadata.license,

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -2788,7 +2788,13 @@ rpm --root="$AVOCADO_EXT_SYSROOTS/{ext_name}" --dbpath=/var/lib/extension.d/rpm 
             .await
         {
             Ok(Some(actual_version)) => {
-                let trimmed_version = actual_version.trim();
+                // `%{VERSION}` is the RPM form, so invert it back to semver. Every
+                // consumer of this value composes it with a name that was built
+                // from the *config* version — `ext/image.rs` names the `.raw` that
+                // way — so returning `1.0.0~rc.1` would have the caller demand an
+                // artifact named after a version nothing produces.
+                let trimmed_version =
+                    crate::utils::version::from_rpm_version(actual_version.trim());
                 if self.verbose {
                     print_info(
                         &format!(
@@ -2797,7 +2803,7 @@ rpm --root="$AVOCADO_EXT_SYSROOTS/{ext_name}" --dbpath=/var/lib/extension.d/rpm 
                         OutputLevel::Normal,
                     );
                 }
-                Ok(trimmed_version.to_string())
+                Ok(trimmed_version)
             }
             Ok(None) => Err(anyhow::anyhow!(
                 "Failed to query version for extension '{ext_name}' from RPM database. \

--- a/src/commands/sdk/package.rs
+++ b/src/commands/sdk/package.rs
@@ -301,7 +301,7 @@ impl SdkPackageCommand {
 
         // Build the RPM script
         let (rpm_build_script, rpm_filenames) =
-            self.generate_rpm_build_script(metadata, pkg_config, target);
+            self.generate_rpm_build_script(metadata, pkg_config, target)?;
 
         if self.verbose {
             print_info(
@@ -365,10 +365,15 @@ impl SdkPackageCommand {
         metadata: &RpmMetadata,
         pkg_config: &PackageConfig,
         _target: &str,
-    ) -> (String, Vec<String>) {
+    ) -> Result<(String, Vec<String>)> {
         let section = &self.section;
         let name = &metadata.name;
-        let version = &metadata.version;
+        // Every use of the version below is an RPM filename or the spec's
+        // `Version:` field, so it's the RPM form throughout — `extract_rpm_metadata`
+        // validates semver but `rpmspec` rejects a `-`, which aborted this command
+        // on any pre-release before.
+        let version = &crate::utils::version::to_rpm_version(&metadata.version)
+            .with_context(|| format!("Section '{}' cannot be packaged", self.section))?;
         let release = &metadata.release;
         let arch = &metadata.arch;
         let summary = &metadata.summary;
@@ -512,7 +517,7 @@ rm -rf "$TMPDIR"
 "#,
         );
 
-        (script, rpm_filenames)
+        Ok((script, rpm_filenames))
     }
 
     /// Generate spec sub-package sections for split packages.

--- a/src/utils/ext_fetch.rs
+++ b/src/utils/ext_fetch.rs
@@ -5,7 +5,7 @@
 //! - Git repositories (with optional sparse checkout)
 //! - Local filesystem paths (mounted via bindfs at runtime)
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
 use crate::utils::config::ExtensionSource;
@@ -166,11 +166,21 @@ impl ExtensionFetcher {
             );
         }
 
-        // Build the package spec using the package name (not extension name)
+        // Build the package spec using the package name (not extension name).
+        //
+        // dnf matches against the RPM's own `Version:`, which is the RPM form, so
+        // a pre-release has to be asked for as `1.0.0~rc.1` even though config
+        // (and the payload's avocado.yaml) spell it `1.0.0-rc.1`. Without this a
+        // published pre-release extension is uninstallable from config: the
+        // `repoquery --provides` layout probe and the install below both match
+        // nothing. Idempotent for a version that's already in RPM form, which is
+        // what the lockfile branch passes.
         let package_spec = if version == "*" {
             package_name.to_string()
         } else {
-            format!("{package_name}-{version}")
+            let rpm_version = crate::utils::version::to_rpm_version(version)
+                .with_context(|| format!("Cannot resolve extension '{ext_name}' from a repo"))?;
+            format!("{package_name}-{rpm_version}")
         };
 
         let repo_arg = repo_name.map(|r| format!("--repo={r}")).unwrap_or_default();

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -71,6 +71,18 @@ pub fn check_cli_requirement(requirement: &str) -> Result<()> {
     Ok(())
 }
 
+/// Convert a semver version string into an RPM-compatible `Version:` value.
+///
+/// RPM forbids `-` in the Version field (it is the Version/Release separator),
+/// so a semver pre-release like `1.0.0-rc.1` is illegal and `rpmbuild` rejects
+/// it. RPM uses `~` for pre-release ordering — `1.0.0~rc.1` sorts *before*
+/// `1.0.0`, matching semver pre-release precedence — and `^` for post-release,
+/// so map the pre-release `-` to `~` and the build-metadata `+` to `^`. A plain
+/// release version (no `-`/`+`) is returned unchanged.
+pub fn to_rpm_version(version: &str) -> String {
+    version.replace('-', "~").replace('+', "^")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -125,6 +137,18 @@ mod tests {
         assert!(check_cli_requirement(&format!("^{major}")).is_ok());
         // Wildcard that matches anything
         assert!(check_cli_requirement("*").is_ok());
+    }
+
+    #[test]
+    fn test_to_rpm_version() {
+        // Plain release versions are unchanged.
+        assert_eq!(to_rpm_version("1.0.0"), "1.0.0");
+        assert_eq!(to_rpm_version("2.1.3"), "2.1.3");
+        // Pre-release `-` becomes `~` (sorts before the release in RPM).
+        assert_eq!(to_rpm_version("1.0.0-rc.1"), "1.0.0~rc.1");
+        assert_eq!(to_rpm_version("1.0.0-alpha.2"), "1.0.0~alpha.2");
+        // Build metadata `+` becomes `^`.
+        assert_eq!(to_rpm_version("1.0.0+build.5"), "1.0.0^build.5");
     }
 
     #[test]

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -79,6 +79,15 @@ pub fn check_cli_requirement(requirement: &str) -> Result<()> {
 /// `1.0.0`, matching semver pre-release precedence — and `^` for post-release,
 /// so map the pre-release `-` to `~` and the build-metadata `+` to `^`. A plain
 /// release version (no `-`/`+`) is returned unchanged.
+///
+/// Every `-` is rewritten, not just the first. That is deliberate and not a
+/// shortcut: RPM rejects `-` anywhere in `Version:`, so a hyphen *inside* a
+/// pre-release identifier (`1.0.0-rc-1`, legal semver) has to go too. Rewriting
+/// only the leading separator would emit `1.0.0~rc-1`, which `rpmbuild` refuses
+/// outright. The cost is that the mapping is lossy — `1.0.0-rc-1` and
+/// `1.0.0~rc~1` do not round-trip back to semver — which is acceptable because
+/// the semver form is what gets baked into the payload's `avocado.yaml`; this
+/// value exists only to satisfy RPM's own grammar and ordering.
 pub fn to_rpm_version(version: &str) -> String {
     version.replace('-', "~").replace('+', "^")
 }
@@ -149,6 +158,41 @@ mod tests {
         assert_eq!(to_rpm_version("1.0.0-alpha.2"), "1.0.0~alpha.2");
         // Build metadata `+` becomes `^`.
         assert_eq!(to_rpm_version("1.0.0+build.5"), "1.0.0^build.5");
+    }
+
+    /// Semver permits `-` *inside* a pre-release or build identifier, and RPM
+    /// permits it nowhere in `Version:`. So every hyphen is rewritten, and the
+    /// result is intentionally not reversible back to the input semver.
+    #[test]
+    fn test_to_rpm_version_rewrites_hyphens_inside_identifiers() {
+        // `rc-1` is one pre-release identifier that happens to contain a
+        // hyphen. Leaving it would emit `1.0.0~rc-1`, which rpmbuild rejects,
+        // so the inner hyphen becomes `~` as well.
+        assert_eq!(to_rpm_version("1.0.0-rc-1"), "1.0.0~rc~1");
+        assert_eq!(to_rpm_version("1.0.0-pre-release-2"), "1.0.0~pre~release~2");
+        // Same rule inside build metadata.
+        assert_eq!(to_rpm_version("1.0.0+build-5"), "1.0.0^build~5");
+        // No `-` survives anywhere, whatever the shape. This is the property
+        // that actually matters: a surviving hyphen is a spec rpmbuild refuses.
+        for v in [
+            "1.0.0-rc-1",
+            "1.0.0+build-5",
+            "1.0.0-rc.1+build-5",
+            "2.0.0-a-b-c+d-e-f",
+        ] {
+            let mapped = to_rpm_version(v);
+            assert!(!mapped.contains('-'), "{v} -> {mapped} still has a hyphen");
+        }
+    }
+
+    #[test]
+    fn test_to_rpm_version_handles_prerelease_and_build_together() {
+        // Both separators present: `-` -> `~` and `+` -> `^` in one pass, with
+        // the pre-release still ordering before the release.
+        assert_eq!(to_rpm_version("1.0.0-rc.1+build.5"), "1.0.0~rc.1^build.5");
+        assert_eq!(to_rpm_version("1.0.0-rc-1+build-5"), "1.0.0~rc~1^build~5");
+        // The real shipping shape for this project.
+        assert_eq!(to_rpm_version("1.0.0-rc.1"), "1.0.0~rc.1");
     }
 
     #[test]

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -80,16 +80,60 @@ pub fn check_cli_requirement(requirement: &str) -> Result<()> {
 /// so map the pre-release `-` to `~` and the build-metadata `+` to `^`. A plain
 /// release version (no `-`/`+`) is returned unchanged.
 ///
-/// Every `-` is rewritten, not just the first. That is deliberate and not a
-/// shortcut: RPM rejects `-` anywhere in `Version:`, so a hyphen *inside* a
-/// pre-release identifier (`1.0.0-rc-1`, legal semver) has to go too. Rewriting
-/// only the leading separator would emit `1.0.0~rc-1`, which `rpmbuild` refuses
-/// outright. The cost is that the mapping is lossy — `1.0.0-rc-1` and
-/// `1.0.0~rc~1` do not round-trip back to semver — which is acceptable because
-/// the semver form is what gets baked into the payload's `avocado.yaml`; this
-/// value exists only to satisfy RPM's own grammar and ordering.
-pub fn to_rpm_version(version: &str) -> String {
-    version.replace('-', "~").replace('+', "^")
+/// The mapping is exact and reversible: semver's grammar admits only
+/// `[0-9A-Za-z.+-]`, so no `~` or `^` can occur in the input and
+/// [`from_rpm_version`] recovers the original string byte for byte.
+///
+/// A `-` *inside* a pre-release or build identifier (`1.0.0-rc-1`, legal semver)
+/// is **rejected** rather than rewritten. Leaving it is not an option — RPM
+/// forbids `-` anywhere in `Version:`, so `1.0.0~rc-1` is refused outright — but
+/// mapping it to `~` as well would silently invert ordering, because `~` is a
+/// precedence operator to RPM and an ordinary character to semver:
+///
+/// | semver                        | RPM after mapping             |
+/// |-------------------------------|-------------------------------|
+/// | `1.0.0-rc1 < 1.0.0-rc1-fix`   | `1.0.0~rc1` **>** `1.0.0~rc1~fix` |
+/// | `1.0.0-rc-1 > 1.0.0-rc.2`     | `1.0.0~rc~1` **<** `1.0.0~rc.2`   |
+///
+/// dnf would treat the newer version as the older one and refuse the upgrade. No
+/// substitute character rescues it either: `_` makes `1.0.0~rc_1` and
+/// `1.0.0~rc.1` compare equal, and `.` collides outright. Refusing the input is
+/// the only behavior that can't ship a wrong answer, and it costs only version
+/// strings nobody writes — this project ships `X.Y.Z` and `X.Y.Z-rc.N`.
+pub fn to_rpm_version(version: &str) -> Result<String> {
+    // Build metadata is whatever follows the first `+`; the pre-release is
+    // whatever follows the first `-` before it. A second `-` in either is inside
+    // an identifier rather than a separator.
+    let (core_pre, build) = match version.split_once('+') {
+        Some((core_pre, build)) => (core_pre, Some(build)),
+        None => (version, None),
+    };
+    let hyphen_in_identifier = core_pre
+        .split_once('-')
+        .is_some_and(|(_core, pre)| pre.contains('-'))
+        || build.is_some_and(|b| b.contains('-'));
+
+    if hyphen_in_identifier {
+        anyhow::bail!(
+            "Version '{version}' has a '-' inside a pre-release or build identifier. \
+             RPM forbids '-' in `Version:`, and rewriting it to '~' would invert version \
+             ordering — dnf would see the newer version as the older one and refuse the \
+             upgrade. Use '.' to separate identifiers instead (e.g. '1.0.0-rc.1')."
+        );
+    }
+
+    Ok(version.replace('-', "~").replace('+', "^"))
+}
+
+/// Invert [`to_rpm_version`], recovering the semver string from an RPM
+/// `Version:` value. Exact for anything `to_rpm_version` produced.
+///
+/// Everything in avocado outside the RPM spec and the NVR filename speaks
+/// semver — config, the payload's `avocado.yaml`, the version the platform
+/// records — so a version read back *out* of rpm (an rpmdb query, a parsed NVR)
+/// has to come back through here or it won't match the config it came from.
+pub fn from_rpm_version(rpm_version: &str) -> String {
+    rpm_version.replace('~', "-").replace('^', "+")
 }
 
 #[cfg(test)]
@@ -151,48 +195,84 @@ mod tests {
     #[test]
     fn test_to_rpm_version() {
         // Plain release versions are unchanged.
-        assert_eq!(to_rpm_version("1.0.0"), "1.0.0");
-        assert_eq!(to_rpm_version("2.1.3"), "2.1.3");
+        assert_eq!(to_rpm_version("1.0.0").unwrap(), "1.0.0");
+        assert_eq!(to_rpm_version("2.1.3").unwrap(), "2.1.3");
         // Pre-release `-` becomes `~` (sorts before the release in RPM).
-        assert_eq!(to_rpm_version("1.0.0-rc.1"), "1.0.0~rc.1");
-        assert_eq!(to_rpm_version("1.0.0-alpha.2"), "1.0.0~alpha.2");
+        assert_eq!(to_rpm_version("1.0.0-rc.1").unwrap(), "1.0.0~rc.1");
+        assert_eq!(to_rpm_version("1.0.0-alpha.2").unwrap(), "1.0.0~alpha.2");
         // Build metadata `+` becomes `^`.
-        assert_eq!(to_rpm_version("1.0.0+build.5"), "1.0.0^build.5");
-    }
-
-    /// Semver permits `-` *inside* a pre-release or build identifier, and RPM
-    /// permits it nowhere in `Version:`. So every hyphen is rewritten, and the
-    /// result is intentionally not reversible back to the input semver.
-    #[test]
-    fn test_to_rpm_version_rewrites_hyphens_inside_identifiers() {
-        // `rc-1` is one pre-release identifier that happens to contain a
-        // hyphen. Leaving it would emit `1.0.0~rc-1`, which rpmbuild rejects,
-        // so the inner hyphen becomes `~` as well.
-        assert_eq!(to_rpm_version("1.0.0-rc-1"), "1.0.0~rc~1");
-        assert_eq!(to_rpm_version("1.0.0-pre-release-2"), "1.0.0~pre~release~2");
-        // Same rule inside build metadata.
-        assert_eq!(to_rpm_version("1.0.0+build-5"), "1.0.0^build~5");
-        // No `-` survives anywhere, whatever the shape. This is the property
-        // that actually matters: a surviving hyphen is a spec rpmbuild refuses.
-        for v in [
-            "1.0.0-rc-1",
-            "1.0.0+build-5",
-            "1.0.0-rc.1+build-5",
-            "2.0.0-a-b-c+d-e-f",
-        ] {
-            let mapped = to_rpm_version(v);
-            assert!(!mapped.contains('-'), "{v} -> {mapped} still has a hyphen");
-        }
+        assert_eq!(to_rpm_version("1.0.0+build.5").unwrap(), "1.0.0^build.5");
     }
 
     #[test]
     fn test_to_rpm_version_handles_prerelease_and_build_together() {
         // Both separators present: `-` -> `~` and `+` -> `^` in one pass, with
         // the pre-release still ordering before the release.
-        assert_eq!(to_rpm_version("1.0.0-rc.1+build.5"), "1.0.0~rc.1^build.5");
-        assert_eq!(to_rpm_version("1.0.0-rc-1+build-5"), "1.0.0~rc~1^build~5");
+        assert_eq!(
+            to_rpm_version("1.0.0-rc.1+build.5").unwrap(),
+            "1.0.0~rc.1^build.5"
+        );
         // The real shipping shape for this project.
-        assert_eq!(to_rpm_version("1.0.0-rc.1"), "1.0.0~rc.1");
+        assert_eq!(to_rpm_version("1.0.0-rc.1").unwrap(), "1.0.0~rc.1");
+    }
+
+    /// A `-` inside an identifier can't be rewritten to `~` — `~` is a
+    /// precedence operator in RPM, so `1.0.0~rc1~fix` sorts *below* `1.0.0~rc1`
+    /// while semver puts `1.0.0-rc1-fix` above `1.0.0-rc1`. dnf would refuse the
+    /// upgrade. It can't be left alone either (rpmbuild rejects any `-`), so the
+    /// only answer that isn't silently wrong is to refuse the input.
+    #[test]
+    fn test_to_rpm_version_rejects_hyphen_inside_identifier() {
+        for v in [
+            "1.0.0-rc-1",          // hyphen in a pre-release identifier
+            "1.0.0-pre-release-2", // several
+            "1.0.0+build-5",       // hyphen in build metadata
+            "1.0.0-rc.1+build-5",  // valid pre-release, bad build metadata
+            "2.0.0-a-b-c+d-e-f",   // bad in both
+            "1.0.0-rc1-fix",       // the measured ordering inversion
+        ] {
+            let err = to_rpm_version(v).expect_err("{v} should be rejected");
+            let msg = err.to_string();
+            assert!(msg.contains(v), "error should name the version: {msg}");
+            assert!(
+                msg.contains("invert version ordering"),
+                "error should explain why, got: {msg}"
+            );
+        }
+    }
+
+    /// The property the RPM spec actually depends on: whatever comes back out of
+    /// `to_rpm_version` carries no `-`, because a surviving hyphen is a spec
+    /// `rpmbuild` refuses outright.
+    #[test]
+    fn test_to_rpm_version_never_emits_a_hyphen() {
+        for v in ["1.0.0", "1.0.0-rc.1", "1.0.0+build.5", "1.0.0-rc.1+build.5"] {
+            let mapped = to_rpm_version(v).unwrap();
+            assert!(!mapped.contains('-'), "{v} -> {mapped} still has a hyphen");
+        }
+    }
+
+    /// The mapping is injective, so it inverts exactly — which is what the
+    /// publish and rpmdb-query paths rely on to get back to the config's semver.
+    #[test]
+    fn test_rpm_version_round_trips() {
+        for v in [
+            "1.0.0",
+            "2.1.3",
+            "1.0.0-rc.1",
+            "1.0.0-alpha.2",
+            "1.0.0+build.5",
+            "1.0.0-rc.1+build.5",
+        ] {
+            let rpm = to_rpm_version(v).unwrap();
+            assert_eq!(
+                from_rpm_version(&rpm),
+                v,
+                "{v} did not round-trip via {rpm}"
+            );
+        }
+        // A release version has nothing to invert.
+        assert_eq!(from_rpm_version("1.0.0"), "1.0.0");
     }
 
     #[test]


### PR DESCRIPTION
## Problem
Packaging an extension whose version is a valid semver **pre-release** (e.g. `1.0.0-rc.1`) fails at spec build:

```
Building for target noarch
error: line 5: Illegal char '-' (0x2d) in: Version: 1.0.0-rc.1
```

RPM forbids `-` in the `Version:` field — it's the Version/Release separator. The extension packager wrote the raw semver string straight into the spec, so any `-rc.N`/`-alpha`/`-beta` version is rejected. Surfaced by the `1.0.0-rc.1` release, but it applies to any pre-release ext version.

## Fix
Map the semver version to an RPM-compatible form for the **spec `Version:`** and the **built RPM's filename**:
- `-` → `~` (RPM pre-release: `1.0.0~rc.1` sorts *before* `1.0.0`, matching semver pre-release precedence)
- `+` → `^` (build metadata → RPM post-release)

Plain releases (`1.0.0`) are unchanged. New helper `utils::version::to_rpm_version`.

The **semver form is preserved** for the `avocado.yaml` baked into the package payload — consumers validate that field as semver, and `~` is not valid semver — so only the RPM artifacts (Version + filename) get the transformed value. This keeps the human/avocado-facing version as `1.0.0-rc.1` while the RPM/feed sees `1.0.0~rc.1`.

## Test
- New unit test `test_to_rpm_version` (plain / `-rc.1` / `-alpha.2` / `+build.5`).
- `cargo build` clean; `version::tests` (31) and `ext::package` (13) suites pass.

## Release note
The packaging is done by the *installed* avocado CLI, so this fix only takes effect once it ships in a CLI release. `1.0.0-rc.1` (already tagged) still packages with the bug — the fix will land in the next tag (rc.2). That release will also want the ext-release/release asset-upload race fix discussed on the prior PR, or its Extension Release run must be re-run after `release.yml` finishes uploading.