### PR TITLE
deploy: align --connect-sign help text with promote-root --key requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `avocado-cli` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`--connect-sign` guidance.** The deploy help text and the Level 2 setup
+  messages now reference `avocado connect trust promote-root --key <KEY>` with
+  its required `--key` option, matching the CLI reference documentation.
+
 ## [1.0.0-rc.1]
 
 Release candidate for 1.0.0.

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -1877,7 +1877,7 @@ echo "Provisioned update authority: metadata/root.json""#
                         anyhow::bail!(
                             "Signing key is configured but connect.server_key is missing.\n\
                              Level 2 requires the server key to build a multi-key root.json.\n\
-                             Run 'avocado connect trust promote-root' to set up Level 2,\n\
+                             Run 'avocado connect trust promote-root --key <KEY>' to set up Level 2,\n\
                              or remove signing.key to use Level 0 (server-managed)."
                         );
                     }

--- a/src/commands/runtime/deploy.rs
+++ b/src/commands/runtime/deploy.rs
@@ -672,7 +672,7 @@ if [ ! -f "$ROOT_JSON_FILE" ]; then
     echo "ERROR: No root.json found at $ROOT_JSON_FILE" >&2
     echo "       The runtime has no update-authority (root.json) baked into its build." >&2
     echo "       This usually means no signing key is configured. Set 'signing.key' for" >&2
-    echo "       the runtime (for a Connect project, run 'avocado connect trust promote-root')" >&2
+    echo "       the runtime (for a Connect project, run 'avocado connect trust promote-root --key <KEY>')" >&2
     echo "       and rebuild. --connect-sign requires a local signing key for this reason." >&2
     exit 1
 fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -444,7 +444,7 @@ enum Commands {
         /// Sign TUF metadata via the Connect platform instead of locally.
         /// Use this when deploying to a device that has received a Connect OTA update.
         /// Requires a local signing key configured for the runtime (Level 2:
-        /// `signing.key` + `avocado connect trust promote-root`); without one no
+        /// signing.key + avocado connect trust promote-root --key <KEY>); without one no
         /// root.json is baked and the deploy fails during Phase 1 hash collection.
         #[arg(long)]
         connect_sign: bool,
@@ -1792,7 +1792,7 @@ enum RuntimeCommands {
         /// Sign TUF metadata via the Connect platform instead of locally.
         /// Use this when deploying to a device that has received a Connect OTA update.
         /// Requires a local signing key configured for the runtime (Level 2:
-        /// `signing.key` + `avocado connect trust promote-root`); without one no
+        /// signing.key + avocado connect trust promote-root --key <KEY>); without one no
         /// root.json is baked and the deploy fails during Phase 1 hash collection.
         #[arg(long)]
         connect_sign: bool,


### PR DESCRIPTION
## Problem

The `--connect-sign` help text and the Level 2 setup messages pointed users at
`avocado connect trust promote-root` without its required `--key <KEY>` option
(`Usage: ... promote-root [OPTIONS] --key <KEY>`), so a copied command failed.
After the command reference docs were corrected in peridio/docs#450, the CLI
help output was left inconsistent with the published docs.

## Solution

Add `--key <KEY>` to every user-facing `promote-root` instruction, and drop the
Markdown backticks from the `--connect-sign` help text. clap renders those
backticks literally in `--help` output, so removing them makes the terminal
help match the documented output verbatim.

## Key changes

- `main.rs`: both deploy `--connect-sign` help blocks now read
  `signing.key + avocado connect trust promote-root --key <KEY>` (backticks removed).
- `commands/runtime/deploy.rs`: the Phase-1 "No root.json found" error names the
  full command with `--key <KEY>`.
- `commands/runtime/build.rs`: the Level 2 setup guidance names the full command.
- `CHANGELOG.md`: added an Unreleased / Fixed entry.

## Reviewer notes

Follow-up to peridio/docs#450 per Lee's review note there. Docs-and-string only,
no behavior change. Verified locally: `cargo fmt --all -- --check`,
`cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test`
(1094 passed) all clean. The `client.rs` API URL paths
(`/api/orgs/{}/trust/promote-root/...`) are intentionally untouched.
