### PR TITLE
fix(deploy): surface container script stderr instead of generic failure messages

### DIFF
--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -789,7 +789,14 @@ impl RuntimeBuildCommand {
         }
 
         // Generate TUF delegation staging and write into the build volume.
-        // If signing keys are not configured this step is skipped with a warning.
+        // Deliberately nonfatal: many projects have no signing configuration,
+        // so build must succeed without staging; a Level-2 project whose
+        // staging fails here surfaces a self-explaining error at deploy or
+        // upload time instead. The skip notice routes through the active
+        // renderer when one exists — print_* is suppressed in TUI/JSON
+        // modes, so it would otherwise vanish exactly where builds usually
+        // run. TUI queues it above the task region; JSON mode writes it to
+        // stderr without corrupting the NDJSON stream.
         let project_dir = std::path::Path::new(&self.config_path)
             .parent()
             .unwrap_or(std::path::Path::new("."));
@@ -807,10 +814,17 @@ impl RuntimeBuildCommand {
             )
             .await
         {
-            print_info(
-                &format!("Skipping TUF delegation staging: {e:#}"),
-                OutputLevel::Normal,
-            );
+            let msg = format!("Skipping TUF delegation staging: {e:#}");
+            if let Some(renderer) = crate::utils::tui::get_active_renderer() {
+                renderer.print_above(&msg);
+            } else if crate::utils::output_format::is_json_output_active() {
+                // Verbose JSON builds create no renderer, and print_info is
+                // suppressed in JSON mode — write to stderr directly so the
+                // notice survives without touching the NDJSON stdout stream.
+                eprintln!("{msg}");
+            } else {
+                print_info(&msg, OutputLevel::Normal);
+            }
         }
 
         Ok(())
@@ -1002,10 +1016,22 @@ echo -n '}}'
             env_vars: self.runtime_env_vars(),
             ..Default::default()
         };
-        let hash_output =
-            run_container_command_with_output(container_helper, hash_run_config, runs_on_context)
-                .await?
-                .context("Hash collection script produced no output")?;
+        let hash_result =
+            run_container_command_capture(container_helper, hash_run_config, runs_on_context)
+                .await?;
+        if !hash_result.success {
+            if self.verbose {
+                crate::utils::container::print_failure_notice(&format!(
+                    "Full container stderr:\n{}",
+                    hash_result.stderr
+                ));
+            }
+            anyhow::bail!(crate::utils::container::container_failure_message(
+                "Hash collection failed in the SDK container",
+                &hash_result.stderr,
+            ));
+        }
+        let hash_output = hash_result.stdout.trim().to_string();
 
         let collection: update_repo::HashCollectionOutput =
             serde_json::from_str(&hash_output).context("Failed to parse hash collection output")?;
@@ -1110,10 +1136,22 @@ cp /opt/src/.tuf-staging-tmp/delegations/runtime-{runtime_uuid}.json \
             env_vars: self.runtime_env_vars(),
             ..Default::default()
         };
-        let hash_output =
-            run_container_command_with_output(container_helper, hash_run_config, runs_on_context)
-                .await?
-                .context("Hash collection script produced no output")?;
+        let hash_result =
+            run_container_command_capture(container_helper, hash_run_config, runs_on_context)
+                .await?;
+        if !hash_result.success {
+            if self.verbose {
+                crate::utils::container::print_failure_notice(&format!(
+                    "Full container stderr:\n{}",
+                    hash_result.stderr
+                ));
+            }
+            anyhow::bail!(crate::utils::container::container_failure_message(
+                "Hash collection failed in the SDK container",
+                &hash_result.stderr,
+            ));
+        }
+        let hash_output = hash_result.stdout.trim().to_string();
 
         let collection: update_repo::HashCollectionOutput =
             serde_json::from_str(&hash_output).context("Failed to parse hash collection output")?;
@@ -2911,19 +2949,22 @@ async fn run_container_command(
     }
 }
 
-/// Helper function to run a container command and capture its output,
-/// using shared context if available.
-async fn run_container_command_with_output(
+/// Run a container command and keep the full result so callers can put the
+/// script's stderr into their own error — required wherever the error must
+/// self-explain in TUI/JSON modes, where printing side effects are
+/// suppressed. Dispatches to the remote capture variant when a
+/// RunsOnContext is active.
+async fn run_container_command_capture(
     container_helper: &SdkContainer,
     config: RunConfig,
     runs_on_context: Option<&RunsOnContext>,
-) -> Result<Option<String>> {
+) -> Result<crate::utils::container::ContainerRunOutput> {
     if let Some(context) = runs_on_context {
         container_helper
-            .run_in_container_with_output_remote(&config, context)
+            .run_in_container_capture_remote(&config, context)
             .await
     } else {
-        container_helper.run_in_container_with_output(config).await
+        container_helper.run_in_container_capture(config).await
     }
 }
 

--- a/src/commands/runtime/deploy.rs
+++ b/src/commands/runtime/deploy.rs
@@ -183,6 +183,13 @@ impl RuntimeDeployCommand {
         }
     }
 
+    /// Compose a phase failure message that carries the container script's
+    /// own stderr diagnostics, so both the CLI error and the JSON step_error
+    /// event name the real problem.
+    fn container_failure_message(context: &str, stderr: &str) -> String {
+        crate::utils::container::container_failure_message(context, stderr)
+    }
+
     pub async fn execute(&self) -> Result<()> {
         let composed = match &self.composed_config {
             Some(cc) => Arc::clone(cc),
@@ -267,11 +274,25 @@ impl RuntimeDeployCommand {
                 ..Default::default()
             };
 
-            let output = match container_helper
-                .run_in_container_with_output(run_config)
-                .await
-            {
-                Ok(o) => o,
+            // Capture the full result so a container failure is reported as
+            // such, not silently converted into a "missing stamps" error.
+            let output = match container_helper.run_in_container_capture(run_config).await {
+                Ok(out) if out.success => out.stdout,
+                Ok(out) => {
+                    if self.verbose {
+                        crate::utils::container::print_failure_notice(&format!(
+                            "Full container stderr:\n{}",
+                            out.stderr
+                        ));
+                    }
+                    let msg = Self::container_failure_message(
+                        "Reading build stamps failed in the SDK container",
+                        &out.stderr,
+                    );
+                    Self::emit_phase_error(PHASE_STAMPS, &msg);
+                    Self::emit_phase_status(PHASE_STAMPS, "failed");
+                    return Err(anyhow::anyhow!(msg));
+                }
                 Err(e) => {
                     Self::emit_phase_error(PHASE_STAMPS, &e.to_string());
                     Self::emit_phase_status(PHASE_STAMPS, "failed");
@@ -279,7 +300,7 @@ impl RuntimeDeployCommand {
                 }
             };
 
-            let validation = validate_stamps_batch(&required, output.as_deref().unwrap_or(""), &[]);
+            let validation = validate_stamps_batch(&required, output.trim(), &[]);
 
             if !validation.is_satisfied() {
                 let msg = format!("Cannot deploy runtime '{}'", self.runtime_name);
@@ -318,14 +339,26 @@ impl RuntimeDeployCommand {
             ..Default::default()
         };
 
+        // Capture the full result so the script's own diagnostics (e.g. the
+        // signing-key prerequisite for --connect-sign) reach the user instead
+        // of a generic "produced no output" error.
         let hash_output = match container_helper
-            .run_in_container_with_output(hash_run_config)
+            .run_in_container_capture(hash_run_config)
             .await
         {
-            Ok(Some(out)) => out,
-            Ok(None) => {
-                let msg = "Hash collection script produced no output";
-                Self::emit_phase_error(PHASE_HASH, msg);
+            Ok(out) if out.success => out.stdout.trim().to_string(),
+            Ok(out) => {
+                if self.verbose {
+                    crate::utils::container::print_failure_notice(&format!(
+                        "Full container stderr:\n{}",
+                        out.stderr
+                    ));
+                }
+                let msg = Self::container_failure_message(
+                    "Hash collection failed in the SDK container",
+                    &out.stderr,
+                );
+                Self::emit_phase_error(PHASE_HASH, &msg);
                 Self::emit_phase_status(PHASE_HASH, "failed");
                 return Err(anyhow::anyhow!(msg));
             }

--- a/src/utils/container.rs
+++ b/src/utils/container.rs
@@ -301,6 +301,123 @@ fn docker_daemon_hint(stderr: &str) -> Option<String> {
     None
 }
 
+/// Full result of a captured container run. Unlike
+/// `run_in_container_with_output`, a non-zero exit keeps both streams so
+/// callers can surface the script's own diagnostics instead of guessing
+/// why the output is missing.
+#[derive(Debug)]
+pub struct ContainerRunOutput {
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Default number of trailing stderr lines surfaced when a captured
+/// container command fails.
+pub const STDERR_TAIL_LINES: usize = 15;
+
+/// Byte ceiling on the detail string, so a single enormous stderr line
+/// can't balloon error messages or the JSON step_error events built
+/// from them.
+const STDERR_TAIL_MAX_BYTES: usize = 4096;
+
+/// Distill captured stderr into the lines most likely to explain a container
+/// failure: the last `max_lines` non-empty lines, annotated when earlier
+/// output was omitted, capped at `STDERR_TAIL_MAX_BYTES` (keeping the end,
+/// where the diagnostic usually is). Returns `None` when stderr has no
+/// non-empty lines.
+pub fn container_failure_detail(stderr: &str, max_lines: usize) -> Option<String> {
+    // Allocations stay bounded by ~max_lines * STDERR_TAIL_MAX_BYTES no
+    // matter how large stderr is: line refs are capped at max_lines and each
+    // pathological line is pre-trimmed to its tail before joining. The final
+    // detail may exceed STDERR_TAIL_MAX_BYTES only by the small constant
+    // annotation lines below.
+    let total = stderr.lines().filter(|l| !l.trim().is_empty()).count();
+    if total == 0 {
+        return None;
+    }
+    let keep = total.min(max_lines);
+    let omitted = total - keep;
+    let mut pretrimmed = false;
+    let mut kept: Vec<&str> = stderr
+        .lines()
+        .rev()
+        .map(str::trim_end)
+        .filter(|l| !l.trim().is_empty())
+        .take(keep)
+        .map(|l| {
+            let t = str_tail(l, STDERR_TAIL_MAX_BYTES);
+            pretrimmed |= t.len() != l.len();
+            t
+        })
+        .collect();
+    kept.reverse();
+    let mut tail = kept.join("\n");
+    if tail.len() > STDERR_TAIL_MAX_BYTES {
+        tail = format!(
+            "… (output truncated)\n{}",
+            str_tail(&tail, STDERR_TAIL_MAX_BYTES)
+        );
+    } else if pretrimmed {
+        tail = format!("… (output truncated)\n{tail}");
+    }
+    if omitted > 0 {
+        Some(format!("… ({omitted} earlier line(s) omitted)\n{tail}"))
+    } else {
+        Some(tail)
+    }
+}
+
+/// The trailing `max_bytes` of `s`, snapped forward to a char boundary.
+fn str_tail(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut start = s.len() - max_bytes;
+    while !s.is_char_boundary(start) {
+        start += 1;
+    }
+    &s[start..]
+}
+
+/// Compose a failure message that carries the container script's own
+/// stderr diagnostics plus any recognized Docker daemon hint. Used for
+/// errors that must explain themselves in every output mode (TUI, JSON
+/// events, plain human) rather than relying on printing side effects.
+pub fn container_failure_message(context: &str, stderr: &str) -> String {
+    let mut msg = match container_failure_detail(stderr, STDERR_TAIL_LINES) {
+        Some(detail) => format!("{context}:\n{detail}"),
+        None => format!("{context} (no stderr output from the container)"),
+    };
+    if let Some(hint) = docker_daemon_hint(stderr) {
+        msg.push('\n');
+        msg.push_str(&hint);
+    }
+    msg
+}
+
+/// Best-effort surface of a failure notice in whatever output mode is
+/// active: TUI renderers queue it above the task region, JSON mode (with
+/// or without a renderer) keeps it on stderr off the NDJSON stdout
+/// stream, and plain human mode uses the standard error print. Exists
+/// because print_error is a no-op in TUI/JSON modes, which would silently
+/// eat container failure diagnostics.
+pub(crate) fn print_failure_notice(msg: &str) {
+    if let Some(renderer) = crate::utils::tui::get_active_renderer() {
+        renderer.print_above(msg);
+    } else if crate::utils::output_format::is_json_output_active() {
+        eprintln!("{msg}");
+    } else {
+        print_error(msg, OutputLevel::Normal);
+    }
+}
+
+/// Convert captured output bytes to a String without an extra copy for
+/// the (overwhelmingly common) valid-UTF-8 case.
+pub(crate) fn bytes_to_string(bytes: Vec<u8>) -> String {
+    String::from_utf8(bytes).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
+}
+
 pub fn normalize_sdk_arch(sdk_arch: &str) -> Result<String> {
     match sdk_arch.to_lowercase().as_str() {
         "aarch64" | "arm64" => Ok("aarch64".to_string()),
@@ -1327,6 +1444,32 @@ impl SdkContainer {
 
     /// Run a command in the container and capture its output
     pub async fn run_in_container_with_output(&self, config: RunConfig) -> Result<Option<String>> {
+        let verbose = config.verbose || self.verbose;
+        let out = self.run_in_container_capture(config).await?;
+        if out.success {
+            return Ok(Some(out.stdout.trim().to_string()));
+        }
+        // Surface the failure. The script's stderr usually names the real
+        // problem, so print its tail instead of hiding it behind --verbose —
+        // otherwise callers convert `None` into misleading errors like
+        // "missing stamps" or "produced no output".
+        if verbose {
+            print_failure_notice(&format!("Container execution failed: {}", out.stderr));
+        } else if let Some(detail) = container_failure_detail(&out.stderr, STDERR_TAIL_LINES) {
+            print_failure_notice(&format!("Container command failed:\n{detail}"));
+        } else if !out.stderr.is_empty() || !out.stdout.is_empty() {
+            print_failure_notice("Container command failed. Run with --verbose to see details.");
+        }
+        if let Some(hint) = docker_daemon_hint(&out.stderr) {
+            print_failure_notice(&hint);
+        }
+        Ok(None)
+    }
+
+    /// Run a command in the container and capture its full result: exit
+    /// success plus stdout and stderr. Prints nothing on failure — callers
+    /// own the error presentation (see `container_failure_detail`).
+    pub async fn run_in_container_capture(&self, config: RunConfig) -> Result<ContainerRunOutput> {
         // Ensure QEMU binfmt_misc is registered when cross-arch emulation is needed
         if let Some(ref arch) = config.sdk_arch {
             ensure_cross_arch_emulation(&self.container_tool, arch).await?;
@@ -1443,31 +1586,21 @@ impl SdkContainer {
             .await
             .with_context(|| "Failed to execute container command")?;
 
-        if output.status.success() {
-            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            Ok(Some(stdout))
-        } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            // Always log the error for debugging - this helps diagnose container failures
-            // that might otherwise be silently converted to "missing stamps" errors
-            if config.verbose || self.verbose {
-                print_error(
-                    &format!("Container execution failed: {stderr}"),
-                    OutputLevel::Normal,
-                );
-            } else if !stderr.is_empty() || !stdout.is_empty() {
-                // Even in non-verbose mode, print a hint about the failure
-                print_error(
-                    "Container command failed. Run with --verbose to see details.",
-                    OutputLevel::Normal,
-                );
-            }
-            if let Some(hint) = docker_daemon_hint(&stderr) {
-                print_error(&hint, OutputLevel::Normal);
-            }
-            Ok(None)
+        // Trim stdout in place, matching the remote counterpart
+        // (`run_command_captured`) so `ContainerRunOutput.stdout` carries
+        // the same whitespace contract on both execution paths. stderr
+        // stays raw on both.
+        let mut stdout = bytes_to_string(output.stdout);
+        stdout.truncate(stdout.trim_end().len());
+        let leading = stdout.len() - stdout.trim_start().len();
+        if leading > 0 {
+            stdout.drain(..leading);
         }
+        Ok(ContainerRunOutput {
+            success: output.status.success(),
+            stdout,
+            stderr: bytes_to_string(output.stderr),
+        })
     }
 
     /// Query installed package versions from a sysroot using rpm -q
@@ -1598,6 +1731,54 @@ impl SdkContainer {
         config: &RunConfig,
         context: &crate::utils::runs_on::RunsOnContext,
     ) -> Result<Option<String>> {
+        let (full_command, env_vars, extra_args) = self.build_remote_run_parts(config, context)?;
+        context
+            .run_container_command_with_output(
+                &config.container_image,
+                &full_command,
+                env_vars,
+                &extra_args,
+            )
+            .await
+    }
+
+    /// Remote counterpart of `run_in_container_capture`: run the command via
+    /// the provided RunsOnContext and return the full result (stderr mixes
+    /// ssh's own output with the container's). Prints nothing on failure —
+    /// callers own the error presentation.
+    pub async fn run_in_container_capture_remote(
+        &self,
+        config: &RunConfig,
+        context: &crate::utils::runs_on::RunsOnContext,
+    ) -> Result<ContainerRunOutput> {
+        let (full_command, env_vars, extra_args) = self.build_remote_run_parts(config, context)?;
+        let out = context
+            .run_container_command_captured(
+                &config.container_image,
+                &full_command,
+                env_vars,
+                &extra_args,
+            )
+            .await?;
+        Ok(ContainerRunOutput {
+            success: out.success,
+            stdout: out.stdout,
+            stderr: out.stderr,
+        })
+    }
+
+    /// Assemble the (command, env, docker args) triple shared by the remote
+    /// execution variants above.
+    #[allow(clippy::type_complexity)]
+    fn build_remote_run_parts(
+        &self,
+        config: &RunConfig,
+        context: &crate::utils::runs_on::RunsOnContext,
+    ) -> Result<(
+        String,
+        std::collections::HashMap<String, String>,
+        Vec<String>,
+    )> {
         if !context.is_active() {
             anyhow::bail!("RunsOnContext is not active (already torn down)");
         }
@@ -1680,15 +1861,7 @@ impl SdkContainer {
             extra_args.extend(args.clone());
         }
 
-        // Run the container on the remote and capture output
-        context
-            .run_container_command_with_output(
-                &config.container_image,
-                &full_command,
-                env_vars,
-                &extra_args,
-            )
-            .await
+        Ok((full_command, env_vars, extra_args))
     }
 
     /// Execute the container command
@@ -2930,6 +3103,60 @@ async fn read_output_stream<R: tokio::io::AsyncRead + Unpin>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn failure_detail_none_for_blank_stderr() {
+        assert_eq!(container_failure_detail("", 10), None);
+        assert_eq!(container_failure_detail("\n  \n\t\n", 10), None);
+    }
+
+    #[test]
+    fn failure_detail_keeps_short_output_verbatim() {
+        let stderr = "ERROR: No root.json found at /path\n       Set 'signing.key' and rebuild.\n";
+        let detail = container_failure_detail(stderr, 10).unwrap();
+        assert_eq!(
+            detail,
+            "ERROR: No root.json found at /path\n       Set 'signing.key' and rebuild."
+        );
+    }
+
+    #[test]
+    fn failure_detail_tails_long_output_and_notes_omission() {
+        let stderr = (1..=20)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let detail = container_failure_detail(&stderr, 5).unwrap();
+        assert!(detail.starts_with("… (15 earlier line(s) omitted"));
+        assert!(detail.ends_with("line 16\nline 17\nline 18\nline 19\nline 20"));
+        assert!(!detail.contains("line 15\n"));
+    }
+
+    #[test]
+    fn failure_detail_caps_total_bytes_keeping_the_end() {
+        // One enormous line must not balloon the detail (and thus error
+        // messages / JSON events) past the byte ceiling.
+        let huge = format!("padding-{}END-OF-STDERR", "x".repeat(64 * 1024));
+        let detail = container_failure_detail(&huge, 15).unwrap();
+        assert!(detail.len() < STDERR_TAIL_MAX_BYTES + 64);
+        assert!(detail.starts_with("… (output truncated)\n"));
+        assert!(detail.ends_with("END-OF-STDERR"));
+    }
+
+    #[test]
+    fn failure_detail_byte_cap_respects_char_boundaries() {
+        let huge = format!("{}…", "é".repeat(8 * 1024));
+        let detail = container_failure_detail(&huge, 15).unwrap();
+        assert!(detail.ends_with('…'));
+    }
+
+    #[test]
+    fn failure_detail_drops_blank_lines_before_tailing() {
+        let stderr = "first\n\n\nsecond\n\nthird\n";
+        let detail = container_failure_detail(stderr, 2).unwrap();
+        assert!(detail.starts_with("… (1 earlier line(s) omitted"));
+        assert!(detail.ends_with("second\nthird"));
+    }
 
     #[test]
     fn test_sdk_container_creation() {

--- a/src/utils/remote.rs
+++ b/src/utils/remote.rs
@@ -11,6 +11,15 @@ use tokio::process::Command as AsyncCommand;
 
 use crate::utils::output::{print_info, OutputLevel};
 
+/// Full result of a remotely-executed command captured via
+/// `SshClient::run_command_captured`.
+#[derive(Debug)]
+pub struct RemoteCommandOutput {
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
+}
+
 /// Represents a remote host in user@host or just host format
 #[derive(Debug, Clone)]
 pub struct RemoteHost {
@@ -289,6 +298,59 @@ impl SshClient {
         }
 
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    /// Run a command on the remote host, returning the full result for the
+    /// caller to handle. Unlike `run_command`, failure does NOT embed the
+    /// command line in the error — remote docker commands carry `-e KEY=value`
+    /// environment values that must not leak into default (non-verbose)
+    /// output. `--verbose` deliberately still logs the full command line, as
+    /// it does across the CLI (the local path prints `Container command:`
+    /// with the same env values); redacting verbose output is a project-wide
+    /// policy question, not a per-call-site one.
+    pub async fn run_command_captured(&self, command: &str) -> Result<RemoteCommandOutput> {
+        if self.verbose {
+            print_info(
+                &format!("Running remote command: {command}"),
+                OutputLevel::Verbose,
+            );
+        }
+
+        let mut args = self.base_ssh_args();
+        args.extend([self.remote.ssh_target(), command.to_string()]);
+
+        let output = AsyncCommand::new("ssh")
+            .args(&args)
+            .output()
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to run command on remote {}",
+                    self.remote.ssh_target()
+                )
+            })?;
+
+        // Move the byte buffers into Strings (no copy for valid UTF-8) and
+        // trim stdout in place — captured streams can be large.
+        let mut stdout = crate::utils::container::bytes_to_string(output.stdout);
+        stdout.truncate(stdout.trim_end().len());
+        let leading = stdout.len() - stdout.trim_start().len();
+        if leading > 0 {
+            stdout.drain(..leading);
+        }
+        // Trimming shrinks the length but not the allocation; give the
+        // memory back when the waste is substantial both absolutely and
+        // relative to what's kept (shrinking copies the retained bytes, so
+        // reclaiming a small fraction of a huge buffer isn't worth it).
+        let waste = stdout.capacity() - stdout.len();
+        if waste > 64 * 1024 && waste >= stdout.len() {
+            stdout.shrink_to_fit();
+        }
+        Ok(RemoteCommandOutput {
+            success: output.status.success(),
+            stdout,
+            stderr: crate::utils::container::bytes_to_string(output.stderr),
+        })
     }
 
     /// Run a command on the remote host, inheriting stdin/stdout/stderr

--- a/src/utils/runs_on.rs
+++ b/src/utils/runs_on.rs
@@ -442,6 +442,54 @@ impl RunsOnContext {
         env_vars: HashMap<String, String>,
         extra_docker_args: &[String],
     ) -> Result<Option<String>> {
+        // Surface the failure before collapsing to None — otherwise callers
+        // convert it into misleading errors like "missing stamps" or
+        // "produced no output". The printed detail is a bounded stderr tail
+        // and never includes the docker command, which carries -e KEY=value
+        // pairs.
+        match self
+            .run_container_command_captured(image, command, env_vars, extra_docker_args)
+            .await
+        {
+            Ok(out) if out.success => Ok(Some(out.stdout)),
+            Ok(out) => {
+                if self.verbose {
+                    crate::utils::container::print_failure_notice(&format!(
+                        "Remote container command failed:\n{}",
+                        out.stderr
+                    ));
+                } else {
+                    crate::utils::container::print_failure_notice(
+                        &crate::utils::container::container_failure_message(
+                            "Remote container command failed",
+                            &out.stderr,
+                        ),
+                    );
+                }
+                Ok(None)
+            }
+            Err(e) => {
+                // ssh itself could not run; this error carries no remote
+                // command line.
+                crate::utils::container::print_failure_notice(&format!(
+                    "Remote container command failed: {e:#}"
+                ));
+                Ok(None)
+            }
+        }
+    }
+
+    /// Run a container command on the remote and return the full captured
+    /// result (exit success plus both streams; stderr mixes ssh's own output
+    /// with the container's). For callers that must put the failure detail
+    /// into their own error instead of relying on printing side effects.
+    pub async fn run_container_command_captured(
+        &self,
+        image: &str,
+        command: &str,
+        env_vars: HashMap<String, String>,
+        extra_docker_args: &[String],
+    ) -> Result<crate::utils::remote::RemoteCommandOutput> {
         let docker_cmd = self.build_docker_command(image, command, &env_vars, extra_docker_args)?;
 
         if self.verbose {
@@ -451,11 +499,7 @@ impl RunsOnContext {
             );
         }
 
-        // Execute on remote and capture output
-        match self.ssh.run_command(&docker_cmd).await {
-            Ok(output) => Ok(Some(output)),
-            Err(_) => Ok(None),
-        }
+        self.ssh.run_command_captured(&docker_cmd).await
     }
 
     /// Build the docker run command string


### PR DESCRIPTION
## Problem

When a script run inside the SDK container exits non-zero, the captured-output helpers collapse the failure to "no output" and discard stderr. Callers then invent their own explanation for the missing output, producing misleading errors:

- `avocado deploy` reports `Hash collection script produced no output` when the script actually failed with an actionable diagnostic (for example, `--connect-sign` requiring a local signing key, or a runtime built without one). The real message was written to stderr and thrown away.
- Deploy's stamp verification misreports any container failure (docker daemon down, entrypoint error) as a missing build stamp / runtime not built.
- In TUI and `--output json` modes, failure prints were suppressed entirely, so those runs got no diagnostic at all.
- `--runs-on` remote failures were fully silent.

## Changes

- New capture API (`run_in_container_capture`, plus a remote counterpart) returns exit status with both streams; the existing `run_in_container_with_output` becomes a compatibility wrapper with unchanged semantics for its ~22 call sites.
- On failure, the wrapper now surfaces a bounded stderr tail (last 15 non-empty lines, 4 KiB cap, char-boundary safe) in every output mode: TUI runs queue it above the task region, JSON runs keep it on stderr so the NDJSON stdout stream stays clean, plain runs print it directly.
- Deploy's stamp and hash phases produce truthful, self-explaining errors that carry the script's stderr in both the CLI error and the `step_error` JSON event, and container failures are no longer conflated with genuinely missing stamps.
- Runtime build's TUF staging skip notice is now visible in TUI/JSON modes (previously suppressed).
- Remote (`--runs-on`) failures report the container's stderr without embedding the docker command line (which carries `-e KEY=value` pairs) in error output.
- `--verbose` prints the full captured stderr at failure sites; truncation annotations no longer promise output that a mode can't deliver.
- Bounded allocations throughout: the tail formatter stays ~`15 × 4 KiB` peak regardless of stderr size, and captured streams avoid redundant full-buffer copies.

Example, deploying a runtime whose build has no update-authority baked:

Before:
```
Error: Hash collection script produced no output
```

After:
```
Error: Hash collection failed in the SDK container:
ERROR: No root.json found at /opt/_avocado/.../metadata/root.json
       The runtime has no update-authority (root.json) baked into its build.
       This usually means no signing key is configured. ...
```

## Testing

- Unit tests for the stderr-tail formatter (blank input, short output, tail selection, blank-line filtering, byte cap, UTF-8 boundaries); `cargo test --lib` — 1121 passed.
- Live-verified against a project with an unbuilt/unsigned runtime: the script's `ERROR:` diagnostics now appear in human output and in the `step_error` NDJSON event.
