### PR TITLE
feat(config): resolve extension versions from the extension's source tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "tokio-test",
  "tokio-tungstenite",
  "tokio-util",
+ "toml",
  "tough",
  "tower",
  "uuid",
@@ -2304,6 +2305,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2734,6 +2744,37 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -3478,6 +3519,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ path = "src/lib.rs"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
+# Only used to read a version out of a Cargo.toml-style file for
+# `extensions.<n>.version: { file, key }`. Reading is all we do, so the
+# serializer (`display`) stays off; `serde` is what provides `toml::Value`.
+toml = { version = "1", default-features = false, features = ["parse", "serde"] }
 anyhow = "1.0"
 bytes = "1"
 clap = { version = "4.0", features = ["derive"] }

--- a/docs/features/extension-versioning-redesign.md
+++ b/docs/features/extension-versioning-redesign.md
@@ -26,6 +26,40 @@ This is the one place a version is *not* the config's string, so it is confined 
 - A `-` *inside* a pre-release identifier (`1.0.0-rc-1`) is rejected rather than mapped: `~` is a precedence operator to RPM, so mapping it would invert ordering and dnf would refuse the upgrade. Use `.` to separate identifiers.
 
 So config remains the source of truth; the RPM form is a representation of it at one boundary, not a second version.
+### Version providers: reading the version from the source tree
+
+Some extensions wrap a program maintained in the same repo (avocado-cli, avocado-conn, avocado-rat) and want the extension version to track that program's version without a second place to bump. `version` therefore also accepts a mapping that names a file inside the **extension's own source tree**:
+
+```yaml
+extensions:
+  avocado-ext-cli:
+    version:
+      file: Cargo.toml        # relative to the extension root; no `..`, no absolute paths
+      key: package.version    # dot path; format inferred from the extension
+
+  some-other-ext:
+    version:
+      file: VERSION           # no `key` => whole file, trimmed
+```
+
+`key` is the discriminator. Absent means read the file and trim it, with no parsing and no format guessing — so `VERSION`, `version.txt`, and `.version` all work, and `file: Cargo.toml` with no `key` is a literal read (which then fails semver, as it should). Present means parse the file and navigate the dot path; `format` (`toml`/`json`/`yaml`) is inferred from the extension and can be set explicitly. Only the extension's direct-child `version:` supports the mapping form — a `target-*:`/`kernel-*:` override must use a literal.
+
+**Why a file and not `{{ env.VAR }}`.** These extensions previously declared `version: '{{ env.AVOCADO_EXT_VERSION }}'`, with CI reading Cargo.toml and exporting the variable. `version` is an *identity* field, but `env` binds it to the **caller's** environment — and the packaging job and a downstream consumer are by definition different environments. Consuming such an extension via `source: { type: git | path }` interpolated the version to `""` (a warning, not an error) and then failed semver validation, which is exactly the failure class listed in the Context above. A file inside the extension's own tree is present in every consumption mode — the working copy for `path`, the clone for `git`, the RPM payload for `package` — so the version is a pure function of the extension.
+
+`{{ avocado.* }}` and `{{ config.* }}` remain fine elsewhere in an extension config: those are consumer-context values that are *supposed* to differ per build. It is specifically `env` in an identity field that cannot work.
+
+**No baking, for providers.** The published `avocado.yaml` keeps the provider rather than a resolved literal: the RPM payload *is* the source tree, so the config resolves itself. `ext package` guarantees this by always adding the provider's file to the package payload, including when the extension declares an explicit `package_files` list.
+
+`config_edit::bake_extension_version` still exists for the legacy `{{ env.AVOCADO_EXT_VERSION }}` form, which genuinely cannot resolve downstream and must be baked. `ext package` skips the bake entirely for a provider-based extension — baking one would strand the provider's `file:`/`key:` lines under a replaced `version:` scalar (see `test_bake_extension_version_would_corrupt_a_provider_block`). The bake goes away once no extension uses the env form.
+
+### Rollout
+
+The provider cannot be adopted by an extension until a CLI that understands it has been *released*, because `setup-avocado-cli` installs `latest` and the release workflow for a program-tracking extension runs on the same tag that publishes the new CLI. Hence two steps:
+
+1. **This change** — the provider, the reader extraction, `config show --detail` reporting `version`. No extension migrates yet; `avocado-cli`, `avocado-conn`, and `avocado-rat` stay on `{{ env.AVOCADO_EXT_VERSION }}` and keep working through the bake.
+2. **After a CLI release carrying step 1** — migrate those three `avocado.yaml` files to `version: { file: Cargo.toml, key: package.version }`, drop `AVOCADO_EXT_VERSION` and the `ext-version` input from their workflows and from `avocado-linux/actions`, and delete the bake.
+
+**Compatibility, at step 2.** Publishing a provider-based extension is a payload format change. A CLI predating providers reads the mapping, coerces it to `"0"`, and fails with `invalid version '0'`. There is no graceful degradation: `cli_requirement` is a top-level field and is not merged from a remote extension's config, so an extension cannot declare a CLI floor a consumer will honor. Publish migrated extensions to `next` first and verify before promoting.
 
 ### Rename `distro.version` → `distro.release`
 
@@ -132,8 +166,11 @@ sdk:
 5. **Core packages use `"*"`** in `sdk/install.rs` — all four `get_distro_version()` calls replaced with `"*"`
 6. **Added `distro_release` to lock file** — `LockFile` struct, `check_distro_release_compat()` method, populated in sdk/ext/runtime install commands
 7. **Updated default config template** — `distro.release`, `"*"` for runtime and SDK packages
+8. **Version providers** — `version: { file, key }` in `src/utils/ext_version_source.rs`, resolved during composition (`load_composed_with_board`) and in `get_merged_section_with_board` (the path `ext package` takes for a local extension). Extracted the four-strategy extension-tree read ladder out of `config.rs` into `src/utils/ext_source_reader.rs` so the provider reads the version file by the same route the config was read. `get_package_files` always ships the provider's file; `ext package` skips the bake for provider-based extensions. `config show --detail` reports each extension's resolved `version`.
 
 ### Remaining (separate repos/PRs)
+
+0. **Adopt version providers** (after a CLI release carrying item 8): migrate `avocado-cli`, `avocado-conn`, `avocado-rat` to `version: { file: Cargo.toml, key: package.version }`; drop `AVOCADO_EXT_VERSION` / the `ext-version` input from their workflows and from `avocado-linux/actions`; have the reusable release workflow read the version via `avocado config show --detail --output json`; delete `bake_extension_version`. See Rollout above.
 
 8. **Tekton CI (iac repo)**: Remove `DISTRO_VERSION` param/env from build-extensions-machine.yaml; future rename of `distro-codename` param
 9. **avocado-os configs**: Remove `{{ avocado.distro.version }}` from extension versions, set concrete semver, change package specs to `"*"`, rename `distro.version` → `distro.release`

--- a/src/commands/config_show.rs
+++ b/src/commands/config_show.rs
@@ -218,10 +218,16 @@ fn build_detail(merged: &serde_yaml::Value) -> serde_json::Value {
                 .get(ext_name)
                 .map(|s| s.iter().cloned().collect())
                 .unwrap_or_default();
+            // Always the resolved literal: `load_composed` has already turned a
+            // `version: { file, key }` provider into a string. Release CI reads
+            // this instead of hand-parsing avocado.yaml, which cannot see through
+            // a provider.
+            let version = ext_value.get("version").and_then(|v| v.as_str());
 
             extensions_out.push(json!({
                 "name": ext_name,
                 "node_path": format!("/extensions/{ext_name}"),
+                "version": version,
                 "types": types,
                 "packages": packages,
                 "enable_services": enable_services,

--- a/src/commands/ext/build.rs
+++ b/src/commands/ext/build.rs
@@ -623,12 +623,11 @@ impl ExtBuildCommand {
         let ext_version = config_version.to_string();
 
         // Validate semver format
-        crate::utils::version::validate_semver(&ext_version).with_context(|| {
-            format!(
-                "Extension '{}' has invalid version '{}'. Version must be in semantic versioning format (e.g., '1.0.0', '2.1.3')",
-                self.extension, ext_version
-            )
-        })?;
+        crate::utils::version::validate_ext_version(
+            &self.extension,
+            &ext_version,
+            composed.get_extension_source_config(&self.extension),
+        )?;
 
         // Determine the extension source path for overlay resolution
         // For remote extensions, files are in $AVOCADO_PREFIX/includes/<ext-name>/

--- a/src/commands/ext/image.rs
+++ b/src/commands/ext/image.rs
@@ -552,12 +552,11 @@ impl ExtImageCommand {
         let ext_version = config_version.to_string();
 
         // Validate semver format
-        crate::utils::version::validate_semver(&ext_version).with_context(|| {
-            format!(
-                "Extension '{}' has invalid version '{}'. Version must be in semantic versioning format (e.g., '1.0.0', '2.1.3')",
-                self.extension, ext_version
-            )
-        })?;
+        crate::utils::version::validate_ext_version(
+            &self.extension,
+            &ext_version,
+            composed.get_extension_source_config(&self.extension),
+        )?;
 
         // Create a single image for the extension
         // The runtime will decide whether to use it as sysext, confext, or both

--- a/src/commands/ext/package.rs
+++ b/src/commands/ext/package.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use super::find_ext_in_mapping;
 use crate::utils::config::{ComposedConfig, Config, ExtensionLocation};
 use crate::utils::container::SdkContainer;
+use crate::utils::ext_version_source::VersionSource;
 use crate::utils::output::{print_info, print_success, print_warning, OutputLevel};
 // Note: Stamp imports removed - we no longer validate build stamps for packaging
 // since we now package src_dir instead of built sysroot
@@ -143,9 +144,9 @@ impl ExtPackageCommand {
             }
         };
 
-        // On-disk config filename (avocado.yaml or avocado.yml). Used both for the
-        // default packaged config and for the version bake so a `.yml` ext stages
-        // and bakes under its real name rather than a hardcoded `avocado.yaml`.
+        // On-disk config filename (avocado.yaml or avocado.yml), so a `.yml`
+        // extension stages under its real name rather than a hardcoded
+        // `avocado.yaml`.
         let cfg_basename = std::path::Path::new(&ext_config_path)
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
@@ -187,13 +188,22 @@ impl ExtPackageCommand {
         };
 
         // Extract RPM metadata with defaults
-        let rpm_metadata = self.extract_rpm_metadata(&ext_config, &target)?;
+        let rpm_metadata = self.extract_rpm_metadata(&ext_config, &target, &ext_config_path)?;
 
         // Determine which files to package
         // Pass both merged config (for package_files), raw config (for all target overlays),
-        // and full parsed config (for sdk.compile scripts)
-        let package_files =
-            self.get_package_files(&ext_config, raw_ext_config.as_ref(), parsed, &cfg_basename);
+        // and full parsed config (for sdk.compile scripts). The version source (if the
+        // extension declared `version: { file, key }`) is read from the composed config
+        // rather than the raw text, so it is found the same way for a local extension and
+        // for one that was fetched from a remote source.
+        let version_source = composed.ext_version_sources.get(&self.extension);
+        let package_files = self.get_package_files(
+            &ext_config,
+            raw_ext_config.as_ref(),
+            parsed,
+            &cfg_basename,
+            version_source,
+        );
 
         if self.verbose {
             print_info(
@@ -211,6 +221,63 @@ impl ExtPackageCommand {
 
         // Create main RPM package in container
         // This packages the extension's src_dir (directory containing avocado.yaml)
+        // Resolve package-time-only fields in the avocado.yaml that ships in the
+        // package payload. Today that is just `version`, and only for the legacy
+        // `version: '{{ env.AVOCADO_EXT_VERSION }}'` form: that template resolves
+        // only while the env var is set (package time), so if it survived into the
+        // published package a downstream build — which has no such env in scope —
+        // would interpolate it to '' and fail semver validation. We bake the
+        // resolved value and leave every other template (e.g. `{{ avocado.target }}`)
+        // for the consumer to resolve at their build time.
+        //
+        // An extension using a `version: { file, key }` provider is SKIPPED: the
+        // provider reads from the extension's own tree, which ships in the payload,
+        // so the published config resolves itself. Baking it would also corrupt the
+        // file — the line-scoped rewriter would replace the `version:` line and
+        // strand its `file:`/`key:` children.
+        let version_bake_section = if version_source.is_some() {
+            String::new()
+        } else {
+            match fs::read_to_string(&ext_config_path) {
+                Ok(text) => {
+                    let baked = crate::utils::config_edit::bake_extension_version(
+                        &text,
+                        &self.extension,
+                        &target,
+                        &rpm_metadata.version,
+                    )
+                    .with_context(|| {
+                        format!(
+                            "Failed to bake resolved version '{}' into the packaged \
+                             config for extension '{}'",
+                            rpm_metadata.version, self.extension
+                        )
+                    })?;
+                    let b64 = BASE64_STANDARD.encode(baked.as_bytes());
+                    // The resolved version is baked into the base64 payload only;
+                    // it is never interpolated into the shell, so a version string
+                    // carrying pre-release/build metadata can't reach the command line.
+                    format!(
+                        r#"
+# Bake the resolved extension version into the packaged config so the published
+# avocado.yaml carries a concrete semver instead of an env-only template that
+# would interpolate to '' during a downstream runtime build.
+if [ -f "$STAGING_DIR/{basename}" ]; then
+    printf '%s' '{b64}' | base64 -d > "$STAGING_DIR/{basename}"
+    echo "Baked resolved extension version into {basename}"
+fi
+"#,
+                        basename = cfg_basename,
+                        b64 = b64,
+                    )
+                }
+                // Remote/unreadable source (e.g. packaging a fetched remote ext
+                // whose config lives in the container volume): leave the payload
+                // untouched rather than fail the package.
+                Err(_) => String::new(),
+            }
+        };
+
         let output_path = self
             .create_rpm_package_in_container(
                 &rpm_metadata,
@@ -218,7 +285,7 @@ impl ExtPackageCommand {
                 &target,
                 &ext_config_path,
                 &package_files,
-                &cfg_basename,
+                &version_bake_section,
             )
             .await?;
 
@@ -284,25 +351,36 @@ impl ExtPackageCommand {
     /// - Compile scripts from sdk.compile sections
     /// - Install scripts from extension package dependencies
     ///
+    /// Whatever the outcome, a `version: { file, key }` provider's file is always
+    /// included: the published `avocado.yaml` keeps the provider rather than a
+    /// baked literal, so a payload missing that file would be unresolvable for
+    /// every consumer. See `version_source`.
+    ///
     /// # Arguments
     /// * `ext_config` - The merged extension config (for package_files check)
     /// * `raw_ext_config` - The raw unmerged extension config (to find all target-specific overlays)
     /// * `full_parsed_config` - The full parsed config (to find sdk.compile scripts)
+    /// * `version_source` - The version provider this extension resolved through, if any
     fn get_package_files(
         &self,
         ext_config: &serde_yaml::Value,
         raw_ext_config: Option<&serde_yaml::Value>,
         full_parsed_config: &serde_yaml::Value,
         cfg_basename: &str,
+        version_source: Option<&VersionSource>,
     ) -> Vec<String> {
         // Check if package_files is explicitly defined
         if let Some(package_files) = ext_config.get("package_files") {
             if let Some(files_array) = package_files.as_sequence() {
-                let files: Vec<String> = files_array
+                let mut files: Vec<String> = files_array
                     .iter()
                     .filter_map(|v| v.as_str().map(|s| s.to_string()))
                     .collect();
                 if !files.is_empty() {
+                    // An explicit list replaces the defaults entirely, so the
+                    // version file has to be added back here too — forgetting it
+                    // would only surface once someone consumed the package.
+                    Self::add_version_source_file(&mut files, version_source);
                     return files;
                 }
             }
@@ -310,7 +388,7 @@ impl ExtPackageCommand {
 
         // Default behavior: the config file + overlays + compile scripts + install
         // scripts. Use the actual on-disk config name so an `avocado.yml` ext is
-        // staged (and later baked) under its real name.
+        // staged under its real name.
         let mut default_files = vec![cfg_basename.to_string()];
         let mut seen_files = std::collections::HashSet::new();
 
@@ -377,6 +455,8 @@ impl ExtPackageCommand {
             }
         }
 
+        Self::add_version_source_file(&mut default_files, version_source);
+
         default_files
     }
 
@@ -415,11 +495,24 @@ impl ExtPackageCommand {
         }
     }
 
+    /// Append a `version: { file, key }` provider's file to a package file list.
+    ///
+    /// Idempotent — an author who already listed the file doesn't get it twice.
+    fn add_version_source_file(files: &mut Vec<String>, version_source: Option<&VersionSource>) {
+        let Some(source) = version_source else { return };
+        if !files.iter().any(|f| f == &source.file) {
+            files.push(source.file.clone());
+        }
+    }
+
     /// Extract RPM metadata from extension configuration with defaults
+    ///
+    /// `source_path` is only used to say where an invalid `version` came from.
     fn extract_rpm_metadata(
         &self,
         ext_config: &serde_yaml::Value,
         _target: &str, // Not used - extensions default to noarch
+        source_path: &str,
     ) -> Result<RpmMetadata> {
         // Version is required
         let version = ext_config
@@ -434,12 +527,7 @@ impl ExtPackageCommand {
             .to_string();
 
         // Validate semver format
-        crate::utils::version::validate_semver(&version).with_context(|| {
-            format!(
-                "Extension '{}' has invalid version '{}'. Version must be in semantic versioning format (e.g., '1.0.0', '2.1.3')",
-                self.extension, version
-            )
-        })?;
+        crate::utils::version::validate_ext_version(&self.extension, &version, source_path)?;
 
         // Generate defaults
         let name = self.extension.clone();
@@ -726,7 +814,7 @@ rm -rf "$TMPDIR"
         target: &str,
         ext_config_path: &str,
         package_files: &[String],
-        cfg_basename: &str,
+        version_bake_section: &str,
     ) -> Result<PathBuf> {
         let container_image = config
             .get_sdk_image()
@@ -785,58 +873,6 @@ rm -rf "$TMPDIR"
             _ => "Provides: avocado-target(*)".to_string(),
         };
 
-        // Resolve package-time-only fields in the avocado.yaml that ships in the
-        // package payload. Today that is just `version`: the in-source program
-        // extensions declare `version: '{{ env.AVOCADO_EXT_VERSION }}'` so the
-        // packaged version tracks Cargo.toml, but that template only resolves
-        // while AVOCADO_EXT_VERSION is set (package time). If it survives into the
-        // published package, a downstream runtime build — which has no such env in
-        // scope — interpolates it to '' and fails semver validation. We bake just
-        // the resolved value (`metadata.version`, already interpolated + validated)
-        // and leave every other template (e.g. `{{ avocado.target }}`,
-        // `{{ env.AVOCADO_DISTRO_RELEASE }}`) for the consumer to resolve at their
-        // build time. Additional required fields can be folded in here later.
-        let version_bake_section = {
-            match fs::read_to_string(ext_config_path) {
-                Ok(text) => {
-                    let baked = crate::utils::config_edit::bake_extension_version(
-                        &text,
-                        &self.extension,
-                        target,
-                        &metadata.version,
-                    )
-                    .with_context(|| {
-                        format!(
-                            "Failed to bake resolved version '{}' into the packaged \
-                                     config for extension '{}'",
-                            metadata.version, self.extension
-                        )
-                    })?;
-                    let b64 = BASE64_STANDARD.encode(baked.as_bytes());
-                    // The resolved version is baked into the base64 payload only;
-                    // it is never interpolated into the shell, so a version string
-                    // carrying pre-release/build metadata can't reach the command line.
-                    format!(
-                        r#"
-# Bake the resolved extension version into the packaged config so the published
-# avocado.yaml carries a concrete semver instead of an env-only template that
-# would interpolate to '' during a downstream runtime build.
-if [ -f "$STAGING_DIR/{basename}" ]; then
-    printf '%s' '{b64}' | base64 -d > "$STAGING_DIR/{basename}"
-    echo "Baked resolved extension version into {basename}"
-fi
-"#,
-                        basename = cfg_basename,
-                        b64 = b64,
-                    )
-                }
-                // Remote/unreadable source (e.g. packaging a fetched remote ext
-                // whose config lives in the container volume): leave the payload
-                // untouched rather than fail the package.
-                Err(_) => String::new(),
-            }
-        };
-
         // Create RPM using rpmbuild in container
         // Package root (/) maps to the extension's src_dir contents
         let rpm_build_script = self.generate_rpm_build_script(
@@ -846,7 +882,7 @@ fi
             &target_provides,
             &container_src_dir,
             &package_files_str,
-            &version_bake_section,
+            version_bake_section,
         );
 
         // Run the RPM build in the container
@@ -1180,7 +1216,9 @@ extensions:
             .resolve_ext_config(&config, &parsed, &location, "qemux86-64")
             .unwrap()
             .expect("extension present in composed config");
-        let meta = cmd.extract_rpm_metadata(&resolved, "qemux86-64").unwrap();
+        let meta = cmd
+            .extract_rpm_metadata(&resolved, "qemux86-64", "avocado.yaml")
+            .unwrap();
 
         assert_eq!(meta.version, "2026.7.1", "per-target version must win");
         assert_eq!(meta.summary, "qemu summary");
@@ -1260,7 +1298,7 @@ extensions:
         );
 
         let metadata = cmd
-            .extract_rpm_metadata(&ext_config, "x86_64-unknown-linux-gnu")
+            .extract_rpm_metadata(&ext_config, "x86_64-unknown-linux-gnu", "avocado.yaml")
             .unwrap();
 
         assert_eq!(metadata.name, "test-extension");
@@ -1327,7 +1365,7 @@ extensions:
         );
 
         let metadata = cmd
-            .extract_rpm_metadata(&ext_config, "aarch64-unknown-linux-gnu")
+            .extract_rpm_metadata(&ext_config, "aarch64-unknown-linux-gnu", "avocado.yaml")
             .unwrap();
 
         assert_eq!(metadata.name, "web-server");
@@ -1356,7 +1394,8 @@ extensions:
 
         let ext_config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
 
-        let result = cmd.extract_rpm_metadata(&ext_config, "x86_64-unknown-linux-gnu");
+        let result =
+            cmd.extract_rpm_metadata(&ext_config, "x86_64-unknown-linux-gnu", "avocado.yaml");
 
         assert!(result.is_err());
         assert!(result
@@ -1395,7 +1434,9 @@ extensions:
         ];
 
         for target in targets {
-            let metadata = cmd.extract_rpm_metadata(&ext_config, target).unwrap();
+            let metadata = cmd
+                .extract_rpm_metadata(&ext_config, target, "avocado.yaml")
+                .unwrap();
             assert_eq!(
                 metadata.arch, "noarch",
                 "Extension should default to noarch for target: {target}"
@@ -1460,7 +1501,8 @@ extensions:
 
         // Pass empty full config since we're not testing compile script extraction
         let empty_full_config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
-        let files = cmd.get_package_files(&ext_config, None, &empty_full_config, "avocado.yaml");
+        let files =
+            cmd.get_package_files(&ext_config, None, &empty_full_config, "avocado.yaml", None);
         assert_eq!(files, vec!["avocado.yaml".to_string()]);
     }
 
@@ -1496,6 +1538,7 @@ extensions:
             Some(&ext_config),
             &empty_full_config,
             "avocado.yaml",
+            None,
         );
         assert_eq!(
             files,
@@ -1545,6 +1588,7 @@ extensions:
             Some(&ext_config),
             &empty_full_config,
             "avocado.yaml",
+            None,
         );
         assert_eq!(
             files,
@@ -1596,6 +1640,7 @@ extensions:
             Some(&ext_config),
             &empty_full_config,
             "avocado.yaml",
+            None,
         );
         assert_eq!(
             files,
@@ -1606,6 +1651,135 @@ extensions:
                 "README.md".to_string(),
             ]
         );
+    }
+
+    /// Helpers for the version-source payload tests below.
+    fn ext_with_version(version: &str) -> serde_yaml::Value {
+        let mut ext = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+        ext.as_mapping_mut().unwrap().insert(
+            serde_yaml::Value::String("version".to_string()),
+            serde_yaml::Value::String(version.to_string()),
+        );
+        ext
+    }
+
+    fn cargo_version_source() -> VersionSource {
+        VersionSource {
+            file: "Cargo.toml".to_string(),
+            key: Some("package.version".to_string()),
+            format: None,
+        }
+    }
+
+    fn package_cmd() -> ExtPackageCommand {
+        ExtPackageCommand::new(
+            "test.yaml".to_string(),
+            "test-ext".to_string(),
+            None,
+            None,
+            false,
+            None,
+            None,
+        )
+    }
+
+    /// The published avocado.yaml keeps the `version: { file, key }` provider
+    /// rather than a baked literal, so the file it names has to ship or the
+    /// package is unresolvable for every consumer.
+    #[test]
+    fn test_get_package_files_default_includes_version_source_file() {
+        let cmd = package_cmd();
+        let ext_config = ext_with_version("1.0.0");
+        let empty_full_config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+
+        let files = cmd.get_package_files(
+            &ext_config,
+            None,
+            &empty_full_config,
+            "avocado.yaml",
+            Some(&cargo_version_source()),
+        );
+
+        assert_eq!(
+            files,
+            vec!["avocado.yaml".to_string(), "Cargo.toml".to_string()]
+        );
+    }
+
+    /// An explicit `package_files` replaces the defaults wholesale, so the
+    /// version file has to be added back on that branch too. Forgetting it
+    /// would only surface when someone consumed the published package.
+    #[test]
+    fn test_get_package_files_explicit_list_includes_version_source_file() {
+        let cmd = package_cmd();
+        let mut ext_config = ext_with_version("1.0.0");
+        ext_config.as_mapping_mut().unwrap().insert(
+            serde_yaml::Value::String("package_files".to_string()),
+            serde_yaml::Value::Sequence(vec![
+                serde_yaml::Value::String("avocado.yaml".to_string()),
+                serde_yaml::Value::String("src".to_string()),
+            ]),
+        );
+        let empty_full_config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+
+        let files = cmd.get_package_files(
+            &ext_config,
+            Some(&ext_config),
+            &empty_full_config,
+            "avocado.yaml",
+            Some(&cargo_version_source()),
+        );
+
+        assert_eq!(
+            files,
+            vec![
+                "avocado.yaml".to_string(),
+                "src".to_string(),
+                "Cargo.toml".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_get_package_files_does_not_duplicate_listed_version_source_file() {
+        let cmd = package_cmd();
+        let mut ext_config = ext_with_version("1.0.0");
+        ext_config.as_mapping_mut().unwrap().insert(
+            serde_yaml::Value::String("package_files".to_string()),
+            serde_yaml::Value::Sequence(vec![
+                serde_yaml::Value::String("avocado.yaml".to_string()),
+                serde_yaml::Value::String("Cargo.toml".to_string()),
+                serde_yaml::Value::String("src".to_string()),
+            ]),
+        );
+        let empty_full_config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+
+        let files = cmd.get_package_files(
+            &ext_config,
+            Some(&ext_config),
+            &empty_full_config,
+            "avocado.yaml",
+            Some(&cargo_version_source()),
+        );
+
+        assert_eq!(
+            files.iter().filter(|f| *f == "Cargo.toml").count(),
+            1,
+            "version source file listed twice: {files:?}"
+        );
+    }
+
+    /// A literal `version:` has no provider, so nothing extra is added.
+    #[test]
+    fn test_get_package_files_without_version_source_is_unchanged() {
+        let cmd = package_cmd();
+        let ext_config = ext_with_version("1.0.0");
+        let empty_full_config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+
+        let files =
+            cmd.get_package_files(&ext_config, None, &empty_full_config, "avocado.yaml", None);
+
+        assert_eq!(files, vec!["avocado.yaml".to_string()]);
     }
 
     #[test]
@@ -1634,7 +1808,8 @@ extensions:
 
         // Pass empty full config since we're not testing compile script extraction
         let empty_full_config = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
-        let files = cmd.get_package_files(&ext_config, None, &empty_full_config, "avocado.yaml");
+        let files =
+            cmd.get_package_files(&ext_config, None, &empty_full_config, "avocado.yaml", None);
         assert_eq!(files, vec!["avocado.yaml".to_string()]);
     }
 
@@ -1703,6 +1878,7 @@ extensions:
             Some(&raw_config),
             &empty_full_config,
             "avocado.yaml",
+            None,
         );
 
         // Should include avocado.yaml and both target-specific overlays

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -8,6 +8,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::utils::container_dev::config::ContainerDevConfig;
+use crate::utils::ext_source_reader::{DirOrigin, ExtSourceReader};
+use crate::utils::ext_version_source::{ExtFileReader, VersionSource};
 use crate::utils::kernel_version::KernelVersionSpec;
 use crate::utils::output::{print_warning, OutputLevel};
 
@@ -416,6 +418,17 @@ impl RuntimeExtDep {
     }
 }
 
+/// What [`Config::merge_installed_remote_extensions`] learned about each remote
+/// extension it merged.
+#[derive(Debug, Default)]
+struct RemoteExtensionMerge {
+    /// Extension name → the config file it was read from.
+    extension_sources: std::collections::HashMap<String, String>,
+    /// Extension name → a reader rooted at its source tree, for reading further
+    /// files out of it (e.g. a `version: { file, key }` provider's target).
+    ext_readers: std::collections::HashMap<String, ExtSourceReader>,
+}
+
 /// A composed configuration that merges the main config with external extension configs.
 ///
 /// This struct provides a unified view where:
@@ -439,6 +452,13 @@ pub struct ComposedConfig {
     /// Extensions from the main config will map to the main config path.
     /// Extensions from remote/external sources will map to their respective config paths.
     pub extension_sources: std::collections::HashMap<String, String>,
+    /// How each extension's `version` was derived, for those that used the
+    /// `version: { file, key }` form.
+    ///
+    /// Resolution overwrites the mapping in `merged_value` with the resolved
+    /// string, so this is the only remaining record that a version came from a
+    /// file. Packaging needs it to guarantee that file ships in the RPM payload.
+    pub ext_version_sources: std::collections::HashMap<String, VersionSource>,
 }
 
 impl ComposedConfig {
@@ -1554,10 +1574,24 @@ impl Config {
         )
         .with_context(|| "Failed to interpolate configuration values")?;
 
-        let base_section = match self.get_nested_section(&parsed, section_path) {
+        let mut base_section = match self.get_nested_section(&parsed, section_path) {
             Some(v) => v.clone(),
             None => return Ok(None),
         };
+
+        // This path re-reads the file directly rather than going through
+        // `load_composed`, so it has to resolve `version: { file, key }` itself.
+        // `ext package` reaches a *local* extension this way — miss it and an
+        // in-source extension packages with an unresolved mapping.
+        if let Some(ext_name) = section_path.strip_prefix("extensions.") {
+            let root = Path::new(config_path).parent().unwrap_or(Path::new("."));
+            let reader = ExtSourceReader::dir(root, DirOrigin::LocalConfig);
+            crate::utils::ext_version_source::resolve_in_ext_value(
+                &mut base_section,
+                ext_name,
+                &reader,
+            )?;
+        }
 
         // Apply target-merge and strip override sub-keys. kernel-merge is a
         // no-op here — get_merged_section runs without a resolved kernel
@@ -1647,11 +1681,23 @@ impl Config {
         // deserializer sees it.
         Self::merge_path_based_image_sections(&mut main_config, path)?;
 
+        // Readers rooted at each extension's source tree, used to resolve a
+        // `version: { file, key }` provider once everything is merged.
+        let mut ext_readers: HashMap<String, ExtSourceReader> = HashMap::new();
+        let main_config_dir = path.parent().unwrap_or(Path::new(".")).to_path_buf();
+
         // Record extensions from the main config
         if let Some(ext_section) = main_config.get("extensions").and_then(|e| e.as_mapping()) {
             for (ext_key, _) in ext_section {
                 if let Some(ext_name) = ext_key.as_str() {
                     extension_sources.insert(ext_name.to_string(), config_path_str.clone());
+                    // An extension defined in place is rooted alongside the
+                    // config that defines it. A remote source overwrites this
+                    // below with a reader for the fetched tree.
+                    ext_readers.insert(
+                        ext_name.to_string(),
+                        ExtSourceReader::dir(main_config_dir.clone(), DirOrigin::LocalConfig),
+                    );
                 }
             }
         }
@@ -1659,9 +1705,9 @@ impl Config {
         // Discover and merge installed remote extension configs
         // Remote extensions are those with a 'source' field that have been fetched
         // to $AVOCADO_PREFIX/includes/<ext_name>/
-        let remote_ext_sources =
-            Self::merge_installed_remote_extensions(&mut main_config, path, target)?;
-        extension_sources.extend(remote_ext_sources);
+        let remote = Self::merge_installed_remote_extensions(&mut main_config, path, target)?;
+        extension_sources.extend(remote.extension_sources);
+        ext_readers.extend(remote.ext_readers);
 
         // Discover all external config references
         let external_refs = Self::discover_external_config_refs(&main_config);
@@ -1712,6 +1758,17 @@ impl Config {
             let resolved_path_str = resolved_path.to_string_lossy().to_string();
             extension_sources.insert(ext_name.clone(), resolved_path_str.clone());
 
+            // An extension pulled in by a legacy `config: <path>` ref is rooted
+            // beside that file, not beside the main config.
+            let external_dir = resolved_path
+                .parent()
+                .unwrap_or(Path::new("."))
+                .to_path_buf();
+            ext_readers.insert(
+                ext_name.clone(),
+                ExtSourceReader::dir(external_dir.clone(), DirOrigin::LocalConfig),
+            );
+
             // Also record any extensions defined within this external config
             if let Some(nested_ext_section) = external_config
                 .get("extensions")
@@ -1721,10 +1778,29 @@ impl Config {
                     if let Some(nested_ext_name) = nested_ext_key.as_str() {
                         extension_sources
                             .insert(nested_ext_name.to_string(), resolved_path_str.clone());
+                        ext_readers.insert(
+                            nested_ext_name.to_string(),
+                            ExtSourceReader::dir(external_dir.clone(), DirOrigin::LocalConfig),
+                        );
                     }
                 }
             }
         }
+
+        // Resolve `version: { file, key }` providers before the final
+        // interpolation pass, so every downstream consumer sees `version` as a
+        // plain string exactly as if it had been written literally.
+        let readers: HashMap<String, Box<dyn ExtFileReader>> = ext_readers
+            .iter()
+            .map(|(name, reader)| {
+                (
+                    name.clone(),
+                    Box::new(reader.clone()) as Box<dyn ExtFileReader>,
+                )
+            })
+            .collect();
+        let ext_version_sources =
+            crate::utils::ext_version_source::resolve_in_config(&mut main_config, &readers)?;
 
         // Apply interpolation to the composed model
         crate::utils::interpolation::interpolate_config(&mut main_config, target, cli_target_board)
@@ -1745,6 +1821,7 @@ impl Config {
             merged_value: main_config,
             config_path: config_path_str,
             extension_sources,
+            ext_version_sources,
         })
     }
 
@@ -1896,13 +1973,17 @@ impl Config {
     /// For each extension with a `source` field that has been installed to
     /// `$AVOCADO_PREFIX/includes/<ext_name>/`, load and merge its avocado.yaml
     ///
-    /// Returns a HashMap mapping extension names to their source config file paths.
+    /// Returns the source config path for each extension, plus the reader that
+    /// found it — the reader is kept so a `version: { file, key }` provider can
+    /// later read the version file out of the very same tree.
     fn merge_installed_remote_extensions(
         main_config: &mut serde_yaml::Value,
         config_path: &Path,
         target: Option<&str>,
-    ) -> Result<std::collections::HashMap<String, String>> {
+    ) -> Result<RemoteExtensionMerge> {
         let mut extension_sources: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        let mut ext_readers: std::collections::HashMap<String, ExtSourceReader> =
             std::collections::HashMap::new();
 
         // Get the src_dir and target to find the extensions directory
@@ -1939,7 +2020,7 @@ impl Config {
             Some(t) => t,
             None => {
                 // No target available - can't locate extensions, skip merging
-                return Ok(extension_sources);
+                return Ok(RemoteExtensionMerge::default());
             }
         };
 
@@ -1949,7 +2030,7 @@ impl Config {
         let remote_extensions = Self::discover_remote_extensions_from_value(main_config)?;
 
         if remote_extensions.is_empty() {
-            return Ok(extension_sources);
+            return Ok(RemoteExtensionMerge::default());
         }
 
         // Get src_dir for loading volume state
@@ -1975,217 +2056,27 @@ impl Config {
             );
         }
 
-        // For each remote extension, try to read its config
+        // For each remote extension, locate its source tree and read its config.
+        // `ExtSourceReader` owns the strategy ladder (host source path, in-container
+        // includes dir, SDK volume, dev fallback); the reader it hands back is kept
+        // so a `version: { file, key }` provider can read the version file out of
+        // that same tree later, by that same route.
         for (ext_name, source) in remote_extensions {
-            // For a `type: path` source, resolve its host dir directly from the
-            // config declaration (relative to src_dir) — the config is the
-            // source of truth, so no separate state file is consulted.
-            let path_source_dir: Option<PathBuf> = match &source {
-                ExtensionSource::Path { path, .. } => {
-                    let p = if Path::new(path).is_absolute() {
-                        PathBuf::from(path)
-                    } else {
-                        src_dir.join(path)
-                    };
-                    Some(p.canonicalize().unwrap_or(p))
-                }
-                _ => None,
+            let Some(discovered) = ExtSourceReader::discover(
+                &ext_name,
+                &source,
+                &src_dir,
+                &resolved_target,
+                volume_state.as_ref(),
+                verbose,
+            ) else {
+                // Not fetched yet (or unreadable). Skip it — the missing
+                // definition surfaces later with a better diagnostic.
+                continue;
             };
-
-            // Try multiple methods to read the extension config:
-            // 0. Path-based extension: read directly from source path (for source: { type: path })
-            // 1. Direct container path (when running inside a container)
-            // 2. Via container command (when running on host)
-            // 3. Local fallback path (for development)
-
-            let ext_content = {
-                // Method 0: path-based extension (source: { type: path }) — read
-                // its config directly from the declared source path on the host.
-                if let Some(ref source_path) = path_source_dir {
-                    let config_path_yaml = source_path.join("avocado.yaml");
-                    let config_path_yml = source_path.join("avocado.yml");
-
-                    if verbose {
-                        eprintln!(
-                            "[DEBUG] Extension '{}' is path-based, checking: {}",
-                            ext_name,
-                            config_path_yaml.display()
-                        );
-                    }
-
-                    if config_path_yaml.exists() {
-                        match fs::read_to_string(&config_path_yaml) {
-                            Ok(content) => {
-                                if verbose {
-                                    eprintln!(
-                                        "[DEBUG]   Read {} bytes from path-based source",
-                                        content.len()
-                                    );
-                                }
-                                content
-                            }
-                            Err(e) => {
-                                if verbose {
-                                    eprintln!("[DEBUG]   Failed to read: {e}");
-                                }
-                                continue;
-                            }
-                        }
-                    } else if config_path_yml.exists() {
-                        match fs::read_to_string(&config_path_yml) {
-                            Ok(content) => {
-                                if verbose {
-                                    eprintln!(
-                                        "[DEBUG]   Read {} bytes from path-based source (.yml)",
-                                        content.len()
-                                    );
-                                }
-                                content
-                            }
-                            Err(e) => {
-                                if verbose {
-                                    eprintln!("[DEBUG]   Failed to read: {e}");
-                                }
-                                continue;
-                            }
-                        }
-                    } else {
-                        if verbose {
-                            eprintln!(
-                                "[DEBUG]   Path-based source path has no avocado.yaml/yml: {}",
-                                source_path.display()
-                            );
-                        }
-                        continue;
-                    }
-                } else {
-                    // package/git — fall through to other methods
-                    "".to_string()
-                }
-            };
-
-            // If we got content from path-based source, skip other methods
-            let ext_content = if !ext_content.is_empty() {
-                ext_content
-            } else {
-                // Method 1: Check if we're inside a container and can read directly
-                // The standard container path is /opt/_avocado/<target>/includes/<ext>/avocado.yaml
-                let container_direct_path =
-                    format!("/opt/_avocado/{resolved_target}/includes/{ext_name}/avocado.yaml");
-                let container_path = Path::new(&container_direct_path);
-
-                if verbose {
-                    eprintln!(
-                        "[DEBUG] Checking for remote extension '{ext_name}' config at: {container_direct_path}"
-                    );
-                    eprintln!("[DEBUG]   Path exists: {}", container_path.exists());
-                }
-
-                if container_path.exists() {
-                    // We're inside a container, read directly
-                    match fs::read_to_string(container_path) {
-                        Ok(content) => {
-                            if verbose {
-                                eprintln!(
-                                    "[DEBUG]   Read {} bytes from container path",
-                                    content.len()
-                                );
-                            }
-                            content
-                        }
-                        Err(e) => {
-                            if verbose {
-                                eprintln!("[DEBUG]   Failed to read: {e}");
-                            }
-                            continue;
-                        }
-                    }
-                } else if let Some(vs) = &volume_state {
-                    // Method 2: Read directly from the Docker volume's host mountpoint.
-                    // This is fast and reliable — no throwaway container needed.
-                    // Falls back to Method 3 if the mountpoint isn't accessible (e.g. permission denied).
-                    let host_content =
-                        Self::get_volume_mountpoint_sync(vs)
-                            .ok()
-                            .and_then(|mountpoint| {
-                                let p = mountpoint
-                                    .join(&resolved_target)
-                                    .join("includes")
-                                    .join(&ext_name)
-                                    .join("avocado.yaml");
-                                if verbose {
-                                    eprintln!("[DEBUG]   Trying host volume path: {}", p.display());
-                                }
-                                fs::read_to_string(&p).ok()
-                            });
-
-                    if let Some(content) = host_content {
-                        if verbose {
-                            eprintln!(
-                                "[DEBUG]   Read {} bytes from host volume mountpoint",
-                                content.len()
-                            );
-                        }
-                        content
-                    } else {
-                        // Method 3: Fall back to spinning up a container to read from the volume.
-                        // Used when the host mountpoint isn't directly accessible.
-                        if verbose {
-                            eprintln!(
-                                "[DEBUG]   Host path not accessible, trying via container command (volume: {})",
-                                vs.volume_name
-                            );
-                        }
-                        match Self::read_extension_config_via_container(
-                            vs,
-                            &resolved_target,
-                            &ext_name,
-                        ) {
-                            Ok(content) => {
-                                if verbose {
-                                    eprintln!(
-                                        "[DEBUG]   Read {} bytes via container",
-                                        content.len()
-                                    );
-                                }
-                                content
-                            }
-                            Err(e) => {
-                                if verbose {
-                                    eprintln!("[DEBUG]   Container read failed: {e}");
-                                }
-                                // Extension not installed yet or config not found, skip
-                                continue;
-                            }
-                        }
-                    }
-                } else {
-                    // Method 3: Fallback to local path (for development)
-                    let fallback_dir = src_dir
-                        .join(".avocado")
-                        .join(&resolved_target)
-                        .join("includes")
-                        .join(&ext_name);
-                    let config_path_local = fallback_dir.join("avocado.yaml");
-                    if verbose {
-                        eprintln!(
-                            "[DEBUG]   Trying fallback path: {}",
-                            config_path_local.display()
-                        );
-                    }
-                    if config_path_local.exists() {
-                        match fs::read_to_string(&config_path_local) {
-                            Ok(content) => content,
-                            Err(_) => continue,
-                        }
-                    } else {
-                        if verbose {
-                            eprintln!("[DEBUG]   No config found for '{ext_name}', skipping");
-                        }
-                        continue;
-                    }
-                }
-            };
+            let config_name = discovered.config_name;
+            let ext_content = discovered.config_content;
+            let reader = discovered.reader;
 
             // Use a .yaml extension so parse_config_value knows to parse as YAML
             let ext_config_path = format!("{ext_name}/avocado.yaml");
@@ -2228,24 +2119,14 @@ impl Config {
                 }
             };
 
-            // Record this extension's source path
-            // For path-based extensions, use the actual host path — recording
-            // the config file that actually exists (avocado.yml is a valid
-            // alternative to avocado.yaml) so downstream relative-path
-            // resolution reads the real file.
-            // For other remote extensions, use the container path.
-            let ext_config_path_str = if let Some(ref source_path) = path_source_dir {
-                let yml = source_path.join("avocado.yml");
-                let config_file = if yml.exists() {
-                    yml
-                } else {
-                    source_path.join("avocado.yaml")
-                };
-                config_file.to_string_lossy().to_string()
-            } else {
-                format!("/opt/_avocado/{resolved_target}/includes/{ext_name}/avocado.yaml")
-            };
+            // Record this extension's source path. The reader reports the real
+            // location of the config it actually read — the host path for a
+            // path-based extension (under its real name, since avocado.yml is a
+            // valid alternative), the container path otherwise — so downstream
+            // relative-path resolution reads the same file we did.
+            let ext_config_path_str = reader.config_path(&config_name);
             extension_sources.insert(ext_name.clone(), ext_config_path_str.clone());
+            ext_readers.insert(ext_name.clone(), reader.clone());
 
             // Also record any extensions defined within this remote extension's config
             if let Some(nested_ext_section) =
@@ -2255,6 +2136,9 @@ impl Config {
                     if let Some(nested_ext_name) = nested_ext_key.as_str() {
                         extension_sources
                             .insert(nested_ext_name.to_string(), ext_config_path_str.clone());
+                        // A nested extension ships inside the same tree, so it
+                        // resolves its version file through the same reader.
+                        ext_readers.insert(nested_ext_name.to_string(), reader.clone());
                     }
                 }
             }
@@ -2307,66 +2191,10 @@ impl Config {
             }
         }
 
-        Ok(extension_sources)
-    }
-
-    /// Read a remote extension's config file by running a container command.
-    ///
-    /// This runs a lightweight container to cat the extension's avocado.yaml from
-    /// the Docker volume, avoiding permission issues with direct host access.
-    fn read_extension_config_via_container(
-        volume_state: &crate::utils::volume::VolumeState,
-        target: &str,
-        ext_name: &str,
-    ) -> Result<String> {
-        // The extension config path inside the container
-        let container_config_path =
-            format!("/opt/_avocado/{target}/includes/{ext_name}/avocado.yaml");
-
-        // Run a minimal container to cat the config file
-        // We use busybox as a lightweight image, but fall back to alpine if needed
-        let images_to_try = [
-            "busybox:latest",
-            "alpine:latest",
-            "docker.io/library/busybox:latest",
-        ];
-
-        for image in &images_to_try {
-            let output = std::process::Command::new(&volume_state.container_tool)
-                .args([
-                    "run",
-                    "--rm",
-                    "-v",
-                    &format!("{}:/opt/_avocado:ro", volume_state.volume_name),
-                    image,
-                    "cat",
-                    &container_config_path,
-                ])
-                .output();
-
-            match output {
-                Ok(out) if out.status.success() => {
-                    let content = String::from_utf8_lossy(&out.stdout).to_string();
-                    if content.is_empty() {
-                        anyhow::bail!("Extension config file is empty");
-                    }
-                    return Ok(content);
-                }
-                Ok(out) => {
-                    let stderr = String::from_utf8_lossy(&out.stderr);
-                    // If file not found, bail immediately (no point trying other images)
-                    if stderr.contains("No such file") || stderr.contains("not found") {
-                        anyhow::bail!("Extension config not found: {container_config_path}");
-                    }
-                    // Otherwise, continue to try next image
-                }
-                Err(_) => {
-                    // Continue to try next image
-                }
-            }
-        }
-
-        anyhow::bail!("Failed to read extension config via container for '{ext_name}'")
+        Ok(RemoteExtensionMerge {
+            extension_sources,
+            ext_readers,
+        })
     }
 
     /// Discover all external config references in runtime and ext dependencies.
@@ -4572,7 +4400,9 @@ impl Config {
         // Try to load volume state and get the mountpoint
         if let Ok(Some(volume_state)) = crate::utils::volume::VolumeState::load_from_dir(&src_dir) {
             // Use synchronous Docker inspect to get the mountpoint
-            if let Ok(mountpoint) = Self::get_volume_mountpoint_sync(&volume_state) {
+            if let Ok(mountpoint) =
+                crate::utils::ext_source_reader::volume_mountpoint(&volume_state)
+            {
                 return mountpoint.join(target).join("includes");
             }
         }
@@ -4599,46 +4429,6 @@ impl Config {
     #[allow(dead_code)]
     pub fn get_extensions_container_path() -> &'static str {
         "$AVOCADO_PREFIX/includes"
-    }
-
-    /// Get the volume mountpoint synchronously (for use in non-async contexts)
-    fn get_volume_mountpoint_sync(
-        volume_state: &crate::utils::volume::VolumeState,
-    ) -> Result<PathBuf> {
-        let output = std::process::Command::new(&volume_state.container_tool)
-            .args([
-                "volume",
-                "inspect",
-                &volume_state.volume_name,
-                "--format",
-                "{{.Mountpoint}}",
-            ])
-            .output()
-            .with_context(|| {
-                format!(
-                    "Failed to inspect Docker volume '{}'",
-                    volume_state.volume_name
-                )
-            })?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!(
-                "Failed to get mountpoint for volume '{}': {}",
-                volume_state.volume_name,
-                stderr
-            );
-        }
-
-        let mountpoint = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if mountpoint.is_empty() {
-            anyhow::bail!(
-                "Docker volume '{}' has no mountpoint",
-                volume_state.volume_name
-            );
-        }
-
-        Ok(PathBuf::from(mountpoint))
     }
 
     /// Check if a remote extension is already installed

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -1583,7 +1583,12 @@ impl Config {
         // `load_composed`, so it has to resolve `version: { file, key }` itself.
         // `ext package` reaches a *local* extension this way — miss it and an
         // in-source extension packages with an unresolved mapping.
-        if let Some(ext_name) = section_path.strip_prefix("extensions.") {
+        // Only a direct `extensions.<name>` block is an extension; a deeper path
+        // would otherwise be read as an extension named `<name>.<sub>`.
+        if let Some(ext_name) = section_path
+            .strip_prefix("extensions.")
+            .filter(|name| !name.contains('.'))
+        {
             let root = Path::new(config_path).parent().unwrap_or(Path::new("."));
             let reader = ExtSourceReader::dir(root, DirOrigin::LocalConfig);
             crate::utils::ext_version_source::resolve_in_ext_value(

--- a/src/utils/config_edit.rs
+++ b/src/utils/config_edit.rs
@@ -1342,6 +1342,28 @@ pub fn bake_extension_version(
 mod tests {
     use super::*;
 
+    /// The provider form and the bake are mutually exclusive by design, but if
+    /// they ever did meet, the line-scoped rewriter would replace the `version:`
+    /// line and strand its `file:`/`key:` children as orphaned mapping entries.
+    /// `ext package` guards against this by skipping the bake entirely when the
+    /// extension resolved through a provider; this test documents why.
+    #[test]
+    fn test_bake_extension_version_would_corrupt_a_provider_block() {
+        let src = "extensions:\n  \
+  my-ext:\n    \
+    version:\n      \
+      file: Cargo.toml\n      \
+      key: package.version\n    \
+    release: r0\n";
+        let out = bake_extension_version(src, "my-ext", "qemux86-64", "1.2.3").unwrap();
+        // The scalar lands, but `file:`/`key:` are left behind — hence the guard.
+        assert!(out.contains("version: '1.2.3'"));
+        assert!(
+            out.contains("file: Cargo.toml"),
+            "expected the orphaned provider keys this guard exists to avoid:\n{out}"
+        );
+    }
+
     #[test]
     fn test_bake_extension_version_replaces_only_version_keeps_other_templates() {
         let src = "supported_targets: '*'\n\

--- a/src/utils/ext_source_reader.rs
+++ b/src/utils/ext_source_reader.rs
@@ -202,7 +202,24 @@ impl ExtSourceReader {
         match self {
             Self::Dir { root, .. } => {
                 let path = root.join(rel);
-                std::fs::read_to_string(&path)
+
+                // `version.file` already rejects absolute paths and `..`, but a
+                // symlink *inside* the tree can still point out of it, and for a
+                // `type: git` extension the tree is third-party content. Resolve
+                // before reading and require the result to stay under the root.
+                let real = path
+                    .canonicalize()
+                    .with_context(|| format!("Failed to read {}", path.display()))?;
+                let real_root = root.canonicalize().unwrap_or_else(|_| root.clone());
+                if !real.starts_with(&real_root) {
+                    anyhow::bail!(
+                        "'{rel}' resolves to {}, outside the extension root {}",
+                        real.display(),
+                        real_root.display()
+                    );
+                }
+
+                std::fs::read_to_string(&real)
                     .with_context(|| format!("Failed to read {}", path.display()))
             }
             Self::Volume {
@@ -360,6 +377,26 @@ mod tests {
         let reader = ExtSourceReader::dir(&dir, DirOrigin::SourcePath);
         assert_eq!(reader.read("VERSION").unwrap(), "1.2.3\n");
         assert!(reader.read("nope").is_err());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn dir_reader_rejects_symlink_out_of_the_root() {
+        let dir = tmpdir("escape");
+        let outside = dir.join("outside");
+        let root = dir.join("ext");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(&outside, "sekrit\n").unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("VERSION")).unwrap();
+
+        let reader = ExtSourceReader::dir(&root, DirOrigin::SourcePath);
+        let err = reader.read("VERSION").unwrap_err();
+        assert!(
+            err.to_string().contains("outside the extension root"),
+            "{err:#}"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src/utils/ext_source_reader.rs
+++ b/src/utils/ext_source_reader.rs
@@ -1,0 +1,516 @@
+//! Reading files out of an extension's source tree.
+//!
+//! An extension's tree is reachable four different ways depending on how it was
+//! sourced and where the CLI is running:
+//!
+//! 0. `source: { type: path }` — the user's working copy, on the host.
+//! 1. Running *inside* the SDK container — `/opt/_avocado/<target>/includes/<ext>`.
+//! 2. On the host with a Docker volume — the volume's mountpoint, when readable.
+//! 3. Same volume, but via a throwaway container `cat` when the mountpoint isn't
+//!    directly accessible (permissions), or a `.avocado/` dev-fallback directory.
+//!
+//! This used to be open-coded in [`crate::utils::config`] purely to fetch
+//! `avocado.yaml`. It is factored out here because version resolution
+//! (`extensions.<n>.version: { file, key }`) has to read a *second* file — the
+//! one holding the version — out of the very same tree, by the very same route.
+//! Anything that reads from an extension's tree should go through here.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+use crate::utils::config::ExtensionSource;
+use crate::utils::ext_version_source::ExtFileReader;
+use crate::utils::volume::VolumeState;
+
+/// Config file names an extension may use, in preference order.
+pub const EXT_CONFIG_NAMES: [&str; 2] = ["avocado.yaml", "avocado.yml"];
+
+/// Where a directory-backed reader's root came from. Only used to make error
+/// messages say something more useful than a bare path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirOrigin {
+    /// The main config's own directory (an extension defined in-place).
+    LocalConfig,
+    /// A `source: { type: path }` working copy.
+    SourcePath,
+    /// The includes dir, visible because we're running inside the container.
+    Container,
+    /// The `<src_dir>/.avocado/<target>/includes/<ext>` development fallback.
+    DevFallback,
+}
+
+impl DirOrigin {
+    fn label(self) -> &'static str {
+        match self {
+            Self::LocalConfig => "config directory",
+            Self::SourcePath => "extension source path",
+            Self::Container => "container includes directory",
+            Self::DevFallback => "local includes directory",
+        }
+    }
+}
+
+/// A handle for reading files from one extension's source root.
+#[derive(Debug, Clone)]
+pub enum ExtSourceReader {
+    /// A directory this process can read directly.
+    Dir { root: PathBuf, origin: DirOrigin },
+    /// A Docker volume. Prefers the host mountpoint and falls back to a
+    /// throwaway container, because the mountpoint is often root-owned.
+    Volume {
+        state: VolumeState,
+        target: String,
+        ext_name: String,
+    },
+}
+
+/// An extension's config, plus the reader that found it.
+pub struct DiscoveredExt {
+    pub reader: ExtSourceReader,
+    /// The config file's real basename — `avocado.yaml` or `avocado.yml`.
+    pub config_name: String,
+    pub config_content: String,
+}
+
+impl ExtSourceReader {
+    /// A reader rooted at a plain directory.
+    pub fn dir(root: impl Into<PathBuf>, origin: DirOrigin) -> Self {
+        Self::Dir {
+            root: root.into(),
+            origin,
+        }
+    }
+
+    /// Locate a remote extension's tree and read its config in one pass.
+    ///
+    /// Returns `None` when no route to the extension can be found — typically
+    /// because it hasn't been fetched yet. Callers skip such extensions rather
+    /// than failing; the missing definition surfaces later with a better
+    /// diagnostic than anything available here.
+    pub fn discover(
+        ext_name: &str,
+        source: &ExtensionSource,
+        src_dir: &Path,
+        target: &str,
+        volume_state: Option<&VolumeState>,
+        verbose: bool,
+    ) -> Option<DiscoveredExt> {
+        for candidate in Self::candidates(ext_name, source, src_dir, target, volume_state) {
+            if verbose {
+                eprintln!(
+                    "[DEBUG] Extension '{ext_name}': trying {}",
+                    candidate.describe()
+                );
+            }
+            match candidate.read_ext_config() {
+                Ok((config_name, config_content)) => {
+                    if verbose {
+                        eprintln!(
+                            "[DEBUG]   Read {} bytes of {config_name} from {}",
+                            config_content.len(),
+                            candidate.describe()
+                        );
+                    }
+                    return Some(DiscoveredExt {
+                        reader: candidate,
+                        config_name,
+                        config_content,
+                    });
+                }
+                Err(e) => {
+                    if verbose {
+                        eprintln!("[DEBUG]   {e:#}");
+                    }
+                }
+            }
+        }
+
+        if verbose {
+            eprintln!("[DEBUG] No config found for '{ext_name}', skipping");
+        }
+        None
+    }
+
+    /// Candidate roots, most authoritative first.
+    ///
+    /// A `type: path` extension is pinned to its declared directory — it never
+    /// falls back to the container, because a stale copy in the volume would
+    /// silently shadow the working copy the user is trying to test.
+    fn candidates(
+        ext_name: &str,
+        source: &ExtensionSource,
+        src_dir: &Path,
+        target: &str,
+        volume_state: Option<&VolumeState>,
+    ) -> Vec<Self> {
+        if let ExtensionSource::Path { path, .. } = source {
+            let resolved = if Path::new(path).is_absolute() {
+                PathBuf::from(path)
+            } else {
+                src_dir.join(path)
+            };
+            let resolved = resolved.canonicalize().unwrap_or(resolved);
+            return vec![Self::dir(resolved, DirOrigin::SourcePath)];
+        }
+
+        let mut candidates = vec![Self::dir(
+            format!("/opt/_avocado/{target}/includes/{ext_name}"),
+            DirOrigin::Container,
+        )];
+
+        match volume_state {
+            Some(state) => candidates.push(Self::Volume {
+                state: state.clone(),
+                target: target.to_string(),
+                ext_name: ext_name.to_string(),
+            }),
+            None => candidates.push(Self::dir(
+                src_dir
+                    .join(".avocado")
+                    .join(target)
+                    .join("includes")
+                    .join(ext_name),
+                DirOrigin::DevFallback,
+            )),
+        }
+
+        candidates
+    }
+
+    /// Read the extension's `avocado.yaml` (or `avocado.yml`).
+    ///
+    /// Both names are accepted from every source kind. Packaging stages the
+    /// config under its real on-disk name, so a `.yml` extension shipped in an
+    /// RPM would otherwise be invisible once installed.
+    pub fn read_ext_config(&self) -> Result<(String, String)> {
+        let mut last_err = None;
+        for name in EXT_CONFIG_NAMES {
+            match self.read(name) {
+                Ok(content) if !content.trim().is_empty() => {
+                    return Ok((name.to_string(), content))
+                }
+                Ok(_) => last_err = Some(anyhow::anyhow!("{name} is empty")),
+                Err(e) => last_err = Some(e),
+            }
+        }
+        Err(last_err.unwrap_or_else(|| anyhow::anyhow!("no extension config found")))
+            .with_context(|| format!("no readable avocado.yaml in {}", self.describe()))
+    }
+
+    /// Read a file relative to the extension root.
+    pub fn read(&self, rel: &str) -> Result<String> {
+        match self {
+            Self::Dir { root, .. } => {
+                let path = root.join(rel);
+                std::fs::read_to_string(&path)
+                    .with_context(|| format!("Failed to read {}", path.display()))
+            }
+            Self::Volume {
+                state,
+                target,
+                ext_name,
+            } => {
+                let in_volume = format!("{target}/includes/{ext_name}/{rel}");
+
+                // The mountpoint is fast and needs no container, but it is
+                // frequently root-owned, so a failure here is expected rather
+                // than exceptional — fall through quietly.
+                if let Ok(mountpoint) = volume_mountpoint(state) {
+                    if let Ok(content) = std::fs::read_to_string(mountpoint.join(&in_volume)) {
+                        return Ok(content);
+                    }
+                }
+
+                read_via_container(state, &format!("/opt/_avocado/{in_volume}"))
+            }
+        }
+    }
+
+    /// Human-readable description of the root, for error messages.
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Dir { root, origin } => format!("{} {}", origin.label(), root.display()),
+            Self::Volume {
+                state,
+                target,
+                ext_name,
+            } => format!(
+                "SDK volume '{}' at /opt/_avocado/{target}/includes/{ext_name}",
+                state.volume_name
+            ),
+        }
+    }
+
+    /// The host path of the extension's config file, when one exists.
+    ///
+    /// Only directory-backed readers have a meaningful host path; a volume
+    /// reader reports the in-container path so messages still point somewhere.
+    pub fn config_path(&self, config_name: &str) -> String {
+        match self {
+            Self::Dir { root, .. } => root.join(config_name).to_string_lossy().to_string(),
+            Self::Volume {
+                target, ext_name, ..
+            } => format!("/opt/_avocado/{target}/includes/{ext_name}/{config_name}"),
+        }
+    }
+}
+
+impl ExtFileReader for ExtSourceReader {
+    fn read_file(&self, rel: &str) -> Result<String> {
+        self.read(rel)
+    }
+
+    fn describe(&self) -> String {
+        ExtSourceReader::describe(self)
+    }
+}
+
+/// Resolve a Docker volume's host mountpoint.
+pub fn volume_mountpoint(state: &VolumeState) -> Result<PathBuf> {
+    let output = std::process::Command::new(&state.container_tool)
+        .args([
+            "volume",
+            "inspect",
+            &state.volume_name,
+            "--format",
+            "{{.Mountpoint}}",
+        ])
+        .output()
+        .with_context(|| format!("Failed to inspect volume '{}'", state.volume_name))?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "Failed to get mountpoint for volume '{}': {}",
+            state.volume_name,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let mountpoint = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if mountpoint.is_empty() {
+        anyhow::bail!("Volume '{}' has no mountpoint", state.volume_name);
+    }
+
+    Ok(PathBuf::from(mountpoint))
+}
+
+/// `cat` a path out of the SDK volume using a minimal throwaway container.
+///
+/// Used when the volume's host mountpoint isn't directly readable.
+fn read_via_container(state: &VolumeState, container_path: &str) -> Result<String> {
+    let images_to_try = [
+        "busybox:latest",
+        "alpine:latest",
+        "docker.io/library/busybox:latest",
+    ];
+
+    for image in &images_to_try {
+        let output = std::process::Command::new(&state.container_tool)
+            .args([
+                "run",
+                "--rm",
+                "-v",
+                &format!("{}:/opt/_avocado:ro", state.volume_name),
+                image,
+                "cat",
+                container_path,
+            ])
+            .output();
+
+        match output {
+            Ok(out) if out.status.success() => {
+                let content = String::from_utf8_lossy(&out.stdout).to_string();
+                if content.is_empty() {
+                    anyhow::bail!("{container_path} is empty");
+                }
+                return Ok(content);
+            }
+            Ok(out) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                // A missing file is conclusive — trying another image won't help.
+                if stderr.contains("No such file") || stderr.contains("not found") {
+                    anyhow::bail!("{container_path} not found in volume");
+                }
+            }
+            // Image unavailable or the tool failed; try the next image.
+            Err(_) => {}
+        }
+    }
+
+    anyhow::bail!("Failed to read {container_path} via container")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn tmpdir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("avocado_ext_reader_{name}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn dir_reader_reads_relative_files() {
+        let dir = tmpdir("read");
+        fs::write(dir.join("VERSION"), "1.2.3\n").unwrap();
+
+        let reader = ExtSourceReader::dir(&dir, DirOrigin::SourcePath);
+        assert_eq!(reader.read("VERSION").unwrap(), "1.2.3\n");
+        assert!(reader.read("nope").is_err());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dir_reader_reads_nested_paths() {
+        let dir = tmpdir("nested");
+        fs::create_dir_all(dir.join("crates/app")).unwrap();
+        fs::write(dir.join("crates/app/Cargo.toml"), "[package]\n").unwrap();
+
+        let reader = ExtSourceReader::dir(&dir, DirOrigin::SourcePath);
+        assert_eq!(reader.read("crates/app/Cargo.toml").unwrap(), "[package]\n");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_ext_config_prefers_yaml() {
+        let dir = tmpdir("prefers_yaml");
+        fs::write(dir.join("avocado.yaml"), "version: '1.0.0'\n").unwrap();
+        fs::write(dir.join("avocado.yml"), "version: '2.0.0'\n").unwrap();
+
+        let reader = ExtSourceReader::dir(&dir, DirOrigin::SourcePath);
+        let (name, content) = reader.read_ext_config().unwrap();
+        assert_eq!(name, "avocado.yaml");
+        assert!(content.contains("1.0.0"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_ext_config_falls_back_to_yml() {
+        let dir = tmpdir("yml");
+        fs::write(dir.join("avocado.yml"), "version: '2.0.0'\n").unwrap();
+
+        let reader = ExtSourceReader::dir(&dir, DirOrigin::SourcePath);
+        let (name, content) = reader.read_ext_config().unwrap();
+        assert_eq!(name, "avocado.yml");
+        assert!(content.contains("2.0.0"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_ext_config_error_names_the_root() {
+        let dir = tmpdir("empty");
+        let reader = ExtSourceReader::dir(&dir, DirOrigin::SourcePath);
+        let err = reader.read_ext_config().unwrap_err();
+        assert!(
+            format!("{err:#}").contains("extension source path"),
+            "{err:#}"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// A `type: path` extension must never fall back to a container copy — a
+    /// stale fetch would shadow the working copy under test.
+    #[test]
+    fn path_source_has_exactly_one_candidate() {
+        let source = ExtensionSource::Path {
+            path: "../my-ext".to_string(),
+            include: None,
+        };
+        let candidates = ExtSourceReader::candidates(
+            "my-ext",
+            &source,
+            Path::new("/projects/app"),
+            "qemux86-64",
+            None,
+        );
+        assert_eq!(candidates.len(), 1);
+        match &candidates[0] {
+            ExtSourceReader::Dir { root, origin } => {
+                assert_eq!(*origin, DirOrigin::SourcePath);
+                assert!(root.ends_with("my-ext"), "{}", root.display());
+            }
+            other => panic!("expected a Dir candidate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn package_source_tries_container_then_dev_fallback() {
+        let source = ExtensionSource::Package {
+            version: "*".to_string(),
+            package: None,
+            repo_name: None,
+            include: None,
+        };
+        let candidates = ExtSourceReader::candidates(
+            "my-ext",
+            &source,
+            Path::new("/projects/app"),
+            "qemux86-64",
+            None,
+        );
+        assert_eq!(candidates.len(), 2);
+        assert!(candidates[0]
+            .describe()
+            .contains("/opt/_avocado/qemux86-64/includes/my-ext"));
+        assert!(candidates[1]
+            .describe()
+            .contains("/projects/app/.avocado/qemux86-64/includes/my-ext"));
+    }
+
+    #[test]
+    fn git_source_with_a_volume_tries_container_then_volume() {
+        let source = ExtensionSource::Git {
+            url: "https://example.invalid/x".to_string(),
+            git_ref: None,
+            sparse_checkout: None,
+            include: None,
+        };
+        let state = VolumeState {
+            volume_name: "avo-test".to_string(),
+            source_path: "/projects/app".to_string(),
+            container_tool: "docker".to_string(),
+        };
+        let candidates = ExtSourceReader::candidates(
+            "my-ext",
+            &source,
+            Path::new("/projects/app"),
+            "qemux86-64",
+            Some(&state),
+        );
+        assert_eq!(candidates.len(), 2);
+        assert!(matches!(candidates[0], ExtSourceReader::Dir { .. }));
+        assert!(matches!(candidates[1], ExtSourceReader::Volume { .. }));
+        assert!(candidates[1].describe().contains("avo-test"));
+    }
+
+    #[test]
+    fn config_path_reports_a_usable_location() {
+        let reader = ExtSourceReader::dir("/projects/my-ext", DirOrigin::SourcePath);
+        assert_eq!(
+            reader.config_path("avocado.yml"),
+            "/projects/my-ext/avocado.yml"
+        );
+
+        let volume = ExtSourceReader::Volume {
+            state: VolumeState {
+                volume_name: "avo-test".to_string(),
+                source_path: "/projects/app".to_string(),
+                container_tool: "docker".to_string(),
+            },
+            target: "qemux86-64".to_string(),
+            ext_name: "my-ext".to_string(),
+        };
+        assert_eq!(
+            volume.config_path("avocado.yaml"),
+            "/opt/_avocado/qemux86-64/includes/my-ext/avocado.yaml"
+        );
+    }
+}

--- a/src/utils/ext_version_source.rs
+++ b/src/utils/ext_version_source.rs
@@ -1,0 +1,714 @@
+//! Source-tree version providers for `extensions.<name>.version`.
+//!
+//! An extension's `version` is an *identity* field: it must resolve to the same
+//! string no matter who is reading the config. `{{ env.VAR }}` cannot satisfy
+//! that — it binds the value to the caller's environment, so a version declared
+//! that way resolves at package time and evaporates (to `""`, with a warning)
+//! for anyone consuming the same extension via `source: { type: git | path }`.
+//!
+//! The mapping form declared here reads the version out of a file **inside the
+//! extension's own source tree**, which is present in every consumption mode —
+//! the working copy for `path`, the clone for `git`, and the RPM payload for
+//! `package`. That makes the version a pure function of the extension.
+//!
+//! ```yaml
+//! # Whole file, trimmed — a plain VERSION file.
+//! version:
+//!   file: VERSION
+//!
+//! # One key out of a structured file.
+//! version:
+//!   file: Cargo.toml
+//!   key: package.version
+//! ```
+//!
+//! `key` is the discriminator: absent means "read the file and trim it", with
+//! no parsing and no format guessing. Present means parse `file` (format
+//! inferred from its extension, or set explicitly) and navigate a dot path.
+
+use anyhow::{bail, Context, Result};
+use serde_yaml::Value;
+use std::collections::HashMap;
+use std::path::{Component, Path};
+
+/// Reads files relative to one extension's source root.
+///
+/// Exists so version resolution doesn't have to know *how* an extension's tree
+/// is reachable — host directory, container path, Docker volume mountpoint, or
+/// a throwaway container. [`crate::utils::ext_source_reader::ExtSourceReader`]
+/// is the real implementation; tests use an in-memory fake.
+pub trait ExtFileReader {
+    /// Read a file at `rel` (relative to the extension root).
+    fn read_file(&self, rel: &str) -> Result<String>;
+
+    /// Human-readable description of the root, for error messages.
+    fn describe(&self) -> String;
+}
+
+/// Structured format used to navigate `key` inside `file`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VersionFileFormat {
+    Toml,
+    Json,
+    Yaml,
+}
+
+impl VersionFileFormat {
+    fn parse_name(name: &str) -> Option<Self> {
+        match name {
+            "toml" => Some(Self::Toml),
+            "json" => Some(Self::Json),
+            "yaml" | "yml" => Some(Self::Yaml),
+            _ => None,
+        }
+    }
+
+    /// Infer from a file extension. Deliberately conservative: an unrecognized
+    /// extension yields `None` so the caller can demand an explicit `format:`
+    /// rather than guessing at the parse.
+    fn infer(file: &str) -> Option<Self> {
+        let ext = Path::new(file).extension()?.to_str()?.to_ascii_lowercase();
+        Self::parse_name(&ext)
+    }
+}
+
+/// A declarative `version:` provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionSource {
+    /// Path to read, relative to the extension's own root.
+    pub file: String,
+    /// Dot path into the parsed document. `None` reads the whole file.
+    pub key: Option<String>,
+    /// Explicit parse format; only meaningful alongside `key`.
+    pub format: Option<VersionFileFormat>,
+}
+
+impl VersionSource {
+    /// Recognize the mapping form of a `version:` value.
+    ///
+    /// Returns `Ok(None)` when `value` is not a mapping (i.e. the ordinary
+    /// string form), so callers can treat this as a probe.
+    pub fn from_value(value: &Value) -> Result<Option<Self>> {
+        let Some(map) = value.as_mapping() else {
+            return Ok(None);
+        };
+
+        for key in map.keys() {
+            match key.as_str() {
+                Some("file") | Some("key") | Some("format") => {}
+                Some(other) => bail!(
+                    "unknown field '{other}' in a `version:` block \
+                     (expected 'file', 'key', or 'format')"
+                ),
+                None => bail!("non-string field in a `version:` block"),
+            }
+        }
+
+        let file = match map.get(Value::String("file".into())) {
+            Some(Value::String(s)) if !s.trim().is_empty() => s.trim().to_string(),
+            Some(_) => bail!("`version.file` must be a non-empty string"),
+            None => bail!("a `version:` block requires a `file` field"),
+        };
+        validate_relative_path(&file)?;
+
+        let key = match map.get(Value::String("key".into())) {
+            Some(Value::String(s)) if !s.trim().is_empty() => Some(s.trim().to_string()),
+            Some(_) => bail!("`version.key` must be a non-empty string"),
+            None => None,
+        };
+
+        let format = match map.get(Value::String("format".into())) {
+            Some(Value::String(s)) => {
+                Some(VersionFileFormat::parse_name(s.trim()).with_context(|| {
+                    format!("unknown `version.format` '{s}' (expected 'toml', 'json', or 'yaml')")
+                })?)
+            }
+            Some(_) => bail!("`version.format` must be a string"),
+            None => None,
+        };
+
+        // Without a `key` the file is never parsed, so a `format` would silently
+        // do nothing. Reject it rather than let someone believe it took effect.
+        if key.is_none() && format.is_some() {
+            bail!("`version.format` has no effect without `version.key`; remove it, or add a `key` to parse the file");
+        }
+
+        Ok(Some(Self { file, key, format }))
+    }
+
+    /// Read and resolve this provider into a semver string.
+    pub fn resolve(&self, reader: &dyn ExtFileReader) -> Result<String> {
+        let content = reader.read_file(&self.file).with_context(|| {
+            format!(
+                "could not read `version.file` '{}' under {}",
+                self.file,
+                reader.describe()
+            )
+        })?;
+
+        let raw = match &self.key {
+            None => content.trim().to_string(),
+            Some(key) => self.extract_key(&content, key)?,
+        };
+
+        if raw.is_empty() {
+            bail!("`version.file` '{}' resolved to an empty string", self.file);
+        }
+
+        crate::utils::version::validate_semver(&raw).with_context(|| match &self.key {
+            Some(key) => format!(
+                "'{}' at key '{key}' in '{}' is not a valid version",
+                raw, self.file
+            ),
+            None => format!("'{}' in '{}' is not a valid version", raw, self.file),
+        })?;
+
+        Ok(raw)
+    }
+
+    fn extract_key(&self, content: &str, key: &str) -> Result<String> {
+        let format = match self.format {
+            Some(f) => f,
+            None => VersionFileFormat::infer(&self.file).with_context(|| {
+                format!(
+                    "cannot infer a parse format from `version.file` '{}'; \
+                     set `version.format` to 'toml', 'json', or 'yaml'",
+                    self.file
+                )
+            })?,
+        };
+
+        let path: Vec<&str> = key.split('.').collect();
+        let found = match format {
+            VersionFileFormat::Toml => {
+                // `toml::from_str`, not `str::parse` — in toml 1.x the latter
+                // parses a bare value expression rather than a document.
+                let doc: toml::Value = toml::from_str(content)
+                    .with_context(|| format!("failed to parse '{}' as TOML", self.file))?;
+                nav(&doc, &path, |v, seg| v.get(seg), |v| v.as_str())
+            }
+            VersionFileFormat::Json => {
+                let doc: serde_json::Value = serde_json::from_str(content)
+                    .with_context(|| format!("failed to parse '{}' as JSON", self.file))?;
+                nav(&doc, &path, |v, seg| v.get(seg), |v| v.as_str())
+            }
+            VersionFileFormat::Yaml => {
+                let doc: Value = serde_yaml::from_str(content)
+                    .with_context(|| format!("failed to parse '{}' as YAML", self.file))?;
+                nav(&doc, &path, |v, seg| v.get(seg), |v| v.as_str())
+            }
+        };
+
+        match found {
+            KeyLookup::Missing => bail!("'{}' has no key '{key}'", self.file),
+            KeyLookup::NotAString => bail!(
+                "key '{key}' in '{}' is not a string; a version must be a scalar string",
+                self.file
+            ),
+            KeyLookup::Found(s) => Ok(s.trim().to_string()),
+        }
+    }
+}
+
+enum KeyLookup {
+    Found(String),
+    Missing,
+    NotAString,
+}
+
+/// Walk `path` through `doc` using the supplied accessors.
+///
+/// Generic over the three document types so TOML/JSON/YAML share one traversal
+/// instead of three near-identical loops.
+fn nav<'a, T, G, S>(doc: &'a T, path: &[&str], get: G, as_str: S) -> KeyLookup
+where
+    G: Fn(&'a T, &str) -> Option<&'a T>,
+    S: Fn(&'a T) -> Option<&'a str>,
+{
+    let mut current = doc;
+    for segment in path {
+        match get(current, segment) {
+            Some(next) => current = next,
+            None => return KeyLookup::Missing,
+        }
+    }
+    match as_str(current) {
+        Some(s) => KeyLookup::Found(s.to_string()),
+        None => KeyLookup::NotAString,
+    }
+}
+
+/// An extension may only read inside its own tree. Reject absolute paths and
+/// any `..` traversal — for a `git`-sourced extension this is reading out of a
+/// shared SDK volume, and for `path` it is reading the user's working copy.
+fn validate_relative_path(file: &str) -> Result<()> {
+    let path = Path::new(file);
+    if path.is_absolute() {
+        bail!("`version.file` '{file}' must be relative to the extension root, not absolute");
+    }
+    for component in path.components() {
+        match component {
+            Component::ParentDir => bail!(
+                "`version.file` '{file}' must stay inside the extension root ('..' is not allowed)"
+            ),
+            Component::RootDir | Component::Prefix(_) => {
+                bail!("`version.file` '{file}' must be relative to the extension root")
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Resolve a mapping-form `version:` on a single extension block, replacing it
+/// in place with the resolved string.
+///
+/// Returns the provider that was used, or `None` when `version` is absent or
+/// already a plain string. Callers keep the returned provider so packaging can
+/// guarantee the referenced file ships in the RPM payload — once the mapping is
+/// replaced, the tree no longer records how the version was derived.
+pub fn resolve_in_ext_value(
+    ext: &mut Value,
+    ext_name: &str,
+    reader: &dyn ExtFileReader,
+) -> Result<Option<VersionSource>> {
+    reject_override_blocks(ext, ext_name)?;
+
+    let Some(version) = ext.get("version") else {
+        return Ok(None);
+    };
+    let Some(source) = VersionSource::from_value(version)
+        .with_context(|| format!("extension '{ext_name}': invalid `version:` block"))?
+    else {
+        return Ok(None);
+    };
+
+    let resolved = source
+        .resolve(reader)
+        .with_context(|| format!("extension '{ext_name}': could not resolve `version`"))?;
+
+    if let Some(map) = ext.as_mapping_mut() {
+        map.insert(
+            Value::String("version".into()),
+            Value::String(resolved.clone()),
+        );
+    }
+
+    Ok(Some(source))
+}
+
+/// A `target-<name>:` / `kernel-<spec>:` sub-block may override `version`, but
+/// only with a literal. Supporting the mapping form there would mean the RPM
+/// packager and this resolver had to agree on two sets of positions; keeping it
+/// to the direct child keeps that surface at one.
+fn reject_override_blocks(ext: &Value, ext_name: &str) -> Result<()> {
+    let Some(map) = ext.as_mapping() else {
+        return Ok(());
+    };
+    for (key, value) in map {
+        let Some(name) = key.as_str() else { continue };
+        if !(name.starts_with("target-") || name.starts_with("kernel-")) {
+            continue;
+        }
+        if value.get("version").is_some_and(|v| v.is_mapping()) {
+            bail!(
+                "extension '{ext_name}': `{name}.version` must be a literal version string. \
+                 The `{{ file, key }}` form is only supported on the extension's own \
+                 `version:` field."
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Resolve every mapping-form `version:` under `extensions.*`.
+///
+/// Extensions with no reader are left untouched: an extension whose source tree
+/// isn't reachable yet (not fetched) still composes, and fails later with the
+/// existing "missing version" diagnostics rather than here.
+pub fn resolve_in_config(
+    config: &mut Value,
+    readers: &HashMap<String, Box<dyn ExtFileReader>>,
+) -> Result<HashMap<String, VersionSource>> {
+    let mut resolved = HashMap::new();
+
+    let Some(extensions) = config
+        .get_mut("extensions")
+        .and_then(|e| e.as_mapping_mut())
+    else {
+        return Ok(resolved);
+    };
+
+    for (name_value, ext) in extensions.iter_mut() {
+        let Some(name) = name_value.as_str().map(str::to_string) else {
+            continue;
+        };
+        let Some(reader) = readers.get(&name) else {
+            continue;
+        };
+        if let Some(source) = resolve_in_ext_value(ext, &name, reader.as_ref())? {
+            resolved.insert(name, source);
+        }
+    }
+
+    Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// In-memory extension root.
+    struct FakeReader(HashMap<String, String>);
+
+    impl FakeReader {
+        fn new(files: &[(&str, &str)]) -> Self {
+            Self(
+                files
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            )
+        }
+    }
+
+    impl ExtFileReader for FakeReader {
+        fn read_file(&self, rel: &str) -> Result<String> {
+            self.0
+                .get(rel)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("no such file: {rel}"))
+        }
+        fn describe(&self) -> String {
+            "<fake>".to_string()
+        }
+    }
+
+    fn source(yaml: &str) -> Result<Option<VersionSource>> {
+        VersionSource::from_value(&serde_yaml::from_str(yaml).unwrap())
+    }
+
+    fn resolve(yaml: &str, files: &[(&str, &str)]) -> Result<String> {
+        source(yaml)?
+            .expect("expected a mapping form")
+            .resolve(&FakeReader::new(files))
+    }
+
+    // --- bare `file:` (no key) --------------------------------------------
+
+    #[test]
+    fn bare_file_reads_whole_file() {
+        let v = resolve("file: VERSION", &[("VERSION", "1.2.3")]).unwrap();
+        assert_eq!(v, "1.2.3");
+    }
+
+    #[test]
+    fn bare_file_trims_trailing_newline() {
+        let v = resolve("file: VERSION", &[("VERSION", "1.2.3\n")]).unwrap();
+        assert_eq!(v, "1.2.3");
+    }
+
+    #[test]
+    fn bare_file_trims_surrounding_whitespace() {
+        let v = resolve("file: VERSION", &[("VERSION", "  \n 1.2.3 \t\n\n")]).unwrap();
+        assert_eq!(v, "1.2.3");
+    }
+
+    #[test]
+    fn bare_file_that_trims_to_empty_errors() {
+        let err = resolve("file: VERSION", &[("VERSION", "  \n\t ")]).unwrap_err();
+        assert!(
+            err.to_string().contains("empty string"),
+            "unexpected: {err:#}"
+        );
+    }
+
+    /// Without a `key` the file is never parsed, so a structured file is taken
+    /// literally rather than being auto-detected. That must fail semver, not
+    /// silently produce something.
+    #[test]
+    fn bare_file_does_not_auto_parse_structured_files() {
+        let err = resolve(
+            "file: Cargo.toml",
+            &[("Cargo.toml", "[package]\nversion = \"1.2.3\"\n")],
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("not a valid version"),
+            "unexpected: {err:#}"
+        );
+    }
+
+    // --- `file:` + `key:` --------------------------------------------------
+
+    #[test]
+    fn toml_key_inferred_from_extension() {
+        let v = resolve(
+            "file: Cargo.toml\nkey: package.version",
+            &[(
+                "Cargo.toml",
+                "[package]\nname = \"x\"\nversion = \"1.0.0-rc.1\"\n",
+            )],
+        )
+        .unwrap();
+        assert_eq!(v, "1.0.0-rc.1");
+    }
+
+    #[test]
+    fn json_key_inferred_from_extension() {
+        let v = resolve(
+            "file: package.json\nkey: version",
+            &[("package.json", r#"{"name":"x","version":"2.1.3"}"#)],
+        )
+        .unwrap();
+        assert_eq!(v, "2.1.3");
+    }
+
+    #[test]
+    fn yaml_key_inferred_from_extension() {
+        let v = resolve(
+            "file: meta.yaml\nkey: project.version",
+            &[("meta.yaml", "project:\n  version: 0.4.2\n")],
+        )
+        .unwrap();
+        assert_eq!(v, "0.4.2");
+    }
+
+    #[test]
+    fn explicit_format_overrides_the_extension() {
+        let v = resolve(
+            "file: versions.txt\nkey: version\nformat: json",
+            &[("versions.txt", r#"{"version":"9.9.9"}"#)],
+        )
+        .unwrap();
+        assert_eq!(v, "9.9.9");
+    }
+
+    #[test]
+    fn unknown_extension_without_format_errors() {
+        let err = resolve(
+            "file: versions.txt\nkey: version",
+            &[("versions.txt", r#"{"version":"9.9.9"}"#)],
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("cannot infer a parse format"),
+            "unexpected: {err:#}"
+        );
+    }
+
+    #[test]
+    fn missing_key_errors() {
+        let err = resolve(
+            "file: Cargo.toml\nkey: package.nope",
+            &[("Cargo.toml", "[package]\nversion = \"1.2.3\"\n")],
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("has no key 'package.nope'"),
+            "unexpected: {err:#}"
+        );
+    }
+
+    #[test]
+    fn non_scalar_key_errors() {
+        let err = resolve(
+            "file: Cargo.toml\nkey: package",
+            &[("Cargo.toml", "[package]\nversion = \"1.2.3\"\n")],
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("is not a string"),
+            "unexpected: {err:#}"
+        );
+    }
+
+    /// A workspace-inherited `version.workspace = true` is a bool, not a string.
+    #[test]
+    fn workspace_inherited_version_errors_clearly() {
+        let err = resolve(
+            "file: Cargo.toml\nkey: package.version",
+            &[("Cargo.toml", "[package]\nversion.workspace = true\n")],
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("is not a string"),
+            "unexpected: {err:#}"
+        );
+    }
+
+    // --- shared ------------------------------------------------------------
+
+    #[test]
+    fn missing_file_names_the_root() {
+        let err = resolve("file: VERSION", &[]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("VERSION") && msg.contains("<fake>"), "{msg}");
+    }
+
+    #[test]
+    fn non_semver_result_errors() {
+        let err = resolve("file: VERSION", &[("VERSION", "nightly")]).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("not a valid version"),
+            "unexpected: {err:#}"
+        );
+    }
+
+    #[test]
+    fn absolute_path_rejected() {
+        let err = source("file: /etc/passwd").unwrap_err();
+        assert!(err.to_string().contains("not absolute"), "{err:#}");
+    }
+
+    #[test]
+    fn parent_traversal_rejected() {
+        let err = source("file: ../../secrets/VERSION").unwrap_err();
+        assert!(err.to_string().contains("'..' is not allowed"), "{err:#}");
+    }
+
+    #[test]
+    fn nested_relative_path_allowed() {
+        let v = resolve(
+            "file: crates/app/Cargo.toml\nkey: package.version",
+            &[("crates/app/Cargo.toml", "[package]\nversion = \"3.2.1\"\n")],
+        )
+        .unwrap();
+        assert_eq!(v, "3.2.1");
+    }
+
+    // --- shape validation ---------------------------------------------------
+
+    #[test]
+    fn string_form_is_not_a_mapping() {
+        assert_eq!(source("'1.2.3'").unwrap(), None);
+    }
+
+    #[test]
+    fn missing_file_field_errors() {
+        let err = source("key: package.version").unwrap_err();
+        assert!(
+            err.to_string().contains("requires a `file` field"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn unknown_field_errors() {
+        let err = source("file: VERSION\nfrom: cargo").unwrap_err();
+        assert!(err.to_string().contains("unknown field 'from'"), "{err:#}");
+    }
+
+    #[test]
+    fn format_without_key_errors() {
+        let err = source("file: VERSION\nformat: toml").unwrap_err();
+        assert!(err.to_string().contains("has no effect without"), "{err:#}");
+    }
+
+    #[test]
+    fn unknown_format_errors() {
+        let err = source("file: v.ini\nkey: a.b\nformat: ini").unwrap_err();
+        assert!(
+            format!("{err:#}").contains("unknown `version.format` 'ini'"),
+            "{err:#}"
+        );
+    }
+
+    // --- in-tree resolution --------------------------------------------------
+
+    #[test]
+    fn resolve_in_ext_value_replaces_the_mapping() {
+        let mut ext: Value =
+            serde_yaml::from_str("version:\n  file: VERSION\nrelease: r0\n").unwrap();
+        let reader = FakeReader::new(&[("VERSION", "1.2.3\n")]);
+
+        let source = resolve_in_ext_value(&mut ext, "my-ext", &reader)
+            .unwrap()
+            .expect("a provider");
+
+        assert_eq!(source.file, "VERSION");
+        assert_eq!(ext.get("version").unwrap().as_str(), Some("1.2.3"));
+        // Untouched siblings stay put.
+        assert_eq!(ext.get("release").unwrap().as_str(), Some("r0"));
+    }
+
+    #[test]
+    fn resolve_in_ext_value_leaves_string_versions_alone() {
+        let mut ext: Value = serde_yaml::from_str("version: '1.2.3'\n").unwrap();
+        let reader = FakeReader::new(&[]);
+        assert!(resolve_in_ext_value(&mut ext, "my-ext", &reader)
+            .unwrap()
+            .is_none());
+        assert_eq!(ext.get("version").unwrap().as_str(), Some("1.2.3"));
+    }
+
+    #[test]
+    fn resolve_in_ext_value_errors_name_the_extension() {
+        let mut ext: Value = serde_yaml::from_str("version:\n  file: VERSION\n").unwrap();
+        let reader = FakeReader::new(&[]);
+        let err = resolve_in_ext_value(&mut ext, "avocado-ext-cli", &reader).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("extension 'avocado-ext-cli'"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn mapping_version_in_a_target_override_is_rejected() {
+        let mut ext: Value = serde_yaml::from_str(
+            "version: '1.0.0'\ntarget-qemux86-64:\n  version:\n    file: VERSION\n",
+        )
+        .unwrap();
+        let reader = FakeReader::new(&[("VERSION", "1.2.3")]);
+        let err = resolve_in_ext_value(&mut ext, "my-ext", &reader).unwrap_err();
+        assert!(
+            err.to_string().contains("target-qemux86-64.version"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn literal_version_in_a_target_override_is_fine() {
+        let mut ext: Value = serde_yaml::from_str(
+            "version:\n  file: VERSION\ntarget-qemux86-64:\n  version: '9.9.9'\n",
+        )
+        .unwrap();
+        let reader = FakeReader::new(&[("VERSION", "1.2.3")]);
+        resolve_in_ext_value(&mut ext, "my-ext", &reader).unwrap();
+        assert_eq!(ext.get("version").unwrap().as_str(), Some("1.2.3"));
+    }
+
+    #[test]
+    fn resolve_in_config_walks_extensions_and_skips_readerless_ones() {
+        let mut config: Value = serde_yaml::from_str(
+            "extensions:\n  \
+               a:\n    version:\n      file: VERSION\n  \
+               b:\n    version: '2.0.0'\n  \
+               c:\n    version:\n      file: VERSION\n",
+        )
+        .unwrap();
+
+        let mut readers: HashMap<String, Box<dyn ExtFileReader>> = HashMap::new();
+        readers.insert(
+            "a".to_string(),
+            Box::new(FakeReader::new(&[("VERSION", "1.1.1")])),
+        );
+        readers.insert("b".to_string(), Box::new(FakeReader::new(&[])));
+        // 'c' has no reader — not fetched yet.
+
+        let resolved = resolve_in_config(&mut config, &readers).unwrap();
+
+        assert_eq!(resolved.len(), 1);
+        assert!(resolved.contains_key("a"));
+        let exts = config.get("extensions").unwrap();
+        assert_eq!(
+            exts.get("a").unwrap().get("version").unwrap().as_str(),
+            Some("1.1.1")
+        );
+        assert_eq!(
+            exts.get("b").unwrap().get("version").unwrap().as_str(),
+            Some("2.0.0")
+        );
+        assert!(exts.get("c").unwrap().get("version").unwrap().is_mapping());
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,6 +5,8 @@ pub mod container_dev;
 #[cfg(target_os = "macos")]
 pub mod disk_writer;
 pub mod ext_fetch;
+pub mod ext_source_reader;
+pub mod ext_version_source;
 pub mod host_copy;
 pub mod image_signing;
 pub mod install_method;

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -1,6 +1,20 @@
 use anyhow::{Context, Result};
 use semver::{Version, VersionReq};
 
+/// Validate an extension's `version`, naming the config file it came from.
+///
+/// The bare [`validate_semver`] message names the extension but not the file,
+/// which is little help when the value was merged in from a remote extension's
+/// own `avocado.yaml` several hops away.
+pub fn validate_ext_version(ext_name: &str, version: &str, source_path: &str) -> Result<()> {
+    validate_semver(version).with_context(|| {
+        format!(
+            "Extension '{ext_name}' has invalid version '{version}' (from {source_path}). \
+             Version must be in semantic versioning format (e.g., '1.0.0', '2.1.3')"
+        )
+    })
+}
+
 /// Validate semantic versioning format (X.Y.Z where X, Y, Z are non-negative integers).
 ///
 /// Accepts standard semver with optional pre-release and build metadata

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -10,7 +10,8 @@ pub fn validate_ext_version(ext_name: &str, version: &str, source_path: &str) ->
     validate_semver(version).with_context(|| {
         format!(
             "Extension '{ext_name}' has invalid version '{version}' (from {source_path}). \
-             Version must be in semantic versioning format (e.g., '1.0.0', '2.1.3')"
+             Version must be in semantic versioning format \
+             (e.g., '1.0.0', '2.1.3', '1.0.0-rc.1', '1.0.0+build.5')"
         )
     })
 }

--- a/tests/ext_version_source.rs
+++ b/tests/ext_version_source.rs
@@ -1,0 +1,345 @@
+//! Integration tests for source-tree extension versions.
+//!
+//! The regression these guard: an extension whose `version` came from
+//! `{{ env.AVOCADO_EXT_VERSION }}` resolved at package time but interpolated to
+//! `""` for anyone consuming it via `source: { type: path | git }`, so switching
+//! an extension to a local checkout for testing failed semver validation. A
+//! `version: { file, key }` provider reads from the extension's own tree, which
+//! is present in every consumption mode, so the composed version is identical
+//! no matter which source kind is used.
+
+use avocado_cli::utils::config::Config;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// A scratch directory that cleans itself up.
+struct TestDir(PathBuf);
+
+impl TestDir {
+    fn new(name: &str) -> Self {
+        let dir = std::env::temp_dir().join(format!("avocado_ext_version_source_{name}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        Self(dir)
+    }
+
+    fn write(&self, rel: &str, content: &str) -> PathBuf {
+        let path = self.0.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&path, content).unwrap();
+        path
+    }
+}
+
+impl Drop for TestDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Write a minimal extension whose version lives in `Cargo.toml`, exactly like
+/// the in-source program extensions (avocado-cli, avocado-conn, avocado-rat).
+fn write_cargo_extension(dir: &TestDir, rel: &str, ext_name: &str, version: &str) {
+    dir.write(
+        &format!("{rel}/Cargo.toml"),
+        &format!("[package]\nname = \"prog\"\nversion = \"{version}\"\nedition = \"2021\"\n"),
+    );
+    dir.write(
+        &format!("{rel}/avocado.yaml"),
+        &format!(
+            "supported_targets: '*'\n\
+             extensions:\n  \
+               {ext_name}:\n    \
+                 version:\n      \
+                   file: Cargo.toml\n      \
+                   key: package.version\n    \
+                 types:\n      \
+                   - sysext\n"
+        ),
+    );
+}
+
+fn composed_ext_version(config_path: &Path, ext_name: &str) -> Option<String> {
+    let composed = Config::load_composed(config_path.to_str().unwrap(), Some("qemux86-64"))
+        .expect("config should compose");
+    composed
+        .merged_value
+        .get("extensions")?
+        .get(ext_name)?
+        .get("version")?
+        .as_str()
+        .map(str::to_string)
+}
+
+/// The reported bug: an extension consumed via `source: { type: path }` must
+/// compose to a real version rather than failing validation.
+#[test]
+fn path_sourced_extension_resolves_version_from_its_own_tree() {
+    let dir = TestDir::new("path_source");
+    write_cargo_extension(&dir, "my-ext", "avocado-ext-prog", "1.0.0-rc.1");
+
+    let project = dir.write(
+        "project/avocado.yaml",
+        "default_target: qemux86-64\n\
+         extensions:\n  \
+           avocado-ext-prog:\n    \
+             source:\n      \
+               type: path\n      \
+               path: ../my-ext\n",
+    );
+
+    assert_eq!(
+        composed_ext_version(&project, "avocado-ext-prog").as_deref(),
+        Some("1.0.0-rc.1")
+    );
+}
+
+/// The version tracks the program it wraps with no edit to avocado.yaml — the
+/// whole point of the provider.
+#[test]
+fn path_sourced_version_tracks_the_program_version() {
+    let dir = TestDir::new("tracks");
+    write_cargo_extension(&dir, "my-ext", "avocado-ext-prog", "1.0.0-rc.1");
+
+    let project = dir.write(
+        "project/avocado.yaml",
+        "default_target: qemux86-64\n\
+         extensions:\n  \
+           avocado-ext-prog:\n    \
+             source:\n      \
+               type: path\n      \
+               path: ../my-ext\n",
+    );
+
+    assert_eq!(
+        composed_ext_version(&project, "avocado-ext-prog").as_deref(),
+        Some("1.0.0-rc.1")
+    );
+
+    // Bump only Cargo.toml.
+    dir.write(
+        "my-ext/Cargo.toml",
+        "[package]\nname = \"prog\"\nversion = \"2.4.0\"\nedition = \"2021\"\n",
+    );
+
+    assert_eq!(
+        composed_ext_version(&project, "avocado-ext-prog").as_deref(),
+        Some("2.4.0")
+    );
+}
+
+/// A bare `VERSION` file, with no `key`, is read whole and trimmed.
+#[test]
+fn path_sourced_extension_resolves_a_bare_version_file() {
+    let dir = TestDir::new("bare_file");
+    dir.write("my-ext/VERSION", "  0.4.2\n\n");
+    dir.write(
+        "my-ext/avocado.yaml",
+        "supported_targets: '*'\n\
+         extensions:\n  \
+           avocado-ext-prog:\n    \
+             version:\n      \
+               file: VERSION\n",
+    );
+
+    let project = dir.write(
+        "project/avocado.yaml",
+        "default_target: qemux86-64\n\
+         extensions:\n  \
+           avocado-ext-prog:\n    \
+             source:\n      \
+               type: path\n      \
+               path: ../my-ext\n",
+    );
+
+    assert_eq!(
+        composed_ext_version(&project, "avocado-ext-prog").as_deref(),
+        Some("0.4.2")
+    );
+}
+
+/// A `package`-sourced extension is read out of the installed payload. The RPM
+/// ships the provider rather than a baked literal, so the payload must resolve
+/// itself — and must land on the same version a `path` source would.
+///
+/// The dev-fallback root (`<src_dir>/.avocado/<target>/includes/<ext>`) stands
+/// in for the installed payload; it is the same directory layout DNF produces.
+#[test]
+fn package_sourced_payload_resolves_to_the_same_version_as_a_path_source() {
+    let dir = TestDir::new("package_parity");
+    write_cargo_extension(&dir, "my-ext", "avocado-ext-prog", "3.1.4");
+
+    // What `avocado ext package` publishes and DNF installs: the extension's
+    // own tree, provider intact, alongside the file the provider names.
+    write_cargo_extension(
+        &dir,
+        "project/.avocado/qemux86-64/includes/avocado-ext-prog",
+        "avocado-ext-prog",
+        "3.1.4",
+    );
+
+    let via_path = dir.write(
+        "project/avocado.yaml",
+        "default_target: qemux86-64\n\
+         extensions:\n  \
+           avocado-ext-prog:\n    \
+             source:\n      \
+               type: path\n      \
+               path: ../my-ext\n",
+    );
+    let path_version = composed_ext_version(&via_path, "avocado-ext-prog");
+
+    let via_package = dir.write(
+        "project/avocado.yaml",
+        "default_target: qemux86-64\n\
+         extensions:\n  \
+           avocado-ext-prog:\n    \
+             source:\n      \
+               type: package\n      \
+               version: '*'\n",
+    );
+    let package_version = composed_ext_version(&via_package, "avocado-ext-prog");
+
+    assert_eq!(path_version.as_deref(), Some("3.1.4"));
+    assert_eq!(
+        path_version, package_version,
+        "switching source kind changed the composed version"
+    );
+
+    // Prove the package leg really read the installed payload rather than
+    // happening to agree with the sibling checkout: bump only the payload.
+    dir.write(
+        "project/.avocado/qemux86-64/includes/avocado-ext-prog/Cargo.toml",
+        "[package]\nname = \"prog\"\nversion = \"3.2.0\"\nedition = \"2021\"\n",
+    );
+    assert_eq!(
+        composed_ext_version(&via_package, "avocado-ext-prog").as_deref(),
+        Some("3.2.0"),
+        "package source did not resolve from the installed payload"
+    );
+}
+
+/// An extension defined in the project's own config resolves against that
+/// config's directory. This is the path `avocado ext package` takes for the
+/// in-source program extensions.
+#[test]
+fn local_extension_resolves_against_its_own_config_directory() {
+    let dir = TestDir::new("local");
+    dir.write(
+        "Cargo.toml",
+        "[package]\nname = \"prog\"\nversion = \"1.0.0-rc.1\"\nedition = \"2021\"\n",
+    );
+    let project = dir.write(
+        "avocado.yaml",
+        "default_target: qemux86-64\n\
+         extensions:\n  \
+           avocado-ext-prog:\n    \
+             version:\n      \
+               file: Cargo.toml\n      \
+               key: package.version\n",
+    );
+
+    assert_eq!(
+        composed_ext_version(&project, "avocado-ext-prog").as_deref(),
+        Some("1.0.0-rc.1")
+    );
+
+    // `ext package` reads a local extension through `get_merged_ext_config`,
+    // which re-reads the file rather than going through `load_composed`. It has
+    // to resolve the provider too, or in-source extensions package unresolved.
+    let config = Config::load(&project).unwrap();
+    let merged = config
+        .get_merged_ext_config("avocado-ext-prog", "qemux86-64", project.to_str().unwrap())
+        .unwrap()
+        .expect("extension section");
+    assert_eq!(
+        merged.get("version").and_then(|v| v.as_str()),
+        Some("1.0.0-rc.1")
+    );
+}
+
+/// A provider that can't be resolved must say which file it wanted and where it
+/// looked, rather than surfacing as an empty or bogus version downstream.
+#[test]
+fn missing_version_file_reports_the_file_and_the_extension() {
+    let dir = TestDir::new("missing_file");
+    dir.write(
+        "my-ext/avocado.yaml",
+        "supported_targets: '*'\n\
+         extensions:\n  \
+           avocado-ext-prog:\n    \
+             version:\n      \
+               file: Cargo.toml\n      \
+               key: package.version\n",
+    );
+
+    let project = dir.write(
+        "project/avocado.yaml",
+        "default_target: qemux86-64\n\
+         extensions:\n  \
+           avocado-ext-prog:\n    \
+             source:\n      \
+               type: path\n      \
+               path: ../my-ext\n",
+    );
+
+    let err = Config::load_composed(project.to_str().unwrap(), Some("qemux86-64"))
+        .expect_err("a missing version file must fail composition");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("avocado-ext-prog"), "{msg}");
+    assert!(msg.contains("Cargo.toml"), "{msg}");
+}
+
+/// The consumer keeps the last word: a literal `version` in the project config
+/// wins over the extension's provider, same as any other field.
+#[test]
+fn consumer_can_still_override_the_version() {
+    let dir = TestDir::new("override");
+    write_cargo_extension(&dir, "my-ext", "avocado-ext-prog", "1.0.0-rc.1");
+
+    let project = dir.write(
+        "project/avocado.yaml",
+        "default_target: qemux86-64\n\
+         extensions:\n  \
+           avocado-ext-prog:\n    \
+             version: '9.9.9'\n    \
+             source:\n      \
+               type: path\n      \
+               path: ../my-ext\n",
+    );
+
+    assert_eq!(
+        composed_ext_version(&project, "avocado-ext-prog").as_deref(),
+        Some("9.9.9")
+    );
+}
+
+/// Plain string versions are untouched — the mapping form is purely additive.
+#[test]
+fn literal_versions_are_unaffected() {
+    let dir = TestDir::new("literal");
+    dir.write(
+        "my-ext/avocado.yaml",
+        "supported_targets: '*'\n\
+         extensions:\n  \
+           avocado-ext-prog:\n    \
+             version: '0.1.0'\n",
+    );
+
+    let project = dir.write(
+        "project/avocado.yaml",
+        "default_target: qemux86-64\n\
+         extensions:\n  \
+           avocado-ext-prog:\n    \
+             source:\n      \
+               type: path\n      \
+               path: ../my-ext\n",
+    );
+
+    assert_eq!(
+        composed_ext_version(&project, "avocado-ext-prog").as_deref(),
+        Some("0.1.0")
+    );
+}


### PR DESCRIPTION
## Problem

An extension's `version` is an **identity** field — it must resolve to the same string no matter who reads the config. `{{ env.VAR }}` can't do that: it binds the value to the *caller's* environment, and the job that packages an extension and the build that consumes it are by definition different environments.

The in-source program extensions (`avocado-ext-cli`, `avocado-ext-connect`, `avocado-ext-tunnels`) declare `version: '{{ env.AVOCADO_EXT_VERSION }}'`, with CI reading `Cargo.toml` and exporting the variable. Point a project at one of them with `source: { type: git | path }` to test a local checkout and it breaks: the variable isn't set, [`env::resolve`](src/utils/interpolation/env.rs) warns and substitutes `""`, and validation fails.

```
Error: Extension 'avocado-ext-cli' has invalid version ''. Version must be in
       semantic versioning format (e.g., '1.0.0', '2.1.3')
```

Three hard failure sites (`ext/build.rs`, `ext/image.rs`, `ext/package.rs`) plus one silent one: `runtime/build.rs` never validates and composes the artifact name `avocado-ext-cli-.raw`.

This also violates an invariant the code already states at `utils/config.rs` — *"switching between package/path/git doesn't change the composed config hash"* — and re-introduces the exact failure class `docs/features/extension-versioning-redesign.md` was written to eliminate (*"wildcards that can't resolve for git/path extensions"*).

## Approach

Keep interpolation; move `version` off the ambient environment and onto a file inside the extension's **own source tree**, which is present in every consumption mode — the working copy for `path`, the clone for `git`, the RPM payload for `package`.

```yaml
version:
  file: VERSION            # no key => whole file, trimmed

version:
  file: Cargo.toml         # parse and navigate
  key: package.version
```

`key` is the discriminator, so there's no format guessing for a plain `VERSION` file, and `file: Cargo.toml` with no `key` is a literal read rather than a surprise parse. `format` (`toml`/`json`/`yaml`) is inferred from the extension and can be set explicitly; it's rejected without a `key`. `file` must stay inside the extension — no `..`, no absolute paths.

Resolution runs during composition, before the final interpolation pass, so **every existing consumer still sees `version` as a plain string** and nothing downstream changes.

`{{ avocado.* }}` and `{{ config.* }}` remain fine elsewhere — those are consumer-context values that are *supposed* to differ per build. It's specifically `env` in an identity field that can't work.

## Notable pieces

**Extracted the extension-tree read ladder.** Reading the version file needs the same access ladder that already existed for an extension's `avocado.yaml` — host source path, in-container includes dir, SDK volume mountpoint, throwaway container `cat`, dev fallback. That was open-coded in `config.rs` with a read/error/`continue` block per strategy; it's now `utils::ext_source_reader`, so both reads go by the same route. `config.rs` is a net ~340-line deletion. This also fixes an incidental bug: only `type: path` accepted `avocado.yml`, so a `.yml` extension shipped in an RPM was invisible once installed.

**The payload must carry the version file.** The published `avocado.yaml` keeps the provider rather than a baked literal, so `ext package` always appends the provider's file — including on the branch where an explicit `package_files` list replaces the defaults wholesale. Forgetting it would only surface when someone consumed the package.

**The legacy bake is retained, and guarded.** `bake_extension_version` still handles the `{{ env.AVOCADO_EXT_VERSION }}` form, which genuinely can't resolve downstream. It's skipped for provider-based extensions — baking one would strand the provider's `file:`/`key:` lines under a replaced `version:` scalar. `test_bake_extension_version_would_corrupt_a_provider_block` documents exactly that.

**Also:** `config show --detail` reports each extension's resolved `version` (release CI will read this instead of hand-parsing YAML, which can't see through a provider), and an invalid version now names the config file it came from.

## Rollout — no extension migrates here

`setup-avocado-cli` installs `latest`, and a program-tracking extension's release workflow runs on the same tag that publishes the new CLI. So the provider has to be in a *released* CLI before any `avocado.yaml` can depend on it, or the first tag after merge installs a pre-feature CLI and fails to publish.

1. **This PR** — the mechanism only. `avocado-cli`, `avocado-conn`, and `avocado-rat` stay on `{{ env.AVOCADO_EXT_VERSION }}` and keep working through the bake.
2. **After a release carrying this** — migrate the three `avocado.yaml` files, drop `AVOCADO_EXT_VERSION` / the `ext-version` input from their workflows and from `avocado-linux/actions`, and delete the bake. Staged locally, not yet opened.

Step 2 is a payload format change: a CLI predating providers reads the mapping, coerces it to `"0"`, and fails with `invalid version '0'`. There's no graceful degradation — `cli_requirement` is top-level and isn't merged from a remote extension's config — so publish to `next` first.

## Verification

`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, and the full suite are clean (1163 lib + 1171 bin + 8 new integration tests).

Beyond tests, verified against real artifacts:

- All three repos resolve from their own `Cargo.toml` with `AVOCADO_EXT_VERSION` unset and no warning — cli `1.0.0-rc.1`, conn/rat `0.1.0`.
- Consuming avocado-cli via `type: path` — the reported bug — resolves `1.0.0-rc.1`.
- Built a real RPM from a scratch extension that **omits** its `VERSION` from `package_files`. Payload came out as `VERSION`, `avocado.yaml`, `extra.txt`; `Version: 0.4.2`; the shipped `avocado.yaml` kept the provider unbaked. A consumer then resolved `0.4.2` from that extracted payload. Deleting `VERSION` from it produces a four-level error chain naming the extension, the field, the file, and the root searched.
- The legacy env path still bakes exactly as before.

## Unrelated issue found while verifying

`avocado ext package avocado-ext-cli` fails with `error: line 5: Illegal char '-' (0x2d) in: Version: 1.0.0-rc.1`. This is **pre-existing and unrelated** — a scratch extension with a plain literal `version: '1.0.0-rc.1'` and no provider fails identically, and `git show HEAD~1:src/commands/ext/package.rs` has no sanitization either. CI exported that exact string, so the ext release workflow was already broken on RC tags. RPM wants `1.0.0~rc.1`. Worth fixing separately before the next tag.

---

_CI note: GitHub Actions was in a critical outage when this was opened, so checks may be delayed or spuriously failing._