### PR TITLE
connect/auth: honor --org before the zero-orgs shortcut

### DIFF
--- a/src/commands/connect/auth.rs
+++ b/src/commands/connect/auth.rs
@@ -431,22 +431,28 @@ enum OrgPick {
 /// Pure logic. No HTTP, no stdin, no stdout. The wrapper `resolve_org_for_login`
 /// adds the IO around this.
 fn pick_org(orgs: Vec<OrgInfo>, org_hint: Option<&str>, output: OutputFormat) -> Result<OrgPick> {
-    if orgs.is_empty() {
-        return Ok(OrgPick::None);
-    }
-
+    // An explicit `--org` must be honored or fail loudly — never silently
+    // dropped. Resolve it before the zero-orgs shortcut so a hint against an
+    // empty org list errors instead of falling through to an unscoped token.
     if let Some(hint) = org_hint {
         return match orgs.iter().find(|o| o.id == hint) {
             Some(o) => Ok(OrgPick::Resolved(o.clone())),
             None => {
-                let available = orgs
-                    .iter()
-                    .map(|o| format!("{} ({})", o.name, o.id))
-                    .collect::<Vec<_>>()
-                    .join(", ");
+                let available = if orgs.is_empty() {
+                    "none".to_string()
+                } else {
+                    orgs.iter()
+                        .map(|o| format!("{} ({})", o.name, o.id))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
                 anyhow::bail!("organization '{hint}' not found. Available: {available}");
             }
         };
+    }
+
+    if orgs.is_empty() {
+        return Ok(OrgPick::None);
     }
 
     if orgs.len() == 1 {
@@ -841,6 +847,20 @@ mod tests {
     fn pick_org_zero_orgs_returns_none() {
         let result = pick_org(vec![], None, OutputFormat::Human).unwrap();
         assert!(matches!(result, OrgPick::None));
+    }
+
+    #[test]
+    fn pick_org_explicit_hint_with_no_orgs_errors_not_dropped() {
+        // An explicit --org must never be silently dropped: an empty org
+        // list combined with a hint has to fail loudly rather than fall
+        // through to an unscoped token. Regression guard for the silent-drop
+        // login bug — the auth server returned zero orgs, so the hint was
+        // ignored and a bogus unscoped profile was minted while reporting
+        // success.
+        let result = pick_org(vec![], Some("uuid-x"), OutputFormat::Json);
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("uuid-x"), "got: {err}");
+        assert!(err.contains("Available: none"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`avocado connect auth login --org <id>` can report a successful login while silently ignoring the org the user asked for.

When the auth server's org list for the login code comes back empty, `pick_org` hits its `orgs.is_empty()` shortcut and returns `OrgPick::None` **before** it ever looks at the `--org` hint. The code exchange then runs with no `organization_id`, minting an **unscoped** token, and the CLI prints `Logged in … / Created new profile`. The user ends up with an "all orgs" profile scoped to nothing, for an org they explicitly named, with no error to signal it.

This is a real footgun: a `--profile X --org <id>` login "succeeds", but `avocado connect auth status --profile X` then reports `Token scope: unscoped (all orgs)`, and every subsequent org-scoped call fails confusingly. It cost meaningful debugging time chasing a token-scope problem that was actually a silent no-op at login.

## Fix

Resolve an explicit `--org` hint **before** the zero-orgs shortcut. A hint that matches nothing, including against an empty list, now fails loudly:

```
Error: organization '<id>' not found. Available: none
```

Everything else is unchanged: the no-hint zero-orgs path still returns `OrgPick::None` (server falls back to its default scoping), and single-org auto-select, multi-org JSON default, and multi-org human prompt all behave exactly as before.

## Test

Added `pick_org_explicit_hint_with_no_orgs_errors_not_dropped` as a regression guard (written failing first, against the old behavior). Full `pick_org` suite green; `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Validation

Built and run against `connect.peridio.com`:

- **Before:** `auth login --org <non-member-org> --profile X` → `Logged in / Created new profile`; `auth status --profile X` → `Token scope: unscoped (all orgs)`.
- **After:** same command → `Error: organization '<id>' not found. Available: none`; the browser shows "CLI Login Failed"; no profile is written.
- **Member path still works:** `auth login --org <member-org>` scopes the token correctly and `projects list --org <member-org>` returns the org's projects.
