### PR TITLE
fix(remote): stop a skipped version check from looking like a passed one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `avocado-desktop` is not affected - its parser already reads the first line's
   second field.
 
+### Changed
+- **A skipped remote version check no longer reports as a passed one.** When
+  the remote's `--version` output cannot be parsed, `--runs-on` used to print
+  `[SUCCESS] Remote avocado version: <whatever it read>`, which is a green line
+  for a comparison that never happened. It now prints a `[WARNING]` saying the
+  check was skipped, on a path an active renderer or `--json` cannot swallow,
+  and emits a `{"event":"warning"}` line on the NDJSON stream so a consumer
+  reading only that stream does not render an unqualified green run.
+  `--runs-on localhost` reports neither: it is the same machine, so the check
+  is skipped with nothing to say rather than asserting a version it never read.
+
+### Breaking
+- **`is_version_compatible` returns `Option<bool>` instead of `bool`.** Only
+  affects consumers of the `avocado_cli` lib target. `None` means the remote
+  version could not be read at all, which the old `bool` could not express -
+  it collapsed "definitely older" and "unreadable" into the same `false`, and
+  that collapse is what let an unparseable version fall through as a pass.
+
 ### Fixed
 - **`--connect-sign` guidance.** The deploy help text and the Level 2 setup
   messages now reference `avocado connect trust promote-root --key <KEY>` with

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -815,16 +815,12 @@ impl RuntimeBuildCommand {
             .await
         {
             let msg = format!("Skipping TUF delegation staging: {e:#}");
-            if let Some(renderer) = crate::utils::tui::get_active_renderer() {
-                renderer.print_above(&msg);
-            } else if crate::utils::output_format::is_json_output_active() {
-                // Verbose JSON builds create no renderer, and print_info is
-                // suppressed in JSON mode — write to stderr directly so the
-                // notice survives without touching the NDJSON stdout stream.
-                eprintln!("{msg}");
-            } else {
-                print_info(&msg, OutputLevel::Normal);
-            }
+            // Verbose JSON builds create no renderer, and print_info is
+            // suppressed in JSON mode, so this routes through the shared notice
+            // sink to reach stderr without touching the NDJSON stdout stream.
+            crate::utils::output::print_notice_above(&msg, |line| {
+                print_info(line, OutputLevel::Normal)
+            });
         }
 
         Ok(())

--- a/src/utils/container.rs
+++ b/src/utils/container.rs
@@ -403,13 +403,7 @@ pub fn container_failure_message(context: &str, stderr: &str) -> String {
 /// because print_error is a no-op in TUI/JSON modes, which would silently
 /// eat container failure diagnostics.
 pub(crate) fn print_failure_notice(msg: &str) {
-    if let Some(renderer) = crate::utils::tui::get_active_renderer() {
-        renderer.print_above(msg);
-    } else if crate::utils::output_format::is_json_output_active() {
-        eprintln!("{msg}");
-    } else {
-        print_error(msg, OutputLevel::Normal);
-    }
+    crate::utils::output::print_notice_above(msg, |line| print_error(line, OutputLevel::Normal));
 }
 
 /// Convert captured output bytes to a String without an extra copy for

--- a/src/utils/output.rs
+++ b/src/utils/output.rs
@@ -92,7 +92,7 @@ pub fn print_warning_above(message: &str) {
 /// Emit `formatted` where neither an active renderer nor the NDJSON stream can
 /// swallow it.
 ///
-/// The three-way routing had been open-coded four times (here,
+/// The three-way routing had been open-coded three times (here,
 /// [`crate::utils::container::print_failure_notice`], and
 /// `commands/runtime/build.rs`), each copy re-deriving the same policy. This is
 /// the one implementation; [`warning_sink`] stays separate as the pure,

--- a/src/utils/output.rs
+++ b/src/utils/output.rs
@@ -61,6 +61,58 @@ pub fn print_warning(message: &str, _level: OutputLevel) {
     }
 }
 
+/// Print a warning that an active renderer cannot swallow.
+///
+/// [`print_warning`] early-returns on [`tui_is_active`], which is also true for
+/// `--json`, so on the interactive renderer path and every JSON invocation it
+/// prints nothing at all. That is fine for progress chatter the task lines
+/// already convey, but not for a notice that a safety check was skipped: those
+/// are exactly the paths where the user would otherwise see an unqualified
+/// green run.
+///
+/// Routes through the renderer's `print_above` when one is active so the notice
+/// lands above the task list instead of being overwritten by it. With no
+/// renderer but JSON output active, goes to stderr - stdout carries the NDJSON
+/// stream and prose would corrupt it.
+pub fn print_warning_above(message: &str) {
+    let formatted = format!("\x1b[93m[WARNING]\x1b[0m {message}");
+    match warning_sink(
+        crate::utils::tui::get_active_renderer().is_some(),
+        crate::utils::output_format::is_json_output_active(),
+    ) {
+        WarningSink::Renderer => {
+            // Unwrap is sound: the sink is Renderer only when one is active, and
+            // nothing clears it mid-call.
+            crate::utils::tui::get_active_renderer()
+                .expect("renderer active")
+                .print_above(&formatted)
+        }
+        WarningSink::Stderr => eprintln!("{formatted}"),
+        WarningSink::Stdout => println!("{formatted}"),
+    }
+}
+
+/// Where a [`print_warning_above`] notice goes.
+///
+/// Split out from the emit so the routing policy is testable: the property that
+/// matters is that there is no fourth, suppressed variant, which is precisely
+/// what `print_warning` has and what made the skipped-check notice invisible on
+/// the default paths.
+#[derive(Debug, PartialEq, Eq)]
+pub enum WarningSink {
+    Renderer,
+    Stderr,
+    Stdout,
+}
+
+pub fn warning_sink(renderer_active: bool, json_active: bool) -> WarningSink {
+    match (renderer_active, json_active) {
+        (true, _) => WarningSink::Renderer,
+        (false, true) => WarningSink::Stderr,
+        (false, false) => WarningSink::Stdout,
+    }
+}
+
 /// Print a message without any color formatting.
 /// Suppressed when TUI is active.
 #[allow(dead_code)]
@@ -131,5 +183,40 @@ mod tests {
         print_debug("Test debug", OutputLevel::Normal);
         flush_stdout();
         flush_stderr();
+    }
+
+    #[test]
+    fn warning_above_is_never_suppressed() {
+        // `tui_is_active()` is true for BOTH an active renderer and `--json`,
+        // and those are the two states `print_warning` drops the message in -
+        // which is every interactive run and every JSON run. Each of the four
+        // combinations has to reach a real sink.
+        for (renderer, json) in [(true, true), (true, false), (false, true), (false, false)] {
+            let sink = warning_sink(renderer, json);
+            assert!(
+                matches!(
+                    sink,
+                    WarningSink::Renderer | WarningSink::Stderr | WarningSink::Stdout
+                ),
+                "renderer={renderer} json={json} produced {sink:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn warning_above_goes_through_the_renderer_when_one_is_active() {
+        // A plain println would be painted over by the task list on the next
+        // frame, so an active renderer has to take precedence over the JSON
+        // check rather than the other way round.
+        assert_eq!(warning_sink(true, false), WarningSink::Renderer);
+        assert_eq!(warning_sink(true, true), WarningSink::Renderer);
+    }
+
+    #[test]
+    fn warning_above_keeps_json_stdout_clean() {
+        // stdout carries the NDJSON stream; prose on it would break consumers
+        // parsing line by line.
+        assert_eq!(warning_sink(false, true), WarningSink::Stderr);
+        assert_eq!(warning_sink(false, false), WarningSink::Stdout);
     }
 }

--- a/src/utils/output.rs
+++ b/src/utils/output.rs
@@ -75,20 +75,48 @@ pub fn print_warning(message: &str, _level: OutputLevel) {
 /// renderer but JSON output active, goes to stderr - stdout carries the NDJSON
 /// stream and prose would corrupt it.
 pub fn print_warning_above(message: &str) {
-    let formatted = format!("\x1b[93m[WARNING]\x1b[0m {message}");
-    match warning_sink(
-        crate::utils::tui::get_active_renderer().is_some(),
-        crate::utils::output_format::is_json_output_active(),
-    ) {
-        WarningSink::Renderer => {
-            // Unwrap is sound: the sink is Renderer only when one is active, and
-            // nothing clears it mid-call.
-            crate::utils::tui::get_active_renderer()
-                .expect("renderer active")
-                .print_above(&formatted)
-        }
-        WarningSink::Stderr => eprintln!("{formatted}"),
-        WarningSink::Stdout => println!("{formatted}"),
+    // stdout carries the NDJSON stream, so the human line goes to stderr under
+    // --json (see print_notice_above). Without an event too, a consumer reading
+    // only the stream sees nothing at all and renders an unqualified green run -
+    // which is the failure this whole notice exists to prevent, just moved.
+    if crate::utils::output_format::is_json_output_active() {
+        crate::utils::output_format::emit_json_event(
+            &serde_json::json!({"event": "warning", "message": message}),
+        );
+    }
+    print_notice_above(&format!("\x1b[93m[WARNING]\x1b[0m {message}"), |line| {
+        println!("{line}")
+    });
+}
+
+/// Emit `formatted` where neither an active renderer nor the NDJSON stream can
+/// swallow it.
+///
+/// The three-way routing had been open-coded four times (here,
+/// [`crate::utils::container::print_failure_notice`], and
+/// `commands/runtime/build.rs`), each copy re-deriving the same policy. This is
+/// the one implementation; [`warning_sink`] stays separate as the pure,
+/// testable statement of that policy.
+///
+/// `plain` is the emit for the neither-active case and is a parameter because
+/// severity genuinely differs there: a warning belongs on stdout, an error on
+/// stderr. Everything above that case is identical, which is the part worth
+/// sharing.
+///
+/// The renderer `Option` is bound once and matched alongside the sink rather
+/// than looked up a second time behind an `expect`. `get_active_renderer`
+/// returning `None` on the second call is reachable - `clear_active_renderer`
+/// is `pub` and is the first statement of `TaskRenderer::shutdown` - so the
+/// old shape could abort the process while printing an informational notice.
+/// Pairing the two makes that branch fall through to stderr instead of
+/// depending on the interleaving being impossible.
+pub fn print_notice_above(formatted: &str, plain: impl FnOnce(&str)) {
+    let renderer = crate::utils::tui::get_active_renderer();
+    let json_active = crate::utils::output_format::is_json_output_active();
+    match (warning_sink(renderer.is_some(), json_active), renderer) {
+        (WarningSink::Renderer, Some(active)) => active.print_above(formatted),
+        (WarningSink::Renderer, None) | (WarningSink::Stderr, _) => eprintln!("{formatted}"),
+        (WarningSink::Stdout, _) => plain(formatted),
     }
 }
 
@@ -191,16 +219,15 @@ mod tests {
         // and those are the two states `print_warning` drops the message in -
         // which is every interactive run and every JSON run. Each of the four
         // combinations has to reach a real sink.
-        for (renderer, json) in [(true, true), (true, false), (false, true), (false, false)] {
-            let sink = warning_sink(renderer, json);
-            assert!(
-                matches!(
-                    sink,
-                    WarningSink::Renderer | WarningSink::Stderr | WarningSink::Stdout
-                ),
-                "renderer={renderer} json={json} produced {sink:?}"
-            );
-        }
+        //
+        // Asserting the exact sink per combination, not merely that the result
+        // is one of the three variants: a three-variant enum makes that weaker
+        // form unfalsifiable, so it stayed green under a `warning_sink` forced
+        // to return a single arm.
+        assert_eq!(warning_sink(true, true), WarningSink::Renderer);
+        assert_eq!(warning_sink(true, false), WarningSink::Renderer);
+        assert_eq!(warning_sink(false, true), WarningSink::Stderr);
+        assert_eq!(warning_sink(false, false), WarningSink::Stdout);
     }
 
     #[test]

--- a/src/utils/remote.rs
+++ b/src/utils/remote.rs
@@ -204,14 +204,10 @@ impl SshClient {
             // printed "[SUCCESS] Remote avocado version: <local>" for a check
             // that never ran - the precise defect Skipped exists to remove.
             //
-            // The warning is empty on purpose. Same machine, same binary, so
-            // there is nothing for the user to act on; an empty warning renders
-            // as no notice at all rather than a [WARNING] line on every
+            // No warning: same machine, same binary, so there is nothing for
+            // the user to act on and nothing to print on every
             // `--runs-on localhost` run.
-            return Ok(RemoteVersionCheck::Skipped {
-                reported: local_version.to_string(),
-                warning: String::new(),
-            });
+            return Ok(RemoteVersionCheck::Skipped(None));
         }
 
         if self.verbose {
@@ -279,10 +275,7 @@ impl SshClient {
             // Proceed, but hand the caller the notice rather than swallowing it.
             // Refusing here would break a working setup whose remote merely
             // prints an unusual version string.
-            VersionGate::Unreadable(warning) => Ok(RemoteVersionCheck::Skipped {
-                reported: remote_version.to_string(),
-                warning,
-            }),
+            VersionGate::Unreadable(warning) => Ok(RemoteVersionCheck::Skipped(Some(warning))),
         }
     }
 
@@ -988,9 +981,9 @@ pub async fn get_local_ip_for_remote(remote_host: &str) -> Result<IpAddr> {
 pub enum RemoteVersionCheck {
     /// The remote reported a parseable version at least as new as the local one.
     Verified(String),
-    /// The remote's `--version` output could not be parsed, so no comparison
-    /// happened. Carries what it reported and the notice to show for it.
-    Skipped { reported: String, warning: String },
+    /// No comparison happened. Carries the notice to show for it, or `None`
+    /// when there is nothing worth saying (localhost).
+    Skipped(Option<String>),
 }
 
 /// The three ways the version gate can land, with the prose for the two that
@@ -1038,8 +1031,8 @@ pub fn version_check_notice(check: &RemoteVersionCheck) -> VersionNotice {
         RemoteVersionCheck::Verified(version) => {
             VersionNotice::Success(format!("Remote avocado version: {version}"))
         }
-        RemoteVersionCheck::Skipped { warning, .. } if warning.is_empty() => VersionNotice::Silent,
-        RemoteVersionCheck::Skipped { warning, .. } => VersionNotice::Warning(warning.clone()),
+        RemoteVersionCheck::Skipped(None) => VersionNotice::Silent,
+        RemoteVersionCheck::Skipped(Some(warning)) => VersionNotice::Warning(warning.clone()),
     }
 }
 
@@ -1393,10 +1386,8 @@ mod tests {
         // The whole point of the Skipped variant. Reverting runs_on's arm to
         // print_success left the suite green because nothing tested the
         // mapping, so the bug this PR fixes could return unobserved.
-        let skipped = RemoteVersionCheck::Skipped {
-            reported: "avocado (dev build)".to_string(),
-            warning: "the version check was skipped".to_string(),
-        };
+        let skipped =
+            RemoteVersionCheck::Skipped(Some("the version check was skipped".to_string()));
         assert_eq!(
             version_check_notice(&skipped),
             VersionNotice::Warning("the version check was skipped".to_string())
@@ -1416,10 +1407,7 @@ mod tests {
         // The localhost path. It has no version to report and nothing to warn
         // about, so it must produce neither a green line nor a [WARNING] on
         // every `--runs-on localhost` run.
-        let localhost = RemoteVersionCheck::Skipped {
-            reported: "0.21.0".to_string(),
-            warning: String::new(),
-        };
+        let localhost = RemoteVersionCheck::Skipped(None);
         assert_eq!(version_check_notice(&localhost), VersionNotice::Silent);
     }
 }

--- a/src/utils/remote.rs
+++ b/src/utils/remote.rs
@@ -174,13 +174,22 @@ impl SshClient {
         Ok(())
     }
 
-    /// Check that the remote avocado CLI version is compatible
+    /// Check that the remote avocado CLI version is compatible.
     ///
-    /// The remote version must be equal to or greater than the local version.
-    /// Returns the remote version string if compatible.
+    /// Returns [`RemoteVersionCheck::Verified`] when the remote reported a
+    /// parseable version at least as new as the local one, and
+    /// [`RemoteVersionCheck::Skipped`] when its `--version` output could not be
+    /// read, so no comparison happened. Errors when the remote is genuinely
+    /// older, or when the CLI is missing there entirely.
+    ///
+    /// The two `Ok` cases stay distinct all the way to the caller on purpose. A
+    /// `Result<String>` collapsed them back into one indistinguishable value, so
+    /// the caller printed the same green success line for a skipped check as for
+    /// a passed one - which is the failure this whole three-valued path exists
+    /// to prevent.
     ///
     /// For localhost/127.0.0.1, this check is skipped since it's the same machine.
-    pub async fn check_cli_version(&self) -> Result<String> {
+    pub async fn check_cli_version(&self) -> Result<RemoteVersionCheck> {
         let local_version = env!("CARGO_PKG_VERSION");
 
         // Skip version check for localhost - it's the same machine
@@ -191,7 +200,7 @@ impl SshClient {
                     OutputLevel::Normal,
                 );
             }
-            return Ok(local_version.to_string());
+            return Ok(RemoteVersionCheck::Verified(local_version.to_string()));
         }
 
         if self.verbose {
@@ -244,17 +253,7 @@ impl SshClient {
 
         let remote_version = parse_reported_version(&version_output);
 
-        // Compare versions
-        if !is_version_compatible(local_version, remote_version) {
-            anyhow::bail!(
-                "Remote avocado version '{}' is older than local version '{}'. \
-                 Please upgrade avocado on '{}' to version {} or later.",
-                remote_version,
-                local_version,
-                self.remote.ssh_target(),
-                local_version
-            );
-        }
+        let gate = version_gate_outcome(local_version, remote_version, &self.remote.ssh_target());
 
         if self.verbose {
             print_info(
@@ -263,7 +262,17 @@ impl SshClient {
             );
         }
 
-        Ok(remote_version.to_string())
+        match gate {
+            VersionGate::Compatible => Ok(RemoteVersionCheck::Verified(remote_version.to_string())),
+            VersionGate::TooOld(message) => anyhow::bail!(message),
+            // Proceed, but hand the caller the notice rather than swallowing it.
+            // Refusing here would break a working setup whose remote merely
+            // prints an unusual version string.
+            VersionGate::Unreadable(warning) => Ok(RemoteVersionCheck::Skipped {
+                reported: remote_version.to_string(),
+                warning,
+            }),
+        }
     }
 
     /// Run a command on the remote host and return the output
@@ -959,6 +968,59 @@ pub async fn get_local_ip_for_remote(remote_host: &str) -> Result<IpAddr> {
         .unwrap_or_else(|| anyhow::anyhow!("No valid addresses found for remote host")))
 }
 
+/// What [`SshClient::check_cli_version`] concluded about the remote CLI.
+///
+/// Kept distinct rather than flattened back to a `String` so a caller can tell a
+/// verified-compatible remote from one whose version was never readable, and
+/// present them differently.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteVersionCheck {
+    /// The remote reported a parseable version at least as new as the local one.
+    Verified(String),
+    /// The remote's `--version` output could not be parsed, so no comparison
+    /// happened. Carries what it reported and the notice to show for it.
+    Skipped { reported: String, warning: String },
+}
+
+/// The three ways the version gate can land, with the prose for the two that
+/// have something to say.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionGate {
+    Compatible,
+    /// The remote is genuinely older; the caller should refuse to proceed.
+    TooOld(String),
+    /// Neither version parsed, so the check did not run.
+    Unreadable(String),
+}
+
+/// Decide the version gate from the two version strings.
+///
+/// Pure, and separate from [`SshClient::check_cli_version`], because the three
+/// arms were otherwise reachable only through a live ssh boundary that nothing
+/// fakes. The warn-and-proceed arm in particular had no test at all: replacing
+/// its whole body with `None => {}` left both `cargo test --lib` and
+/// `tests/runs_on_integration.rs` passing, which is how a silent skip got
+/// through review in the first place.
+pub fn version_gate_outcome(
+    local_version: &str,
+    remote_version: &str,
+    ssh_target: &str,
+) -> VersionGate {
+    match is_version_compatible(local_version, remote_version) {
+        Some(true) => VersionGate::Compatible,
+        Some(false) => VersionGate::TooOld(format!(
+            "Remote avocado version '{remote_version}' is older than local version \
+             '{local_version}'. Please upgrade avocado on '{ssh_target}' to version \
+             {local_version} or later."
+        )),
+        None => VersionGate::Unreadable(format!(
+            "Could not read the avocado version on '{ssh_target}' from \
+             '{remote_version}', so the version check was skipped. If this command \
+             fails oddly, confirm the remote has avocado {local_version} or later."
+        )),
+    }
+}
+
 /// Extract the version from `avocado --version` output.
 ///
 /// The line reads `avocado <version> (<short-sha> <commit-date>)`, so the
@@ -1014,7 +1076,18 @@ fn is_version_shaped(token: &str) -> bool {
 ///
 /// The remote version must be equal to or greater than the local version.
 /// Uses semantic versioning comparison.
-pub fn is_version_compatible(local_version: &str, remote_version: &str) -> bool {
+///
+/// `Some(true)` compatible, `Some(false)` the remote is older, and `None` when
+/// either version could not be parsed.
+///
+/// `None` used to be `true`: an unreadable version was indistinguishable from a
+/// verified-compatible one, so the check passed silently and the user never
+/// learned it had been skipped. Proceeding on `None` is still the right default
+/// for the caller to choose - refusing to run because a remote printed an odd
+/// version string would break working setups to guard against a hypothetical -
+/// but that is the caller's call to make and to announce, not something this
+/// function should decide by returning the same answer as success.
+pub fn is_version_compatible(local_version: &str, remote_version: &str) -> Option<bool> {
     let parse_version = |v: &str| -> Option<(u32, u32, u32)> {
         let parts: Vec<&str> = v.split('.').collect();
         if parts.len() >= 3 {
@@ -1031,14 +1104,11 @@ pub fn is_version_compatible(local_version: &str, remote_version: &str) -> bool 
     };
 
     match (parse_version(local_version), parse_version(remote_version)) {
-        (Some(local), Some(remote)) => {
-            // Remote must be >= local
-            remote >= local
-        }
-        _ => {
-            // If we can't parse versions, assume compatible (fail open)
-            true
-        }
+        // Remote must be >= local
+        (Some(local), Some(remote)) => Some(remote >= local),
+        // Unparseable on either side: report that rather than answering the
+        // question we could not actually evaluate.
+        _ => None,
     }
 }
 
@@ -1094,22 +1164,22 @@ mod tests {
 
     #[test]
     fn test_version_compatible_equal() {
-        assert!(is_version_compatible("0.20.0", "0.20.0"));
-        assert!(is_version_compatible("1.0.0", "1.0.0"));
+        assert_eq!(is_version_compatible("0.20.0", "0.20.0"), Some(true));
+        assert_eq!(is_version_compatible("1.0.0", "1.0.0"), Some(true));
     }
 
     #[test]
     fn test_version_compatible_remote_newer() {
-        assert!(is_version_compatible("0.20.0", "0.21.0"));
-        assert!(is_version_compatible("0.20.0", "1.0.0"));
-        assert!(is_version_compatible("0.20.0", "0.20.1"));
+        assert_eq!(is_version_compatible("0.20.0", "0.21.0"), Some(true));
+        assert_eq!(is_version_compatible("0.20.0", "1.0.0"), Some(true));
+        assert_eq!(is_version_compatible("0.20.0", "0.20.1"), Some(true));
     }
 
     #[test]
     fn test_version_incompatible_remote_older() {
-        assert!(!is_version_compatible("0.21.0", "0.20.0"));
-        assert!(!is_version_compatible("1.0.0", "0.20.0"));
-        assert!(!is_version_compatible("0.20.1", "0.20.0"));
+        assert_eq!(is_version_compatible("0.21.0", "0.20.0"), Some(false));
+        assert_eq!(is_version_compatible("1.0.0", "0.20.0"), Some(false));
+        assert_eq!(is_version_compatible("0.20.1", "0.20.0"), Some(false));
     }
 
     #[test]
@@ -1186,21 +1256,79 @@ mod tests {
 
     #[test]
     fn test_version_compatible_major_minor_only() {
-        assert!(is_version_compatible("0.20", "0.20.0"));
-        assert!(is_version_compatible("0.20.0", "0.21"));
+        assert_eq!(is_version_compatible("0.20", "0.20.0"), Some(true));
+        assert_eq!(is_version_compatible("0.20.0", "0.21"), Some(true));
     }
 
     #[test]
     fn test_version_compatible_with_prerelease() {
         // Pre-release versions should still compare by numbers
-        assert!(is_version_compatible("0.20.0-beta", "0.20.0"));
-        assert!(is_version_compatible("0.20.0", "0.20.1-rc1"));
+        assert_eq!(is_version_compatible("0.20.0-beta", "0.20.0"), Some(true));
+        assert_eq!(is_version_compatible("0.20.0", "0.20.1-rc1"), Some(true));
     }
 
     #[test]
-    fn test_version_compatible_unparseable() {
-        // Unparseable versions should fail open (assume compatible)
-        assert!(is_version_compatible("unparseable", "0.20.0"));
-        assert!(is_version_compatible("0.20.0", "unparseable"));
+    fn test_version_unparseable_is_reported_as_unknown_not_compatible() {
+        // Was `assert!(is_version_compatible(..))`, pinning a silent fail-open:
+        // an unreadable version returned the same `true` as a genuinely
+        // compatible one, so the caller could not tell "verified compatible"
+        // from "gave up" and said nothing either way. Proceeding is still the
+        // right call - blocking a working deploy over an odd version string
+        // would be a worse failure than the one being fixed - but it has to be
+        // distinguishable so the caller can say so.
+        assert_eq!(is_version_compatible("unparseable", "0.20.0"), None);
+        assert_eq!(is_version_compatible("0.20.0", "unparseable"), None);
+    }
+
+    #[test]
+    fn test_version_gate_compatible_says_nothing() {
+        // A passed check carries no prose: anything it emitted would compete
+        // with the caller's own success line.
+        assert_eq!(
+            version_gate_outcome("0.20.0", "0.21.0", "user@host"),
+            VersionGate::Compatible
+        );
+    }
+
+    #[test]
+    fn test_version_gate_too_old_names_both_versions_and_the_target() {
+        let VersionGate::TooOld(message) =
+            version_gate_outcome("0.21.0", "0.20.0", "user@board.local")
+        else {
+            panic!("an older remote must not pass the gate");
+        };
+        // The user has to know which host to upgrade and to what, so all three
+        // facts belong in the one line they will see.
+        assert!(message.contains("0.20.0"), "{message}");
+        assert!(message.contains("0.21.0"), "{message}");
+        assert!(message.contains("user@board.local"), "{message}");
+    }
+
+    #[test]
+    fn test_version_gate_unreadable_warns_instead_of_staying_silent() {
+        // The arm that had no test at all, and the one this whole three-valued
+        // path exists for. Deleting its body left every suite green, so what is
+        // pinned here is that it produces a notice, not merely that it proceeds.
+        let VersionGate::Unreadable(warning) =
+            version_gate_outcome("0.20.0", "avocado (dev build)", "user@board.local")
+        else {
+            panic!("an unparseable remote version must not read as verified");
+        };
+        // "skipped", not "failed": the run continues, and the wording is the
+        // only thing telling the user the check did not happen.
+        assert!(warning.contains("skipped"), "{warning}");
+        assert!(warning.contains("avocado (dev build)"), "{warning}");
+        assert!(warning.contains("user@board.local"), "{warning}");
+    }
+
+    #[test]
+    fn test_version_gate_does_not_treat_unreadable_as_too_old() {
+        // Both non-compatible arms would satisfy a test that only checked "not
+        // Compatible", but one bails and the other proceeds - collapsing them
+        // would either block working setups or restore the silent pass.
+        let unreadable = version_gate_outcome("0.20.0", "not-a-version", "user@host");
+        let too_old = version_gate_outcome("0.21.0", "0.20.0", "user@host");
+        assert!(matches!(unreadable, VersionGate::Unreadable(_)));
+        assert!(matches!(too_old, VersionGate::TooOld(_)));
     }
 }

--- a/src/utils/remote.rs
+++ b/src/utils/remote.rs
@@ -200,7 +200,18 @@ impl SshClient {
                     OutputLevel::Normal,
                 );
             }
-            return Ok(RemoteVersionCheck::Verified(local_version.to_string()));
+            // Skipped, not Verified: no version was read, and returning Verified
+            // printed "[SUCCESS] Remote avocado version: <local>" for a check
+            // that never ran - the precise defect Skipped exists to remove.
+            //
+            // The warning is empty on purpose. Same machine, same binary, so
+            // there is nothing for the user to act on; an empty warning renders
+            // as no notice at all rather than a [WARNING] line on every
+            // `--runs-on localhost` run.
+            return Ok(RemoteVersionCheck::Skipped {
+                reported: local_version.to_string(),
+                warning: String::new(),
+            });
         }
 
         if self.verbose {
@@ -1001,6 +1012,37 @@ pub enum VersionGate {
 /// its whole body with `None => {}` left both `cargo test --lib` and
 /// `tests/runs_on_integration.rs` passing, which is how a silent skip got
 /// through review in the first place.
+/// What a caller should emit for a [`RemoteVersionCheck`].
+///
+/// Extracted from `runs_on`'s match arm so the routing is testable. That arm
+/// had no coverage at all: reverting it to the pre-gate
+/// `print_success("Remote avocado version: {reported}")` left the entire suite
+/// green, so the bug this PR fixes could have come straight back.
+#[derive(Debug, PartialEq, Eq)]
+pub enum VersionNotice {
+    /// A real comparison happened - safe to report green.
+    Success(String),
+    /// The check did not run; say so where a renderer cannot swallow it.
+    Warning(String),
+    /// Skipped with nothing worth saying (localhost).
+    Silent,
+}
+
+/// Map a version-check outcome to the notice it deserves.
+///
+/// The load-bearing property is that [`RemoteVersionCheck::Skipped`] can never
+/// produce [`VersionNotice::Success`]: a skipped check must not render as a
+/// green version line.
+pub fn version_check_notice(check: &RemoteVersionCheck) -> VersionNotice {
+    match check {
+        RemoteVersionCheck::Verified(version) => {
+            VersionNotice::Success(format!("Remote avocado version: {version}"))
+        }
+        RemoteVersionCheck::Skipped { warning, .. } if warning.is_empty() => VersionNotice::Silent,
+        RemoteVersionCheck::Skipped { warning, .. } => VersionNotice::Warning(warning.clone()),
+    }
+}
+
 pub fn version_gate_outcome(
     local_version: &str,
     remote_version: &str,
@@ -1330,5 +1372,54 @@ mod tests {
         let too_old = version_gate_outcome("0.21.0", "0.20.0", "user@host");
         assert!(matches!(unreadable, VersionGate::Unreadable(_)));
         assert!(matches!(too_old, VersionGate::TooOld(_)));
+    }
+
+    #[test]
+    fn version_gate_reports_compatible_when_the_remote_is_new_enough() {
+        // The third arm. Its two siblings were covered and this one was not, so
+        // a gate that never returned Compatible would have gone unnoticed.
+        assert_eq!(
+            version_gate_outcome("0.20.0", "0.20.0", "user@host"),
+            VersionGate::Compatible
+        );
+        assert_eq!(
+            version_gate_outcome("0.20.0", "0.21.0", "user@host"),
+            VersionGate::Compatible
+        );
+    }
+
+    #[test]
+    fn a_skipped_check_never_renders_as_a_green_version_line() {
+        // The whole point of the Skipped variant. Reverting runs_on's arm to
+        // print_success left the suite green because nothing tested the
+        // mapping, so the bug this PR fixes could return unobserved.
+        let skipped = RemoteVersionCheck::Skipped {
+            reported: "avocado (dev build)".to_string(),
+            warning: "the version check was skipped".to_string(),
+        };
+        assert_eq!(
+            version_check_notice(&skipped),
+            VersionNotice::Warning("the version check was skipped".to_string())
+        );
+    }
+
+    #[test]
+    fn a_verified_check_renders_the_version_it_actually_read() {
+        assert_eq!(
+            version_check_notice(&RemoteVersionCheck::Verified("0.21.0".to_string())),
+            VersionNotice::Success("Remote avocado version: 0.21.0".to_string())
+        );
+    }
+
+    #[test]
+    fn a_skipped_check_with_no_warning_says_nothing() {
+        // The localhost path. It has no version to report and nothing to warn
+        // about, so it must produce neither a green line nor a [WARNING] on
+        // every `--runs-on localhost` run.
+        let localhost = RemoteVersionCheck::Skipped {
+            reported: "0.21.0".to_string(),
+            warning: String::new(),
+        };
+        assert_eq!(version_check_notice(&localhost), VersionNotice::Silent);
     }
 }

--- a/src/utils/runs_on.rs
+++ b/src/utils/runs_on.rs
@@ -15,8 +15,8 @@ use crate::utils::nfs_server::{
 };
 use crate::utils::output::{print_info, print_success, print_warning_above, OutputLevel};
 use crate::utils::remote::{
-    get_local_ip_for_remote, RemoteHost, RemoteVersionCheck, RemoteVolumeManager, SshClient,
-    SshControlMaster,
+    get_local_ip_for_remote, version_check_notice, RemoteHost, RemoteVolumeManager, SshClient,
+    SshControlMaster, VersionNotice,
 };
 
 #[cfg(unix)]
@@ -120,16 +120,15 @@ impl RunsOnContext {
 
         // Check remote CLI version compatibility
         print_info("Checking remote avocado version...", OutputLevel::Normal);
-        match ssh.check_cli_version().await? {
-            RemoteVersionCheck::Verified(remote_version) => print_success(
-                &format!("Remote avocado version: {remote_version}"),
-                OutputLevel::Normal,
-            ),
-            // Never a green success line here: the check did not run. The notice
-            // goes through `print_warning_above` because `print_warning` is
-            // suppressed whenever a renderer or `--json` is active, which is the
-            // default for most of these commands.
-            RemoteVersionCheck::Skipped { warning, .. } => print_warning_above(&warning),
+        // The Verified/Skipped -> notice mapping lives in `version_check_notice`
+        // so it is covered by tests; this arm is a total dispatch over its
+        // result. `print_warning_above` rather than `print_warning` because the
+        // latter is suppressed whenever a renderer or `--json` is active, which
+        // is the default for most of these commands.
+        match version_check_notice(&ssh.check_cli_version().await?) {
+            VersionNotice::Success(message) => print_success(&message, OutputLevel::Normal),
+            VersionNotice::Warning(warning) => print_warning_above(&warning),
+            VersionNotice::Silent => {}
         }
 
         // Determine which port to use

--- a/src/utils/runs_on.rs
+++ b/src/utils/runs_on.rs
@@ -13,9 +13,10 @@ use crate::utils::nfs_server::{
     find_available_port, get_docker_volume_mountpoint, is_port_available, NfsExport, NfsServer,
     NfsServerConfig, DEFAULT_NFS_PORT_RANGE,
 };
-use crate::utils::output::{print_info, print_success, OutputLevel};
+use crate::utils::output::{print_info, print_success, print_warning_above, OutputLevel};
 use crate::utils::remote::{
-    get_local_ip_for_remote, RemoteHost, RemoteVolumeManager, SshClient, SshControlMaster,
+    get_local_ip_for_remote, RemoteHost, RemoteVersionCheck, RemoteVolumeManager, SshClient,
+    SshControlMaster,
 };
 
 #[cfg(unix)]
@@ -119,11 +120,17 @@ impl RunsOnContext {
 
         // Check remote CLI version compatibility
         print_info("Checking remote avocado version...", OutputLevel::Normal);
-        let remote_version = ssh.check_cli_version().await?;
-        print_success(
-            &format!("Remote avocado version: {remote_version}"),
-            OutputLevel::Normal,
-        );
+        match ssh.check_cli_version().await? {
+            RemoteVersionCheck::Verified(remote_version) => print_success(
+                &format!("Remote avocado version: {remote_version}"),
+                OutputLevel::Normal,
+            ),
+            // Never a green success line here: the check did not run. The notice
+            // goes through `print_warning_above` because `print_warning` is
+            // suppressed whenever a renderer or `--json` is active, which is the
+            // default for most of these commands.
+            RemoteVersionCheck::Skipped { warning, .. } => print_warning_above(&warning),
+        }
 
         // Determine which port to use
         let port = match nfs_port {

--- a/tests/runs_on_integration.rs
+++ b/tests/runs_on_integration.rs
@@ -154,52 +154,52 @@ mod version_compatibility_tests {
 
     #[test]
     fn test_equal_versions() {
-        assert!(is_version_compatible("0.20.0", "0.20.0"));
-        assert!(is_version_compatible("1.0.0", "1.0.0"));
-        assert!(is_version_compatible("2.5.10", "2.5.10"));
+        assert_eq!(is_version_compatible("0.20.0", "0.20.0"), Some(true));
+        assert_eq!(is_version_compatible("1.0.0", "1.0.0"), Some(true));
+        assert_eq!(is_version_compatible("2.5.10", "2.5.10"), Some(true));
     }
 
     #[test]
     fn test_remote_newer_patch() {
-        assert!(is_version_compatible("0.20.0", "0.20.1"));
-        assert!(is_version_compatible("0.20.0", "0.20.99"));
+        assert_eq!(is_version_compatible("0.20.0", "0.20.1"), Some(true));
+        assert_eq!(is_version_compatible("0.20.0", "0.20.99"), Some(true));
     }
 
     #[test]
     fn test_remote_newer_minor() {
-        assert!(is_version_compatible("0.20.0", "0.21.0"));
-        assert!(is_version_compatible("0.20.5", "0.25.0"));
+        assert_eq!(is_version_compatible("0.20.0", "0.21.0"), Some(true));
+        assert_eq!(is_version_compatible("0.20.5", "0.25.0"), Some(true));
     }
 
     #[test]
     fn test_remote_newer_major() {
-        assert!(is_version_compatible("0.20.0", "1.0.0"));
-        assert!(is_version_compatible("1.5.3", "2.0.0"));
+        assert_eq!(is_version_compatible("0.20.0", "1.0.0"), Some(true));
+        assert_eq!(is_version_compatible("1.5.3", "2.0.0"), Some(true));
     }
 
     #[test]
     fn test_remote_older_patch() {
-        assert!(!is_version_compatible("0.20.1", "0.20.0"));
-        assert!(!is_version_compatible("0.20.5", "0.20.4"));
+        assert_eq!(is_version_compatible("0.20.1", "0.20.0"), Some(false));
+        assert_eq!(is_version_compatible("0.20.5", "0.20.4"), Some(false));
     }
 
     #[test]
     fn test_remote_older_minor() {
-        assert!(!is_version_compatible("0.21.0", "0.20.0"));
-        assert!(!is_version_compatible("0.25.0", "0.20.5"));
+        assert_eq!(is_version_compatible("0.21.0", "0.20.0"), Some(false));
+        assert_eq!(is_version_compatible("0.25.0", "0.20.5"), Some(false));
     }
 
     #[test]
     fn test_remote_older_major() {
-        assert!(!is_version_compatible("1.0.0", "0.20.0"));
-        assert!(!is_version_compatible("2.0.0", "1.5.3"));
+        assert_eq!(is_version_compatible("1.0.0", "0.20.0"), Some(false));
+        assert_eq!(is_version_compatible("2.0.0", "1.5.3"), Some(false));
     }
 
     #[test]
     fn test_prerelease_versions() {
         // Pre-release suffix should be stripped for comparison
-        assert!(is_version_compatible("0.20.0-beta", "0.20.0"));
-        assert!(is_version_compatible("0.20.0", "0.20.1-rc1"));
+        assert_eq!(is_version_compatible("0.20.0-beta", "0.20.0"), Some(true));
+        assert_eq!(is_version_compatible("0.20.0", "0.20.1-rc1"), Some(true));
     }
 }
 


### PR DESCRIPTION
## Problem

`is_version_compatible` returned `true` when either version failed to parse, so
"the remote is new enough" and "I could not tell" were the same answer. The
version gate in `RemoteHost`'s runs-on path then proceeded without printing
anything.

The case the gate exists to catch - a remote CLI too old for the command about
to run - is also the case most likely to report a version this parser cannot
read, so the check was most likely to be skipped exactly when it mattered. It
was skipped silently: nothing in the output distinguished a verified-compatible
remote from one that was never checked.

## Approach

Return `Option<bool>` so the caller can tell the two apart, and have it warn and
carry on rather than bail.

Proceeding on `None` is deliberate. Refusing to run because a remote printed an
unusual version string would break working setups to guard against a
hypothetical, and the complaint here is the silence, not the permissiveness. The
warning names the string that could not be read and the version the remote
needs, so an odd later failure has a breadcrumb.

If you would rather this fail closed, that is a one-line change at the call site
(`None` arm bails instead of warning) - say so and I will switch it. I went with
warn-and-proceed because it cannot break a working deploy.

`test_version_compatible_unparseable` asserted the old behaviour with the
comment "should fail open (assume compatible)". Fail-open was a deliberate,
documented, tested choice rather than an oversight, so that test is **flipped
rather than deleted** - the replacement records that the decision was
reconsidered, not that it never existed. A paired test pins `Some(true)` against
`Some(false)` so a caller matching on the result cannot collapse unknown into
either.

## Scope note

The desktop half of this failure mode is
avocado-linux/avocado-desktop#75 - `parse_cli_version` there accepted any
non-empty token, so a different program named `avocado` cleared the desktop's
`min_cli_version` floor. The two repos need different answers (the desktop can
fail closed without breaking anything; this side should not), which is why they
are separate changes rather than one.

This does not touch `parse_reported_version`, which is only on #186's branch.

## Verification

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
```

All green at the tip: 1115 lib + 1123 + 126 + 20 + 5 + 49 across the test
binaries.

Falsified: restoring the `_ => Some(true)` fail-open makes
`test_version_unparseable_is_reported_as_unknown_not_compatible` fail, and only
that test.
