### PR TITLE
ci: test and publish against the 2024 'next' channel

### DIFF
--- a/.github/workflows/ext-release.yml
+++ b/.github/workflows/ext-release.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         include:
           - { target: qemux86-64, distro-release: "2026", distro-channel: edge }
-          - { target: qemux86-64, distro-release: "2024", distro-channel: edge-next }
+          - { target: qemux86-64, distro-release: "2024", distro-channel: next }
     uses: avocado-linux/actions/.github/workflows/extension-release.yml@v1
     with:
       target:         ${{ matrix.target }}

--- a/.github/workflows/ext-test.yml
+++ b/.github/workflows/ext-test.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { target: qemux86-64, distro-release: "2024", distro-channel: edge-next }
+          - { target: qemux86-64, distro-release: "2024", distro-channel: next }
     uses: avocado-linux/actions/.github/workflows/extension-test.yml@v1
     with:
       target:         ${{ matrix.target }}


### PR DESCRIPTION
## Problem

The 2024 legs of both extension workflows still name the `edge-next` channel, which is the pre-rename name for what is now `next` in the `next -> edge -> stable` promotion chain. CI has been exercising a channel under its old name.

## Change

Two lines:

- `.github/workflows/ext-test.yml` — the `build` matrix's only entry, `2024/edge-next` -> `2024/next`
- `.github/workflows/ext-release.yml` — the 2024 leg of the `publish` matrix, `2024/edge-next` -> `2024/next`

The 2026 leg of `ext-release` already tracks `edge` and is untouched.

The channel is a feed path segment — the reusable workflow documents the feed as `<repo-url>/<distro-release>/<distro-channel>/...` — so this repoints both jobs at the renamed path. CI on this PR is the verification: the `build (qemux86-64, 2024, next)` job either resolves the feed or it does not.

## Note for a follow-up, not changed here

`ext-test` covers only the 2024 leg while `ext-release` publishes to both `2026/edge` and `2024/next`, so the 2026 target is published without ever being tested. Worth adding a `2026/edge` entry to the test matrix, but that is a scope change rather than a rename and belongs in its own PR.