### PR TITLE
Report the build commit in avocado --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Build commit in `avocado --version`.** The version line now reports the
+  commit the binary was built from and its date, following rustc's shape:
+  `avocado 1.0.0-rc.1 (abc1234 2026-03-05)`. A bug report now identifies the
+  exact build. Builds made outside a git checkout - or inside an unrelated
+  one, such as a vendored copy in another repository - keep reporting the bare
+  version rather than embedding a commit that is not this binary's. Anything
+  parsing this line must read the **second** whitespace-separated field, since
+  the last field is now a date.
+
+  **Rollout note.** That instruction only reaches parsers written from here
+  on. Every already-released `avocado` reads the remote's version with
+  `.last()` over the whole `--version` output, so during the window where an
+  older local CLI talks to a newer remote it takes `2026-03-05)` as the remote
+  version, fails to parse it, and - on those releases - falls open rather than
+  refusing: the minimum-remote-version check is skipped and a date is printed
+  as the version. Nothing can be shipped that fixes those binaries
+  retroactively, so upgrade the local side first. Moving the build detail to a
+  second output line would not have avoided this: the shipped parser splits the
+  entire stdout blob, not its first line, so `.last()` still reaches it.
+  `avocado-desktop` is not affected - its parser already reads the first line's
+  second field.
+
 ### Fixed
 - **`--connect-sign` guidance.** The deploy help text and the Level 2 setup
   messages now reference `avocado connect trust promote-root --key <KEY>` with

--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,117 @@
 use std::env;
+use std::path::Path;
 use std::process::Command;
 
+/// Emit the version string reported by `avocado --version`, plus the target
+/// triple `avocado upgrade` uses to pick its release asset.
+///
+/// The build detail follows rustc's shape, `1.2.3 (abc1234 2026-03-05)`, so the
+/// version stays a bare semver in its own field and the commit and its date sit
+/// in a trailing parenthetical. Anything parsing this line has to read the
+/// SECOND whitespace-separated field: the last one is now a date.
+/// `utils::remote::check_cli_version` does, and avocado-desktop's
+/// `parse_cli_version` has to match.
+///
+/// The date is the commit date, not the build date, so the string stays
+/// reproducible across rebuilds of the same commit.
 fn main() {
-    // This runs only during build
-    let output = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .unwrap();
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!(
-        "cargo:rustc-env=AVOCADO_CLI_VERSION={} {}",
-        env!("CARGO_PKG_VERSION"),
-        git_hash
-    );
+    println!("cargo:rerun-if-changed=build.rs");
+    emit_git_rerun_hints();
+
+    let version = match (
+        git(&["rev-parse", "--short", "HEAD"]),
+        git(&["show", "-s", "--format=%cs", "HEAD"]),
+    ) {
+        (Some(sha), Some(date)) if in_own_repository() => {
+            format!("{} ({sha} {date})", env!("CARGO_PKG_VERSION"))
+        }
+        // Building outside a git checkout (source tarball, vendored crate) is
+        // legitimate, so report the bare crate version rather than failing the
+        // build the way an unwrap here would. `in_own_repository` routes the
+        // more dangerous case here too: git succeeded, but against somebody
+        // else's repository.
+        _ => env!("CARGO_PKG_VERSION").to_string(),
+    };
+    println!("cargo:rustc-env=AVOCADO_CLI_VERSION={version}");
+
     println!("cargo:rustc-env=TARGET={}", env::var("TARGET").unwrap());
+}
+
+/// Whether the repository git just answered from is this crate's own.
+///
+/// `git` runs with the build script's cwd and will happily answer from whatever
+/// repository encloses it. A crate unpacked inside an unrelated one - a vendored
+/// copy in a monorepo, a source tree under a Yocto `WORKDIR` that is itself
+/// version-controlled, a docker build context inside a repo - would otherwise
+/// embed that repository's sha, and the string looks authoritative enough that a
+/// bug report citing an unrelated commit goes unquestioned. Reporting the bare
+/// version, as if git were absent, is the honest answer there.
+///
+/// This crate lives at its repository root, so an exact match is the check;
+/// anything else means git found a different tree.
+fn in_own_repository() -> bool {
+    let (Some(toplevel), Ok(manifest_dir)) = (
+        git(&["rev-parse", "--show-toplevel"]),
+        env::var("CARGO_MANIFEST_DIR"),
+    ) else {
+        return false;
+    };
+    // Compare canonicalized: either side can arrive with a symlinked path.
+    match (
+        std::fs::canonicalize(&toplevel),
+        std::fs::canonicalize(&manifest_dir),
+    ) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => toplevel == manifest_dir,
+    }
+}
+
+/// Rebuild when HEAD moves. Without these, cargo caches the build-script
+/// output and the reported commit goes stale after the next commit or checkout.
+fn emit_git_rerun_hints() {
+    let mut watched = Vec::new();
+    if let Some(head) = git(&["rev-parse", "--git-path", "HEAD"]) {
+        watched.push(head);
+    }
+    // The reflog is the only one of these that changes on EVERY commit and is
+    // never packed away. `.git/HEAD` is a symref whose contents do not change
+    // when you commit, and the loose branch ref that does is deleted by
+    // `git gc` / `pack-refs` / `maintenance` - after which nothing watched here
+    // would move again and the embedded sha would stay stale indefinitely,
+    // without self-healing. `packed-refs` is no substitute: its mtime does not
+    // change on commit either.
+    if let Some(reflog) = git(&["rev-parse", "--git-path", "logs/HEAD"]) {
+        watched.push(reflog);
+    }
+    // Follow the branch ref too, for the case the reflog is disabled
+    // (`core.logAllRefUpdates=false`, the default in a bare repository).
+    // `--symbolic-full-name` prints `HEAD` on a detached checkout, which
+    // resolves right back to `.git/HEAD`; a detached checkout needs no extra
+    // watch anyway, since `.git/HEAD` then holds the sha directly and changes
+    // with it. Dedup below drops the repeat.
+    if let Some(branch) = git(&["rev-parse", "--symbolic-full-name", "HEAD"]) {
+        if let Some(path) = git(&["rev-parse", "--git-path", &branch]) {
+            watched.push(path);
+        }
+    }
+
+    watched.sort();
+    watched.dedup();
+    for path in watched {
+        if Path::new(&path).exists() {
+            println!("cargo:rerun-if-changed={path}");
+        }
+    }
+}
+
+/// Run a git command, returning its trimmed stdout when it succeeds with
+/// output. `None` covers git being absent as well as a failed invocation.
+fn git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    (!stdout.is_empty()).then_some(stdout)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ use commands::upgrade::UpgradeCommand;
 #[derive(Parser)]
 #[command(name = "avocado")]
 #[command(about = "Avocado CLI - A command line interface for Avocado")]
-#[command(version)]
+#[command(version = env!("AVOCADO_CLI_VERSION"))]
 #[command(disable_help_subcommand = true)]
 struct Cli {
     #[command(subcommand)]

--- a/src/utils/remote.rs
+++ b/src/utils/remote.rs
@@ -242,11 +242,7 @@ impl SshClient {
             );
         }
 
-        // Parse version from output like "avocado 0.20.0"
-        let remote_version = version_output
-            .split_whitespace()
-            .last()
-            .unwrap_or(&version_output);
+        let remote_version = parse_reported_version(&version_output);
 
         // Compare versions
         if !is_version_compatible(local_version, remote_version) {
@@ -963,6 +959,57 @@ pub async fn get_local_ip_for_remote(remote_host: &str) -> Result<IpAddr> {
         .unwrap_or_else(|| anyhow::anyhow!("No valid addresses found for remote host")))
 }
 
+/// Extract the version from `avocado --version` output.
+///
+/// The line reads `avocado <version> (<short-sha> <commit-date>)`, so the
+/// version is the second field and the last one is a date.
+///
+/// The input is the whole stdout blob, not a single line: the remote command
+/// sources `~/.profile` and `~/.bashrc` first, so anything they echo arrives
+/// ahead of the version. A fixed field index reads that banner instead - for
+/// `"Welcome to the board!\navocado 1.0.0-rc.1 (...)"`, the second field is
+/// `to`. So anchor on the line the CLI actually prints rather than counting
+/// fields from the start of the blob.
+///
+/// Falls back to the first version-shaped token so a remote on an older CLI
+/// that prints a bare version still resolves behind a banner, which the
+/// previous `.last()` handled and a positional read does not.
+fn parse_reported_version(output: &str) -> &str {
+    const PROGRAM: &str = "avocado";
+
+    for line in output.lines() {
+        let mut fields = line.split_whitespace();
+        if fields.next() == Some(PROGRAM) {
+            if let Some(version) = fields.next() {
+                return version;
+            }
+        }
+    }
+
+    for token in output.split_whitespace() {
+        if is_version_shaped(token) {
+            return token;
+        }
+    }
+
+    output.trim()
+}
+
+/// Whether `token` could be a version: a numeric leading segment, after an
+/// optional `v` and ignoring any pre-release or build suffix.
+///
+/// Deliberately shallow. It only has to separate a version from a word in a
+/// login banner, not validate semver - `0.40.0-dev` and `1.0.0-rc.1` both have
+/// to keep passing.
+fn is_version_shaped(token: &str) -> bool {
+    let token = token.strip_prefix('v').unwrap_or(token);
+    let core = token.split(['-', '+']).next().unwrap_or(token);
+    match core.split('.').next() {
+        Some(segment) => !segment.is_empty() && segment.parse::<u64>().is_ok(),
+        None => false,
+    }
+}
+
 /// Check if a remote version is compatible with the local version
 ///
 /// The remote version must be equal to or greater than the local version.
@@ -1063,6 +1110,78 @@ mod tests {
         assert!(!is_version_compatible("0.21.0", "0.20.0"));
         assert!(!is_version_compatible("1.0.0", "0.20.0"));
         assert!(!is_version_compatible("0.20.1", "0.20.0"));
+    }
+
+    #[test]
+    fn test_parse_reported_version_reads_the_version_field() {
+        // The build detail is a trailing parenthetical, so the last field is a
+        // date. Taking it would feed a date into the compatibility check.
+        assert_eq!(
+            parse_reported_version("avocado 1.0.0-rc.1 (abc1234 2026-03-05)"),
+            "1.0.0-rc.1"
+        );
+        // A remote on an older CLI prints just the version.
+        assert_eq!(parse_reported_version("avocado 0.41.2"), "0.41.2");
+        // Nothing to split on: fall back rather than drop the value.
+        assert_eq!(parse_reported_version("0.41.2"), "0.41.2");
+    }
+
+    #[test]
+    fn test_parse_reported_version_skips_a_login_banner() {
+        // The remote command sources ~/.profile and ~/.bashrc before running
+        // avocado, so whatever they echo lands ahead of the version and the
+        // input is a multi-line blob. Counting fields from the start of that
+        // blob reads the banner: the second field here is "to".
+        assert_eq!(
+            parse_reported_version(
+                "Welcome to the board!\navocado 1.0.0-rc.1 (abc1234 2026-03-05)"
+            ),
+            "1.0.0-rc.1"
+        );
+        // Same shape, older remote printing a bare version. The `.last()` parser
+        // this replaced got this one right, so a positional read would be a
+        // regression for the combination rather than a carried-forward weakness.
+        assert_eq!(
+            parse_reported_version("Welcome to the board!\n0.41.2"),
+            "0.41.2"
+        );
+    }
+
+    #[test]
+    fn test_parse_reported_version_does_not_invent_a_version_from_prose() {
+        // Negative path: nothing version-shaped anywhere. The value returned has
+        // to stay something the compatibility check will reject, not a word that
+        // happens to sit in the second position.
+        let parsed = parse_reported_version("bash: avocado: command not found");
+        assert!(
+            !is_version_shaped(parsed),
+            "prose parsed as a version: {parsed:?}"
+        );
+        assert_ne!(parsed, "avocado:");
+    }
+
+    #[test]
+    fn test_parse_reported_version_ignores_a_different_program() {
+        // A same-named binary earlier on the remote's PATH answers with its own
+        // name, so the anchor must not match it.
+        let parsed = parse_reported_version("Python 3.11.2");
+        assert_eq!(
+            parsed, "3.11.2",
+            "expected the version-shaped fallback, not a field index"
+        );
+    }
+
+    #[test]
+    fn test_is_version_shaped_separates_versions_from_words() {
+        for token in ["0.41.2", "1.0.0-rc.1", "v0.40.0", "0.20", "2026"] {
+            assert!(is_version_shaped(token), "{token} should be version-shaped");
+        }
+        for token in ["to", "avocado:", "command", "not-installed", "", "dev"] {
+            assert!(
+                !is_version_shaped(token),
+                "{token:?} should not be version-shaped"
+            );
+        }
     }
 
     #[test]

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -1,0 +1,110 @@
+//! `avocado --version` reports the commit the binary was built from, in the
+//! same shape rustc uses: `avocado <version> (<short-sha> <commit-date>)`.
+//!
+//! The version is the SECOND whitespace-separated field. Anything parsing this
+//! line must read that field: the trailing `(<sha> <date>)` means the last
+//! field is a date, not a version. `utils::remote::check_cli_version` parses it
+//! that way, and avocado-desktop's `parse_cli_version` has to match.
+
+use std::process::Command;
+
+use semver::Version;
+
+/// Read the `--version` line the way its consumers do.
+fn version_line() -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_avocado"))
+        .arg("--version")
+        .output()
+        .expect("failed to run `avocado --version`");
+
+    assert!(
+        output.status.success(),
+        "`avocado --version` exited with {:?}",
+        output.status.code()
+    );
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+/// Run a git command in the source tree, returning trimmed stdout on success.
+/// `None` means this is not a git checkout (source tarball, vendored build).
+fn git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    (!stdout.is_empty()).then_some(stdout)
+}
+
+#[test]
+fn version_field_is_the_bare_crate_version() {
+    let line = version_line();
+    assert!(
+        line.starts_with("avocado "),
+        "version line should start with the binary name: {line:?}"
+    );
+
+    // Field 1 is the version, and it stays a bare semver so version
+    // comparisons keep working: the commit rides in the parenthetical.
+    let field = line
+        .split_whitespace()
+        .nth(1)
+        .unwrap_or_else(|| panic!("no version field in {line:?}"));
+    let parsed =
+        Version::parse(field).unwrap_or_else(|e| panic!("{field:?} must parse as semver: {e}"));
+
+    assert_eq!(
+        parsed,
+        Version::parse(env!("CARGO_PKG_VERSION")).expect("crate version is semver"),
+        "reported version {field:?} must equal the crate version"
+    );
+
+    // Any build detail is a PARENTHETICAL. Without this the test also passes for
+    // the older `avocado <version> <sha>` shape, so nothing here would catch a
+    // revert to it - and under that shape the last field is a bare sha, which is
+    // exactly what a `.last()` parser would report as the version.
+    let detail = line[format!("avocado {field}").len()..].trim();
+    assert!(
+        detail.is_empty() || (detail.starts_with('(') && detail.ends_with(')')),
+        "build detail must be parenthesized, got {detail:?} in {line:?}"
+    );
+}
+
+#[test]
+fn version_reports_the_commit_and_date_it_was_built_from() {
+    let line = version_line();
+    let bare = format!("avocado {}", env!("CARGO_PKG_VERSION"));
+
+    let (Some(sha), Some(date)) = (
+        git(&["rev-parse", "--short", "HEAD"]),
+        git(&["show", "-s", "--format=%cs", "HEAD"]),
+    ) else {
+        // Not a git checkout, or git is absent. Assert the other branch rather
+        // than returning: a bare `return` here made the whole format check a
+        // no-op that reported success on a runner without git, which is the one
+        // environment where a silent pass is most likely to go unnoticed.
+        assert_eq!(
+            line, bare,
+            "with no git available the version line must be bare"
+        );
+        return;
+    };
+
+    assert_eq!(
+        line,
+        format!("{bare} ({sha} {date})"),
+        "version line should carry the build commit and its date"
+    );
+}


### PR DESCRIPTION
## Problem

`avocado --version` reports only `avocado 1.0.0-rc.1`, which does not identify which build a user is running. Release candidates move faster than the version number, so one string covers many different binaries and a bug report cannot be tied to a commit.

`build.rs` already computed a short SHA into `AVOCADO_CLI_VERSION`, but nothing consumed it: the CLI declared a bare `#[command(version)]`, which clap fills from `CARGO_PKG_VERSION`.

## Solution

Report the commit in rustc's shape:

```
avocado 1.0.0-rc.1 (e566baa 2026-07-31)
```

Keeping the version in its own field leaves it a bare semver, so version comparisons need no special handling for an appended commit. The date is the **commit** date, not the build date, so rebuilding the same commit yields the same string.

This does move the version out of the last field, which two consumers were reading:

- `utils::remote::check_cli_version` (this repo) — fixed here.
- avocado-desktop's `parse_cli_version` — fixed in avocado-linux/avocado-desktop#73. That one accepts both the old and new shapes, so it is safe to merge first and is correct against today's released CLI too.

## Key changes

- `main.rs`: `#[command(version = env!("AVOCADO_CLI_VERSION"))]`, so the value `build.rs` computes actually reaches `--version`.
- `build.rs` emits `<version> (<short-sha> <commit-date>)`, and is hardened: it unwrapped the git invocation, so building outside a checkout (source tarball, vendored crate) aborted the build instead of falling back to the bare version; it never trimmed the trailing newline off `rev-parse`, which would have put a line break inside the version string; and it declared no `rerun-if-changed`, so cargo cached the script output and kept reporting a stale commit. The rerun hint follows the **branch ref**, not `HEAD` alone, because `HEAD` is a symref whose contents do not change on commit.
- `check_cli_version` reads the version field via a `parse_reported_version` helper instead of `split_whitespace().last()`, which now yields the commit date. This matters beyond cosmetics: an unparseable version makes that check **fail open** and silently accept a remote running an older CLI. The helper still tolerates a bare version from an older remote.
- `tests/version.rs`: the version field is a bare semver equal to the crate version, and the line carries the current commit and date (skips outside a git checkout).
- Unit tests for `parse_reported_version` across the new shape, the old bare shape, and a version with no prefix.

## Reviewer notes

- Verified end to end: prints `avocado 1.0.0-rc.1 (e566baa 2026-07-31)`; committing without touching `build.rs` rebuilds and reports the new commit, which is the check that the stale-commit fix actually works.
- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and the full `cargo test` suite are clean.
- No CI change needed: `actions/checkout@v5` leaves `.git` present, so release and PR builds resolve a commit; `cross` musl builds and the Windows `cargo check` fall back to the bare version if git is unavailable rather than failing.
- `env!("TARGET")` from the same build script is unchanged (still used by `avocado upgrade`).
- A `.dirty` marker for uncommitted builds was deliberately left out to keep this focused; easy follow-up if wanted.
