### PR TITLE
Reap abandoned build volumes and clarify stale-volume errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ are made now, in the RC, precisely so 1.0.0 can commit to the contract above.
   `-alpha`/`-beta` tags remain internal-only prereleases. (#170)
 - **VM guest networking.** VMs use `virtio-net-pci` so the guest NIC binds on the
   q35 machine type.
+- **Abandoned build volumes reclaimed automatically.** `install` and `build` now
+  delete provably-abandoned per-project `avo-*` Docker volumes (source directory
+  gone, or `.avocado-state` missing or pointing at a different volume) when a new
+  volume is created, so they no longer accumulate after a project directory is
+  removed without `avocado clean`. A stale or half-populated volume now fails the
+  rootfs build with an actionable message pointing at `avocado clean`/`avocado
+  prune` instead of a cryptic `grep: .../etc/passwd` error. (#178)
 
 ### Fixed
 - **Standalone `avocado kernel image` on non-arm targets.** The command located

--- a/src/commands/connect/keys/list.rs
+++ b/src/commands/connect/keys/list.rs
@@ -42,7 +42,7 @@ impl ConnectKeysListCommand {
 
             println!(
                 "{:<12} {:<10} {:<10} {:<66} {:<24}",
-                key.key_type, key.status, user, &key.keyid, activated
+                key.key_type, key.status, user, key.keyid, activated
             );
         }
 

--- a/src/commands/ext/image.rs
+++ b/src/commands/ext/image.rs
@@ -652,7 +652,7 @@ impl ExtImageCommand {
                     &format!(
                         "Successfully created image for extension '{}-{}': {}",
                         self.extension,
-                        &ext_version,
+                        ext_version,
                         PathBuf::from(output_dir).join(&image_filename).display()
                     ),
                     OutputLevel::Normal,
@@ -662,7 +662,7 @@ impl ExtImageCommand {
                     &format!(
                         "Successfully created image for extension '{}-{}' (types: {}).",
                         self.extension,
-                        &ext_version,
+                        ext_version,
                         ext_types.join(", ")
                     ),
                     OutputLevel::Normal,

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -6,11 +6,10 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::path::Path;
 use tokio::process::Command as AsyncCommand;
 
 use crate::utils::output::{print_error, print_info, print_success, print_warning, OutputLevel};
-use crate::utils::volume::VolumeState;
+use crate::utils::volume::avo_abandonment_reason;
 
 /// Information about a Docker volume from `docker volume inspect`
 #[derive(Debug, Clone, Deserialize)]
@@ -207,59 +206,20 @@ impl PruneCommand {
     /// 2. If .avocado-state file exists in that directory
     /// 3. If the state file links back to this volume's UUID
     async fn classify_avo_volume(&self, volume_name: &str) -> Result<VolumeStatus> {
-        // Get volume info including labels
+        // Read the recorded source_path label, then delegate the on-disk
+        // decision to the shared classifier so `prune` and the init-time
+        // reap agree on what "abandoned" means.
         let volume_info = self.inspect_volume(volume_name).await?;
+        let source_path = volume_info
+            .labels
+            .as_ref()
+            .and_then(|labels| labels.get("avocado.source_path"))
+            .map(String::as_str);
 
-        // Get the source_path label
-        let source_path = match &volume_info.labels {
-            Some(labels) => labels.get("avocado.source_path"),
-            None => None,
-        };
-
-        let source_path = match source_path {
-            Some(path) => path,
-            None => {
-                return Ok(VolumeStatus::Abandoned(
-                    "no source_path label found".to_string(),
-                ));
-            }
-        };
-
-        // Check if the source directory exists
-        let source_dir = Path::new(source_path);
-        if !source_dir.exists() {
-            return Ok(VolumeStatus::Abandoned(format!(
-                "source directory '{source_path}' does not exist"
-            )));
-        }
-
-        // Check for .avocado-state file
-        let state_file = source_dir.join(".avocado-state");
-        if !state_file.exists() {
-            return Ok(VolumeStatus::Abandoned(format!(
-                "no .avocado-state file in '{source_path}'"
-            )));
-        }
-
-        // Load and verify the state file links to this volume
-        match VolumeState::load_from_dir(source_dir) {
-            Ok(Some(state)) => {
-                if state.volume_name == volume_name {
-                    Ok(VolumeStatus::Active)
-                } else {
-                    Ok(VolumeStatus::Abandoned(format!(
-                        ".avocado-state links to '{}', not this volume",
-                        state.volume_name
-                    )))
-                }
-            }
-            Ok(None) => Ok(VolumeStatus::Abandoned(format!(
-                "could not read .avocado-state in '{source_path}'"
-            ))),
-            Err(e) => Ok(VolumeStatus::Abandoned(format!(
-                "error reading .avocado-state: {e}"
-            ))),
-        }
+        Ok(match avo_abandonment_reason(volume_name, source_path) {
+            Some(reason) => VolumeStatus::Abandoned(reason),
+            None => VolumeStatus::Active,
+        })
     }
 
     /// Classify an avocado-src-* or avocado-state-* volume

--- a/src/commands/rootfs/image.rs
+++ b/src/commands/rootfs/image.rs
@@ -140,6 +140,18 @@ if [ -d "$ROOTFS_SYSROOT/usr" ]; then
     mkdir -p "$(dirname "$ROOTFS_WORK")"
     rm -rf "$ROOTFS_WORK"
     cp -a "$ROOTFS_SYSROOT" "$ROOTFS_WORK"
+
+    # A fully-installed sysroot always ships /etc/passwd. If it is absent
+    # the build volume is half-populated or stale (e.g. a prior install
+    # was interrupted, or the project dir was deleted without `avocado
+    # clean`). Fail here with an actionable message rather than letting
+    # the user-creation step below emit a cryptic
+    # `grep: .../etc/passwd: No such file`.
+    if [ ! -f "$ROOTFS_WORK/etc/passwd" ]; then
+        echo "ERROR: rootfs staging at $ROOTFS_WORK is missing /etc/passwd. The build volume looks half-populated or stale." >&2
+        echo "Reset the build state with 'avocado clean' and 'avocado prune', then re-run 'avocado install -f' and 'avocado build'." >&2
+        exit 1
+    fi
 {permissions_section}
 
 {post_install_block}
@@ -498,5 +510,61 @@ export AVOCADO_OS_VERSION_ID
         print_success("Built rootfs image.", OutputLevel::Normal);
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rootfs_script_guards_against_half_populated_sysroot() {
+        // A stale or interrupted build volume can leave the sysroot with
+        // /usr present but /etc/passwd missing, which used to surface as
+        // a cryptic `grep: .../etc/passwd: No such file` from the
+        // user-creation step. The generated script must instead fail
+        // fast with an actionable message pointing at `avocado clean`.
+        let script = generate_rootfs_build_script(
+            "00000000-0000-0000-0000-000000000000",
+            "erofs-lz4",
+            None,
+            "# permissions placeholder\n",
+        );
+
+        assert!(
+            script.contains("$ROOTFS_WORK/etc/passwd"),
+            "script must check for the base rootfs /etc/passwd before user creation"
+        );
+        assert!(
+            script.contains("avocado clean"),
+            "script must tell the user to run `avocado clean` on a stale volume"
+        );
+        assert!(
+            script.contains("avocado prune"),
+            "script must also point at `avocado prune`, since clean alone does not \
+             clear abandoned volumes that can shadow a build"
+        );
+    }
+
+    #[test]
+    fn test_rootfs_passwd_guard_precedes_permissions_section() {
+        // The guard only helps if it runs before the user-creation
+        // (permissions) step it protects.
+        let marker = "# PERMISSIONS_MARKER_FOR_TEST";
+        let script = generate_rootfs_build_script(
+            "00000000-0000-0000-0000-000000000000",
+            "erofs-lz4",
+            None,
+            marker,
+        );
+
+        let guard_pos = script
+            .find("$ROOTFS_WORK/etc/passwd")
+            .expect("guard present");
+        let perms_pos = script.find(marker).expect("permissions section present");
+        assert!(
+            guard_pos < perms_pos,
+            "the /etc/passwd guard must run before the permissions/user-creation section"
+        );
     }
 }

--- a/src/commands/sdk/deps.rs
+++ b/src/commands/sdk/deps.rs
@@ -134,7 +134,7 @@ impl SdkDepsCommand {
         self.collect_compile_dependencies_by_section(config, &mut sections);
 
         // Sort packages within each section
-        for (_, packages) in sections.iter_mut() {
+        for packages in sections.values_mut() {
             packages.sort_by(|a, b| a.1.cmp(&b.1)); // Sort by package name
         }
 

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -100,12 +100,12 @@ impl UpgradeCommand {
             if err.kind() == ErrorKind::PermissionDenied {
                 return Err(format!(
                     "CLI failed to upgrade: permission denied writing to {}",
-                    &current_cli_executable.display()
+                    current_cli_executable.display()
                 ));
             }
             return Err(format!(
                 "CLI failed to upgrade: unknown error writing to {}",
-                &current_cli_executable.display()
+                current_cli_executable.display()
             ));
         }
 

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -2916,10 +2916,7 @@ impl Config {
         let mut current = yaml;
 
         for part in parts {
-            match current.get(part) {
-                Some(value) => current = value,
-                None => return None,
-            }
+            current = current.get(part)?;
         }
 
         Some(current)

--- a/src/utils/volume.rs
+++ b/src/utils/volume.rs
@@ -70,6 +70,41 @@ impl VolumeState {
     }
 }
 
+/// Decide whether an `avo-<uuid>` volume is abandoned, based solely on
+/// on-disk state (no container calls), given the `avocado.source_path`
+/// label recorded on the volume when it was created.
+///
+/// Returns `Some(reason)` when the volume is a stale leftover safe to
+/// reap, or `None` when it is still bound to a live project. The checks
+/// mirror the ones `avocado prune` applies so both paths agree on what
+/// "abandoned" means.
+pub fn avo_abandonment_reason(volume_name: &str, source_path: Option<&str>) -> Option<String> {
+    let source_path = match source_path {
+        Some(path) => path,
+        None => return Some("no source_path label found".to_string()),
+    };
+
+    let source_dir = Path::new(source_path);
+    if !source_dir.exists() {
+        return Some(format!("source directory '{source_path}' does not exist"));
+    }
+
+    let state_file = source_dir.join(".avocado-state");
+    if !state_file.exists() {
+        return Some(format!("no .avocado-state file in '{source_path}'"));
+    }
+
+    match VolumeState::load_from_dir(source_dir) {
+        Ok(Some(state)) if state.volume_name == volume_name => None,
+        Ok(Some(state)) => Some(format!(
+            ".avocado-state links to '{}', not this volume",
+            state.volume_name
+        )),
+        Ok(None) => Some(format!("could not read .avocado-state in '{source_path}'")),
+        Err(e) => Some(format!("error reading .avocado-state: {e}")),
+    }
+}
+
 /// Docker volume manager for Avocado operations
 pub struct VolumeManager {
     container_tool: String,
@@ -109,6 +144,20 @@ impl VolumeManager {
             }
         }
 
+        // We're about to mint a fresh volume for this project. That's the
+        // natural moment to sweep volumes left behind by projects deleted
+        // from disk without `avocado clean`: a manual `rm -rf` drops the
+        // project folder but not its per-project `avo-<uuid>` volume, so
+        // they otherwise accumulate forever. Best-effort by design — a
+        // container-tool hiccup must never block volume creation.
+        let reaped = self.reap_abandoned_avo_volumes().await;
+        if !reaped.is_empty() && self.verbose {
+            print_info(
+                &format!("Reaped {} abandoned build volume(s).", reaped.len()),
+                OutputLevel::Normal,
+            );
+        }
+
         // Create new volume state
         let state = VolumeState::new(source_dir.to_path_buf(), self.container_tool.clone());
 
@@ -126,6 +175,72 @@ impl VolumeManager {
         }
 
         Ok(state)
+    }
+
+    /// Best-effort removal of abandoned `avo-*` volumes left behind by
+    /// projects deleted from disk without `avocado clean`. Each `avo-*`
+    /// volume is classified with [`avo_abandonment_reason`] and removed
+    /// when abandoned. Any container-tool failure — daemon down, volume
+    /// still held by a container — is swallowed so this never blocks the
+    /// caller. Returns the names of the volumes actually removed.
+    pub async fn reap_abandoned_avo_volumes(&self) -> Vec<String> {
+        let names = match self.list_avo_volumes().await {
+            Ok(names) => names,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut removed = Vec::new();
+        for name in names {
+            let source_path = self.inspect_source_path_label(&name).await;
+            if avo_abandonment_reason(&name, source_path.as_deref()).is_some()
+                && self.remove_volume(&name).await.is_ok()
+            {
+                removed.push(name);
+            }
+        }
+        removed
+    }
+
+    /// List every `avo-*` docker volume name.
+    async fn list_avo_volumes(&self) -> Result<Vec<String>> {
+        let output = AsyncCommand::new(&self.container_tool)
+            .args(["volume", "ls", "--format", "{{.Name}}"])
+            .output()
+            .await
+            .with_context(|| "Failed to list docker volumes")?;
+
+        if !output.status.success() {
+            anyhow::bail!("Failed to list docker volumes");
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter(|line| line.starts_with("avo-"))
+            .map(|s| s.to_string())
+            .collect())
+    }
+
+    /// Read the `avocado.source_path` label off a volume. Returns `None`
+    /// when the volume is missing, unlabeled, or the inspect output
+    /// cannot be parsed.
+    async fn inspect_source_path_label(&self, volume_name: &str) -> Option<String> {
+        let output = AsyncCommand::new(&self.container_tool)
+            .args(["volume", "inspect", volume_name])
+            .output()
+            .await
+            .ok()?;
+
+        if !output.status.success() {
+            return None;
+        }
+
+        let infos: Vec<VolumeInfo> =
+            serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).ok()?;
+        infos
+            .into_iter()
+            .next()
+            .and_then(|info| info.labels)
+            .and_then(|labels| labels.get("avocado.source_path").cloned())
     }
 
     /// Check if a docker volume exists
@@ -436,5 +551,54 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let result = VolumeState::load_from_dir(temp_dir.path()).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_abandonment_reason_active_when_state_matches() {
+        // A volume whose recorded source directory still holds a
+        // .avocado-state file pointing back at it is live: no reason.
+        let temp_dir = TempDir::new().unwrap();
+        let state = VolumeState::new(temp_dir.path().to_path_buf(), "docker".to_string());
+        state.save_to_dir(temp_dir.path()).unwrap();
+
+        assert_eq!(
+            avo_abandonment_reason(&state.volume_name, Some(&state.source_path)),
+            None
+        );
+    }
+
+    #[test]
+    fn test_abandonment_reason_no_source_path_label() {
+        let reason = avo_abandonment_reason("avo-x", None).unwrap();
+        assert!(reason.contains("no source_path label"));
+    }
+
+    #[test]
+    fn test_abandonment_reason_missing_source_dir() {
+        let reason =
+            avo_abandonment_reason("avo-x", Some("/nonexistent/avocado/project/xyz")).unwrap();
+        assert!(reason.contains("does not exist"));
+    }
+
+    #[test]
+    fn test_abandonment_reason_no_state_file() {
+        // Source dir exists but carries no .avocado-state: abandoned.
+        let temp_dir = TempDir::new().unwrap();
+        let reason =
+            avo_abandonment_reason("avo-x", Some(temp_dir.path().to_str().unwrap())).unwrap();
+        assert!(reason.contains("no .avocado-state"));
+    }
+
+    #[test]
+    fn test_abandonment_reason_state_points_elsewhere() {
+        // The state file links to a different volume name, so this
+        // volume is a stale leftover safe to reap.
+        let temp_dir = TempDir::new().unwrap();
+        let state = VolumeState::new(temp_dir.path().to_path_buf(), "docker".to_string());
+        state.save_to_dir(temp_dir.path()).unwrap();
+
+        let reason =
+            avo_abandonment_reason("avo-different-uuid", Some(&state.source_path)).unwrap();
+        assert!(reason.contains("not this volume"));
     }
 }

--- a/src/utils/volume.rs
+++ b/src/utils/volume.rs
@@ -148,7 +148,7 @@ impl VolumeManager {
         // natural moment to sweep volumes left behind by projects deleted
         // from disk without `avocado clean`: a manual `rm -rf` drops the
         // project folder but not its per-project `avo-<uuid>` volume, so
-        // they otherwise accumulate forever. Best-effort by design — a
+        // they otherwise accumulate forever. Best-effort by design: a
         // container-tool hiccup must never block volume creation.
         let reaped = self.reap_abandoned_avo_volumes().await;
         if !reaped.is_empty() && self.verbose {
@@ -161,11 +161,18 @@ impl VolumeManager {
         // Create new volume state
         let state = VolumeState::new(source_dir.to_path_buf(), self.container_tool.clone());
 
+        // Persist the state file BEFORE creating the docker volume. This
+        // closes a cross-process race: a concurrent reap in another project
+        // must never observe this volume after `docker volume create` but
+        // before its `.avocado-state` exists, which would classify it as
+        // abandoned and delete it mid-mint. Writing state first means the
+        // volume is never visible without its state pointer. `volume_exists`
+        // already tolerates a state file pointing at a not-yet-created
+        // volume, so a failed create is simply superseded on the next call.
+        state.save_to_dir(source_dir)?;
+
         // Create the docker volume with metadata
         self.create_volume(&state).await?;
-
-        // Save state to file
-        state.save_to_dir(source_dir)?;
 
         if self.verbose {
             print_info(
@@ -180,9 +187,10 @@ impl VolumeManager {
     /// Best-effort removal of abandoned `avo-*` volumes left behind by
     /// projects deleted from disk without `avocado clean`. Each `avo-*`
     /// volume is classified with [`avo_abandonment_reason`] and removed
-    /// when abandoned. Any container-tool failure — daemon down, volume
-    /// still held by a container — is swallowed so this never blocks the
-    /// caller. Returns the names of the volumes actually removed.
+    /// when abandoned. Any container-tool failure (daemon down, volume
+    /// still held by a container, inspect error) is swallowed or skipped so
+    /// this never blocks the caller, and a failed inspect is skipped rather
+    /// than reaped. Returns the names of the volumes actually removed.
     pub async fn reap_abandoned_avo_volumes(&self) -> Vec<String> {
         let names = match self.list_avo_volumes().await {
             Ok(names) => names,
@@ -191,11 +199,23 @@ impl VolumeManager {
 
         let mut removed = Vec::new();
         for name in names {
-            let source_path = self.inspect_source_path_label(&name).await;
-            if avo_abandonment_reason(&name, source_path.as_deref()).is_some()
-                && self.remove_volume(&name).await.is_ok()
-            {
-                removed.push(name);
+            // Skip on inspect failure: a transient docker hiccup must never
+            // be read as "no source_path label", which would classify an
+            // active project's volume as abandoned and delete it.
+            let source_path = match self.inspect_source_path_label(&name).await {
+                Ok(source_path) => source_path,
+                Err(_) => continue,
+            };
+            if let Some(reason) = avo_abandonment_reason(&name, source_path.as_deref()) {
+                if self.remove_volume(&name).await.is_ok() {
+                    if self.verbose {
+                        print_info(
+                            &format!("Reaped abandoned build volume '{name}': {reason}"),
+                            OutputLevel::Normal,
+                        );
+                    }
+                    removed.push(name);
+                }
             }
         }
         removed
@@ -220,27 +240,34 @@ impl VolumeManager {
             .collect())
     }
 
-    /// Read the `avocado.source_path` label off a volume. Returns `None`
-    /// when the volume is missing, unlabeled, or the inspect output
-    /// cannot be parsed.
-    async fn inspect_source_path_label(&self, volume_name: &str) -> Option<String> {
+    /// Read the `avocado.source_path` label off a volume.
+    ///
+    /// Returns `Ok(Some(path))` when the label is present, `Ok(None)` when
+    /// the volume exists but carries no such label, and `Err` when the
+    /// inspect itself failed (daemon down, timeout, unparseable output).
+    /// The tri-state is load-bearing for the reap: a failed inspect must
+    /// NOT collapse to "no label", or a transient hiccup would classify an
+    /// active project's volume as abandoned and delete it. The caller skips
+    /// the volume on `Err`.
+    async fn inspect_source_path_label(&self, volume_name: &str) -> Result<Option<String>> {
         let output = AsyncCommand::new(&self.container_tool)
             .args(["volume", "inspect", volume_name])
             .output()
             .await
-            .ok()?;
+            .with_context(|| format!("Failed to inspect volume {volume_name}"))?;
 
         if !output.status.success() {
-            return None;
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Failed to inspect volume {volume_name}: {}", stderr.trim());
         }
 
-        let infos: Vec<VolumeInfo> =
-            serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).ok()?;
-        infos
+        let infos: Vec<VolumeInfo> = serde_json::from_str(&String::from_utf8_lossy(&output.stdout))
+            .with_context(|| "Failed to parse volume inspect output")?;
+        Ok(infos
             .into_iter()
             .next()
             .and_then(|info| info.labels)
-            .and_then(|labels| labels.get("avocado.source_path").cloned())
+            .and_then(|labels| labels.get("avocado.source_path").cloned()))
     }
 
     /// Check if a docker volume exists


### PR DESCRIPTION
## Problem

Each project gets a per-project Docker volume (`avo-<uuid>`) recorded in its `.avocado-state` file. Deleting a project directory by hand drops the folder but not the volume, so `avo-*` volumes accumulate unbounded. Worse, a stale or half-populated volume makes `avocado build` fail during `runtime build dev` with a cryptic `grep: .../rootfs-work/etc/passwd: No such file`, naming neither the cause nor the fix.

## Solution

Reclaim provably-abandoned `avo-*` volumes at the moment a fresh volume is minted, and guard the rootfs build so a half-populated sysroot fails fast with an actionable message instead of the grep noise.

## Key changes

- Auto-reap abandoned `avo-*` volumes in `get_or_create_volume` (the natural GC point, and the only path already holding a container-tool handle, so `init` and the pure-filesystem commands stay docker-free). Best-effort: a daemon-down or held-volume failure is swallowed and never blocks a build.
- Share one classifier, `avo_abandonment_reason`, between the reap and `avocado prune` so the two paths cannot drift on what "abandoned" means.
- Guard the rootfs build: if `rootfs-work` lacks `/etc/passwd` after the sysroot copy, exit with a message pointing at `avocado clean` and `avocado prune`.
- Tests: 5 classifier cases plus generated-script assertions (guard present and ordered before user creation).

## Reviewer notes

- Behavior change: `install`/`build` now delete provably-dead `avo-*` volumes (source dir gone, no `.avocado-state`, or state pointing at a different volume). Active project volumes are never touched.
- Verified against the QEMU getting-started flow: a clean build still succeeds, and the guard fires with the actionable message on a simulated half-populated sysroot.
- Companion docs troubleshooting note is a separate peridio/docs PR.
