### PR TITLE
feat(ext): inter-extension dependencies via `depends_on`

### DIFF
--- a/src/commands/ext/fetch.rs
+++ b/src/commands/ext/fetch.rs
@@ -4,7 +4,7 @@
 //! and installs them to `$AVOCADO_PREFIX/includes/<ext_name>/`.
 
 use anyhow::{Context, Result};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -280,23 +280,15 @@ impl ExtFetchCommand {
                     ..
                 } = &effective_source
                 {
-                    let pkg_name = package.as_deref().unwrap_or(ext_name).to_string();
                     package_batch.push(PackageFetchEntry::from_package_source(
                         ext_name,
                         package.as_deref(),
                         version,
                         repo_name.as_deref(),
                     ));
-                    lock_file.set_extension_source(
-                        &target,
-                        ext_name,
-                        ExtensionSourceLock {
-                            source_type: "package".to_string(),
-                            package: Some(pkg_name),
-                            version: Some(version.clone()),
-                        },
-                    );
-                    lock_file_dirty = true;
+                    // Lock entries are written *after* the transaction, from
+                    // the installroot's rpmdb — see below. Recording the
+                    // requested version here would pin `"*"` as `"*"`.
                     fetched_count += 1;
                     continue;
                 }
@@ -329,6 +321,40 @@ impl ExtFetchCommand {
                 }
             }
 
+            // Replay dependencies the lock already recorded, pinned to the
+            // versions they resolved to last time.
+            //
+            // This is what makes a clean checkout reproducible. An implied
+            // dependency is named nowhere in `avocado.yaml` — only the lock
+            // knows it exists — so without seeding it here, the first fetch on
+            // a fresh tree lets the depsolver choose freely and quietly
+            // produces a different closure than the lock describes.
+            //
+            // Declared extensions are skipped: they are already in the batch
+            // carrying the author's own constraint, which outranks the lock.
+            let declared: HashSet<String> =
+                package_batch.iter().map(|e| e.ext_name.clone()).collect();
+            for (name, pin) in lock_file.implied_extension_sources(&target) {
+                if declared.contains(&name) {
+                    continue;
+                }
+                let Some(version) = pin.version.as_deref() else {
+                    continue;
+                };
+                if self.verbose {
+                    print_info(
+                        &format!("Pinning locked dependency '{name}' to {version}"),
+                        OutputLevel::Normal,
+                    );
+                }
+                package_batch.push(PackageFetchEntry::from_package_source(
+                    &name,
+                    pin.package.as_deref(),
+                    version,
+                    None,
+                ));
+            }
+
             // One transaction for every package-source extension. dnf resolves and
             // installs any dependency extensions beyond those named here.
             if !package_batch.is_empty() {
@@ -339,9 +365,39 @@ impl ExtFetchCommand {
                     ),
                     OutputLevel::Normal,
                 );
-                fetcher
+                let resolved = fetcher
                     .fetch_packages(&package_batch, force_this_round)
                     .await?;
+
+                // Record what the installroot actually holds — the only
+                // reproducible answer. It covers extensions the depsolver
+                // pulled in unasked, and resolves `version: "*"` to a real
+                // NEVRA instead of round-tripping the wildcard.
+                let requested: HashMap<&str, &PackageFetchEntry> = package_batch
+                    .iter()
+                    .map(|e| (e.package_name.as_str(), e))
+                    .collect();
+                for (pkg_name, version) in &resolved {
+                    let entry = requested.get(pkg_name.as_str());
+                    // An installed package nobody asked for is a dependency the
+                    // depsolver added. Its extension name is its package name —
+                    // only a declared entry can carry a `source.package` rename.
+                    let ext_name = entry
+                        .map(|e| e.ext_name.clone())
+                        .unwrap_or_else(|| pkg_name.clone());
+                    lock_file.set_extension_source(
+                        &target,
+                        &ext_name,
+                        ExtensionSourceLock {
+                            source_type: "package".to_string(),
+                            package: Some(pkg_name.clone()),
+                            version: Some(version.clone()),
+                            implied: entry.is_none(),
+                        },
+                    );
+                    lock_file_dirty = true;
+                }
+
                 print_success(
                     &format!(
                         "Successfully fetched {} package extension(s).",

--- a/src/commands/ext/fetch.rs
+++ b/src/commands/ext/fetch.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use crate::utils::config::{ComposedConfig, Config, ExtensionSource};
 use crate::utils::ext_fetch::{ExtensionFetcher, PackageFetchEntry};
 use crate::utils::lockfile::{ExtensionSourceLock, LockFile};
-use crate::utils::output::{print_info, print_success, OutputLevel};
+use crate::utils::output::{print_info, print_success, print_warning, OutputLevel};
 use crate::utils::target::resolve_target_required;
 
 /// Command to fetch remote extensions
@@ -34,6 +34,8 @@ pub struct ExtFetchCommand {
     pub runs_on: Option<String>,
     /// NFS port for remote execution
     pub nfs_port: Option<u16>,
+    /// Refuse to update the lock; fail on dependency drift instead.
+    pub locked: bool,
     /// Pre-composed configuration to avoid reloading
     composed_config: Option<Arc<ComposedConfig>>,
 }
@@ -58,6 +60,7 @@ impl ExtFetchCommand {
             sdk_arch: None,
             runs_on: None,
             nfs_port: None,
+            locked: false,
             composed_config: None,
         }
     }
@@ -65,6 +68,13 @@ impl ExtFetchCommand {
     /// Set SDK container architecture for cross-arch emulation
     pub fn with_sdk_arch(mut self, sdk_arch: Option<String>) -> Self {
         self.sdk_arch = sdk_arch;
+        self
+    }
+
+    /// Fail rather than update the lock when a locked dependency cannot
+    /// satisfy a new requirement.
+    pub fn with_locked(mut self, locked: bool) -> Self {
+        self.locked = locked;
         self
     }
 
@@ -334,6 +344,10 @@ impl ExtFetchCommand {
             // carrying the author's own constraint, which outranks the lock.
             let declared: HashSet<String> =
                 package_batch.iter().map(|e| e.ext_name.clone()).collect();
+            // Everything up to here is author-declared; pins are appended
+            // after, so the two groups can be separated again if the pinned
+            // solve has to be retried without them.
+            let declared_count = package_batch.len();
             for (name, pin) in lock_file.implied_extension_sources(&target) {
                 if declared.contains(&name) {
                     continue;
@@ -355,6 +369,8 @@ impl ExtFetchCommand {
                 ));
             }
 
+            let pinned_count = package_batch.len() - declared_count;
+
             // One transaction for every package-source extension. dnf resolves and
             // installs any dependency extensions beyond those named here.
             if !package_batch.is_empty() {
@@ -365,9 +381,100 @@ impl ExtFetchCommand {
                     ),
                     OutputLevel::Normal,
                 );
-                let resolved = fetcher
+                // Locked pins are handed to dnf as exact NEVRAs, so a
+                // dependent requiring a newer base does not silently win — the
+                // depsolve fails on contradictory requests. That failure is
+                // the drift signal.
+                //
+                // Default is to re-solve without the pins and report what
+                // moved: the conflict only arises because something the author
+                // changed invalidated the old solution, and recomputing it is
+                // the lock doing its job. `--locked` turns the same situation
+                // into an error, which is what CI wants.
+                let resolved = match fetcher
                     .fetch_packages(&package_batch, force_this_round)
-                    .await?;
+                    .await
+                {
+                    Ok(r) => r,
+                    Err(e) if pinned_count > 0 && !self.locked => {
+                        print_warning(
+                            "Locked dependency versions could not satisfy current \
+                             requirements; re-resolving.",
+                            OutputLevel::Normal,
+                        );
+                        if self.verbose {
+                            print_info(&format!("Depsolve error was: {e}"), OutputLevel::Normal);
+                        }
+                        let unpinned: Vec<PackageFetchEntry> =
+                            package_batch.iter().take(declared_count).cloned().collect();
+                        fetcher
+                            .fetch_packages(&unpinned, force_this_round)
+                            .await
+                            .with_context(|| {
+                                "Re-resolving without locked dependency versions also failed"
+                            })?
+                    }
+                    Err(e) if pinned_count > 0 && self.locked => {
+                        return Err(e).with_context(|| {
+                            "avocado.lock pins dependency versions that cannot satisfy the \
+                             current requirements.\n\
+                             Re-run without --locked to update the lock, or align the \
+                             declared versions."
+                        });
+                    }
+                    Err(e) => return Err(e),
+                };
+
+                // Report any locked dependency whose version moved. Under
+                // --locked this is fatal; otherwise it is a loud warning
+                // backed by a reviewable diff in avocado.lock.
+                let mut drift: Vec<String> = Vec::new();
+                let mut downgrades: Vec<String> = Vec::new();
+                for (name, pin) in lock_file.implied_extension_sources(&target) {
+                    let pkg = pin.package.clone().unwrap_or_else(|| name.clone());
+                    let (Some(was), Some(now)) = (pin.version.as_deref(), resolved.get(&pkg))
+                    else {
+                        continue;
+                    };
+                    if was == now {
+                        continue;
+                    }
+                    let line = format!("  {name}: {was} -> {now}");
+                    if crate::utils::ext_deps::is_rpm_downgrade(was, now) {
+                        downgrades.push(line);
+                    } else {
+                        drift.push(line);
+                    }
+                }
+
+                // A constraint dragging a shared base *backwards* has no benign
+                // reading — it means something old was pinned against a newer
+                // platform. Refuse regardless of --locked.
+                if !downgrades.is_empty() {
+                    return Err(anyhow::anyhow!(
+                        "Refusing to downgrade locked dependency extension(s):\n{}\n\
+                         A dependent is constraining a shared base to an older version. \
+                         Align the declared versions rather than moving the base back.",
+                        downgrades.join("\n")
+                    ));
+                }
+                if !drift.is_empty() {
+                    if self.locked {
+                        return Err(anyhow::anyhow!(
+                            "avocado.lock is out of date; --locked forbids updating it:\n{}\n\
+                             Re-run without --locked to update the lock.",
+                            drift.join("\n")
+                        ));
+                    }
+                    print_warning(
+                        &format!(
+                            "Updating locked dependency extension(s) in avocado.lock:\n{}\n\
+                             Review the avocado.lock diff before committing.",
+                            drift.join("\n")
+                        ),
+                        OutputLevel::Normal,
+                    );
+                }
 
                 // Record what the installroot actually holds — the only
                 // reproducible answer. It covers extensions the depsolver

--- a/src/commands/ext/fetch.rs
+++ b/src/commands/ext/fetch.rs
@@ -4,11 +4,12 @@
 //! and installs them to `$AVOCADO_PREFIX/includes/<ext_name>/`.
 
 use anyhow::{Context, Result};
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
 
 use crate::utils::config::{ComposedConfig, Config, ExtensionSource};
-use crate::utils::ext_fetch::ExtensionFetcher;
+use crate::utils::ext_fetch::{ExtensionFetcher, PackageFetchEntry};
 use crate::utils::lockfile::{ExtensionSourceLock, LockFile};
 use crate::utils::output::{print_info, print_success, OutputLevel};
 use crate::utils::target::resolve_target_required;
@@ -101,9 +102,19 @@ impl ExtFetchCommand {
             .get_sdk_image()
             .ok_or_else(|| anyhow::anyhow!("No SDK container image specified in configuration"))?;
 
-        // Discover remote extensions (with target interpolation for extension names)
+        // Discover remote extensions from the **composed** value, not the raw
+        // consumer yaml. A dependency declared inside an already-fetched
+        // extension's own avocado.yaml only exists in the composed config;
+        // reading the raw file would make it permanently undiscoverable.
         let remote_extensions =
-            Config::discover_remote_extensions(&self.config_path, Some(&target))?;
+            Config::discover_remote_extensions_from_value(&composed.merged_value)?;
+
+        // Everything visible before we materialize anything. Later rounds fetch
+        // only what was *revealed* by a fetch, which is also what keeps a
+        // `--extension` filter meaningful: extensions the filter excluded were
+        // visible from the start and are never picked up by a later round.
+        let visible_at_start: HashSet<String> =
+            remote_extensions.iter().map(|(n, _)| n.clone()).collect();
 
         if remote_extensions.is_empty() {
             print_info(
@@ -187,93 +198,202 @@ impl ExtFetchCommand {
         let mut fetched_count = 0;
         let mut skipped_count = 0;
 
-        for (ext_name, source) in &extensions_to_fetch {
-            // Check if already installed
-            if !self.force && ExtensionFetcher::is_extension_installed(&extensions_dir, ext_name) {
-                if self.verbose {
-                    print_info(
+        // Materialization proceeds in rounds. Round 1 fetches what the config
+        // already shows; each later round picks up extensions that only became
+        // visible *because* of the previous round — a `git`/`path` dependency
+        // the depsolver cannot pull, or a sibling declaration merged in only
+        // once its parent's avocado.yaml became readable.
+        //
+        // In practice this settles in one round: package dependencies are
+        // resolved inside a single dnf transaction (see below), so there is
+        // usually nothing left to reveal.
+        let mut attempted: HashSet<String> = HashSet::new();
+        let mut round_targets = extensions_to_fetch;
+        let mut round = 0usize;
+
+        // Defensive bound. Termination is already guaranteed by `attempted`
+        // growing monotonically over a finite extension set; this only stops a
+        // pathological config from spinning.
+        const MAX_ROUNDS: usize = 10;
+
+        while !round_targets.is_empty() && round < MAX_ROUNDS {
+            round += 1;
+
+            // `--force` re-fetches what the user asked for, not extensions
+            // discovered on the way — those were just installed.
+            let force_this_round = self.force && round == 1;
+
+            // Package-source extensions are collected and installed in ONE dnf
+            // transaction rather than one container run each. That is what lets the
+            // depsolver pull in each package's `Requires: avocado-ext(<dep>)`
+            // closure — inter-extension dependencies are materialized by dnf, not
+            // by repeated fetch/recompose/discover rounds.
+            let mut package_batch: Vec<PackageFetchEntry> = Vec::new();
+
+            for (ext_name, source) in &round_targets {
+                if !attempted.insert(ext_name.clone()) {
+                    continue;
+                }
+                // Check if already installed
+                if !force_this_round
+                    && ExtensionFetcher::is_extension_installed(&extensions_dir, ext_name)
+                {
+                    if self.verbose {
+                        print_info(
                         &format!("Extension '{ext_name}' is already installed, skipping (use --force to re-fetch)"),
                         OutputLevel::Normal,
                     );
-                }
-                skipped_count += 1;
-                continue;
-            }
-
-            // For package-type sources, use locked version if available
-            let effective_source = if let ExtensionSource::Package {
-                version,
-                package,
-                repo_name,
-                include,
-            } = source
-            {
-                let effective_version = lock_file
-                    .get_extension_source(&target, ext_name)
-                    .and_then(|s| s.version.as_deref())
-                    .unwrap_or(version.as_str())
-                    .to_string();
-                ExtensionSource::Package {
-                    version: effective_version,
-                    package: package.clone(),
-                    repo_name: repo_name.clone(),
-                    include: include.clone(),
-                }
-            } else {
-                source.clone()
-            };
-
-            print_info(
-                &format!("Fetching extension '{ext_name}'..."),
-                OutputLevel::Normal,
-            );
-
-            match fetcher
-                .fetch(ext_name, &effective_source, &extensions_dir, self.force)
-                .await
-            {
-                Ok(install_path) => {
-                    print_success(
-                        &format!(
-                            "Successfully fetched extension '{ext_name}' to {}",
-                            install_path.display()
-                        ),
-                        OutputLevel::Normal,
-                    );
-
-                    // Record source metadata in lock file for package-type
-                    // extensions. Source metadata is intentionally global —
-                    // it describes "where this package came from" /
-                    // "what version anchors the build config," which is
-                    // a property of the fetch, not of any runtime that
-                    // later builds a sysroot from it. Runtime-scoping
-                    // applies to the built sysroots downstream, not to
-                    // source descriptors.
-                    if let ExtensionSource::Package {
-                        version, package, ..
-                    } = &effective_source
-                    {
-                        let pkg_name = package.as_deref().unwrap_or(ext_name).to_string();
-                        lock_file.set_extension_source(
-                            &target,
-                            ext_name,
-                            ExtensionSourceLock {
-                                source_type: "package".to_string(),
-                                package: Some(pkg_name),
-                                version: Some(version.clone()),
-                            },
-                        );
-                        lock_file_dirty = true;
                     }
-
-                    fetched_count += 1;
+                    skipped_count += 1;
+                    continue;
                 }
-                Err(e) => {
-                    return Err(anyhow::anyhow!(
-                        "Failed to fetch extension '{ext_name}': {e}"
+
+                // For package-type sources, use locked version if available
+                let effective_source = if let ExtensionSource::Package {
+                    version,
+                    package,
+                    repo_name,
+                    include,
+                } = source
+                {
+                    let effective_version = lock_file
+                        .get_extension_source(&target, ext_name)
+                        .and_then(|s| s.version.as_deref())
+                        .unwrap_or(version.as_str())
+                        .to_string();
+                    ExtensionSource::Package {
+                        version: effective_version,
+                        package: package.clone(),
+                        repo_name: repo_name.clone(),
+                        include: include.clone(),
+                    }
+                } else {
+                    source.clone()
+                };
+
+                // Defer package sources to the batched transaction below; record
+                // their lock metadata now so the bookkeeping is identical either way.
+                if let ExtensionSource::Package {
+                    version,
+                    package,
+                    repo_name,
+                    ..
+                } = &effective_source
+                {
+                    let pkg_name = package.as_deref().unwrap_or(ext_name).to_string();
+                    package_batch.push(PackageFetchEntry::from_package_source(
+                        ext_name,
+                        package.as_deref(),
+                        version,
+                        repo_name.as_deref(),
                     ));
+                    lock_file.set_extension_source(
+                        &target,
+                        ext_name,
+                        ExtensionSourceLock {
+                            source_type: "package".to_string(),
+                            package: Some(pkg_name),
+                            version: Some(version.clone()),
+                        },
+                    );
+                    lock_file_dirty = true;
+                    fetched_count += 1;
+                    continue;
+                }
+
+                print_info(
+                    &format!("Fetching extension '{ext_name}'..."),
+                    OutputLevel::Normal,
+                );
+
+                match fetcher
+                    .fetch(ext_name, &effective_source, &extensions_dir, self.force)
+                    .await
+                {
+                    Ok(install_path) => {
+                        print_success(
+                            &format!(
+                                "Successfully fetched extension '{ext_name}' to {}",
+                                install_path.display()
+                            ),
+                            OutputLevel::Normal,
+                        );
+
+                        fetched_count += 1;
+                    }
+                    Err(e) => {
+                        return Err(anyhow::anyhow!(
+                            "Failed to fetch extension '{ext_name}': {e}"
+                        ));
+                    }
                 }
             }
+
+            // One transaction for every package-source extension. dnf resolves and
+            // installs any dependency extensions beyond those named here.
+            if !package_batch.is_empty() {
+                print_info(
+                    &format!(
+                        "Fetching {} package extension(s) and their dependencies...",
+                        package_batch.len()
+                    ),
+                    OutputLevel::Normal,
+                );
+                fetcher
+                    .fetch_packages(&package_batch, force_this_round)
+                    .await?;
+                print_success(
+                    &format!(
+                        "Successfully fetched {} package extension(s).",
+                        package_batch.len()
+                    ),
+                    OutputLevel::Normal,
+                );
+            }
+
+            // Recompose and see whether materializing the round revealed any
+            // remote extension that was not visible before we started.
+            let recomposed =
+                Config::load_composed(&self.config_path, Some(&target)).with_context(|| {
+                    format!(
+                        "Failed to reload config from {} after fetch",
+                        self.config_path
+                    )
+                })?;
+            round_targets =
+                Config::discover_remote_extensions_from_value(&recomposed.merged_value)?
+                    .into_iter()
+                    .filter(|(name, _)| {
+                        !visible_at_start.contains(name) && !attempted.contains(name)
+                    })
+                    .collect();
+
+            if !round_targets.is_empty() && self.verbose {
+                print_info(
+                    &format!(
+                        "Discovered {} additional remote extension(s) after fetching: {}",
+                        round_targets.len(),
+                        round_targets
+                            .iter()
+                            .map(|(n, _)| n.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ),
+                    OutputLevel::Normal,
+                );
+            }
+        }
+
+        if round >= MAX_ROUNDS && !round_targets.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Extension discovery did not settle after {MAX_ROUNDS} fetch rounds; \
+                 still pending: {}",
+                round_targets
+                    .iter()
+                    .map(|(n, _)| n.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
         }
 
         // Save lock file if we recorded any source metadata

--- a/src/commands/ext/install.rs
+++ b/src/commands/ext/install.rs
@@ -15,7 +15,7 @@ use crate::utils::output::{
 };
 use crate::utils::runs_on::RunsOnContext;
 use crate::utils::stamps::{
-    compute_ext_install_input_hash, generate_write_stamp_script, Stamp, StampOutputs,
+    compute_ext_install_input_hash_with_deps, generate_write_stamp_script, Stamp, StampOutputs,
 };
 use crate::utils::target::resolve_target_required;
 use crate::utils::tui::{TaskId, TuiGuard};
@@ -498,7 +498,34 @@ impl ExtInstallCommand {
                     ctx.renderer
                         .append_output(&ctx.task_id, "Writing install stamp...".to_string());
                 }
-                let inputs = compute_ext_install_input_hash(parsed, ext_name)?;
+                // Fold in the state of whatever this extension was seeded
+                // from, so changing a dependency invalidates its dependents.
+                // Read after the dependency installed — topological order
+                // guarantees its lock entry is already current.
+                let dep_state: Vec<(String, String)> = direct_deps
+                    .get(ext_name)
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[])
+                    .iter()
+                    .map(|dep| {
+                        let versions = lock_file
+                            .get_extension_packages(target, dep)
+                            .map(|pkgs| {
+                                let mut v: Vec<String> =
+                                    pkgs.iter().map(|(k, val)| format!("{k}={val:?}")).collect();
+                                v.sort();
+                                v.join(",")
+                            })
+                            .unwrap_or_default();
+                        let source = lock_file
+                            .get_extension_source(target, dep)
+                            .and_then(|s| s.version.clone())
+                            .unwrap_or_default();
+                        (dep.clone(), format!("{source}|{versions}"))
+                    })
+                    .collect();
+                let inputs =
+                    compute_ext_install_input_hash_with_deps(parsed, ext_name, &dep_state)?;
                 let outputs = StampOutputs::default();
                 let stamp = Stamp::ext_install(ext_name, target, inputs, outputs);
                 let stamp_script = generate_write_stamp_script(&stamp)?;

--- a/src/commands/ext/install.rs
+++ b/src/commands/ext/install.rs
@@ -29,6 +29,8 @@ pub struct ExtInstallCommand {
     container_args: Option<Vec<String>>,
     dnf_args: Option<Vec<String>>,
     no_stamps: bool,
+    /// See [`Self::with_deps_scheduled`].
+    deps_scheduled: bool,
     runs_on: Option<String>,
     nfs_port: Option<u16>,
     sdk_arch: Option<String>,
@@ -64,6 +66,7 @@ impl ExtInstallCommand {
             container_args,
             dnf_args,
             no_stamps: false,
+            deps_scheduled: false,
             runs_on: None,
             nfs_port: None,
             sdk_arch: None,
@@ -117,6 +120,19 @@ impl ExtInstallCommand {
     /// Set the no_stamps flag
     pub fn with_no_stamps(mut self, no_stamps: bool) -> Self {
         self.no_stamps = no_stamps;
+        self
+    }
+
+    /// Declare that the caller has already scheduled every `depends_on`
+    /// target as its own install, ordered before this one.
+    ///
+    /// `avocado install` fans out one command per extension and runs them
+    /// concurrently. Each of them expanding its own closure would have two
+    /// dependents rebuild the same shared base at the same time — a `rm -rf`
+    /// of a sysroot another task is installing into. The scheduler owns the
+    /// closure there; this command only installs what it was handed.
+    pub fn with_deps_scheduled(mut self, scheduled: bool) -> Self {
+        self.deps_scheduled = scheduled;
         self
     }
 
@@ -257,35 +273,18 @@ impl ExtInstallCommand {
             return Ok(());
         }
 
-        // Direct `depends_on` edges per extension, used to pick each one's
-        // rpmdb seed source below.
-        let direct_deps: std::collections::HashMap<String, Vec<String>> =
-            match crate::utils::ext_deps::DependencyGraph::from_composed(&composed, &target) {
-                Ok(graph) => extensions_to_install
-                    .iter()
-                    .filter_map(|(name, _)| {
-                        let node = graph.get(name)?;
-                        if node.depends_on.is_empty() {
-                            return None;
-                        }
-                        Some((
-                            name.clone(),
-                            node.depends_on.iter().map(|d| d.name.clone()).collect(),
-                        ))
-                    })
-                    .collect(),
-                Err(_) => std::collections::HashMap::new(),
-            };
+        let graph = crate::utils::ext_deps::DependencyGraph::from_composed(&composed, &target)?;
 
-        // Order dependencies before dependents.
+        // Expand to the dependency closure, then order dependencies before
+        // dependents.
         //
         // This is the *install* order, deliberately the opposite of the
         // runtime manifest's parent-first merge order: a dependency's sysroot
         // has to exist and be fully populated before a dependent can seed its
         // rpmdb from it. Installing alphabetically would seed from an empty or
         // half-built dependency and silently defeat de-duplication.
+        let mut closure_resolved = true;
         let extensions_to_install = {
-            let graph = crate::utils::ext_deps::DependencyGraph::from_composed(&composed, &target)?;
             let requested: Vec<String> = extensions_to_install
                 .iter()
                 .map(|(n, _)| n.clone())
@@ -302,6 +301,41 @@ impl ExtInstallCommand {
                             .unwrap_or(usize::MAX)
                     };
                     let mut ordered = extensions_to_install;
+                    // `ext install kiosk-a` has to install weston-base too.
+                    // kiosk-a's rpmdb is seeded from its dependency's sysroot,
+                    // so a dependency the author never named still has to be
+                    // there — ordering alone would leave the seed source
+                    // absent and the install would fail creating the sysroot.
+                    //
+                    // Every closure member is a key in the composed
+                    // `extensions:` mapping by construction (that mapping is
+                    // what the graph was built from), which is exactly what
+                    // `Local` means here: read the block out of `parsed`. The
+                    // install path treats `Local` and `Remote` identically —
+                    // both read the merged config — so a remote dependency
+                    // needs no separate lookup.
+                    //
+                    // `closure.order` holds each name once, so the set of
+                    // names already present needs no updating as entries are
+                    // appended.
+                    let missing: Vec<String> = if self.deps_scheduled {
+                        vec![]
+                    } else {
+                        let present: HashSet<&String> = ordered.iter().map(|(n, _)| n).collect();
+                        closure
+                            .order
+                            .iter()
+                            .filter(|n| !present.contains(n))
+                            .cloned()
+                            .collect()
+                    };
+                    for name in missing {
+                        let location = ExtensionLocation::Local {
+                            name: name.clone(),
+                            config_path: self.config_path.clone(),
+                        };
+                        ordered.push((name, location));
+                    }
                     ordered.sort_by_key(|(name, _)| position(name));
                     if self.verbose {
                         print_info(
@@ -323,6 +357,7 @@ impl ExtInstallCommand {
                 // still works, just without de-duplication, so do not block
                 // the whole command here.
                 Err(e) => {
+                    closure_resolved = false;
                     if self.verbose {
                         print_info(
                             &format!("Dependency ordering unavailable ({e}); installing as listed"),
@@ -332,6 +367,33 @@ impl ExtInstallCommand {
                     extensions_to_install
                 }
             }
+        };
+
+        // Direct `depends_on` edges per extension, used to pick each one's
+        // rpmdb seed source. Derived *after* the expansion above so a
+        // dependency that was pulled in rather than named gets its own seed
+        // source too — a chain seeds base <- mid <- app, not just the leaf.
+        //
+        // Empty when the graph did not resolve. Seeding reads the dependency's
+        // sysroot, which only a resolved closure guarantees exists; without
+        // one, installing as listed and skipping de-duplication is the
+        // fallback the branch above already documents.
+        let direct_deps: HashMap<String, Vec<String>> = if closure_resolved {
+            extensions_to_install
+                .iter()
+                .filter_map(|(name, _)| {
+                    let node = graph.get(name)?;
+                    if node.depends_on.is_empty() {
+                        return None;
+                    }
+                    Some((
+                        name.clone(),
+                        node.depends_on.iter().map(|d| d.name.clone()).collect(),
+                    ))
+                })
+                .collect()
+        } else {
+            HashMap::new()
         };
 
         let ext_names: Vec<&str> = extensions_to_install

--- a/src/commands/ext/install.rs
+++ b/src/commands/ext/install.rs
@@ -10,7 +10,9 @@ use crate::utils::kernel_resolver::{
 };
 use crate::utils::kernel_version::substitute_kernel_version;
 use crate::utils::lockfile::{build_package_spec_with_lock, LockFile, SysrootType};
-use crate::utils::output::{print_debug, print_error, print_info, print_success, OutputLevel};
+use crate::utils::output::{
+    print_debug, print_error, print_info, print_success, print_warning, OutputLevel,
+};
 use crate::utils::runs_on::RunsOnContext;
 use crate::utils::stamps::{
     compute_ext_install_input_hash, generate_write_stamp_script, Stamp, StampOutputs,
@@ -255,6 +257,83 @@ impl ExtInstallCommand {
             return Ok(());
         }
 
+        // Direct `depends_on` edges per extension, used to pick each one's
+        // rpmdb seed source below.
+        let direct_deps: std::collections::HashMap<String, Vec<String>> =
+            match crate::utils::ext_deps::DependencyGraph::from_composed(&composed, &target) {
+                Ok(graph) => extensions_to_install
+                    .iter()
+                    .filter_map(|(name, _)| {
+                        let node = graph.get(name)?;
+                        if node.depends_on.is_empty() {
+                            return None;
+                        }
+                        Some((
+                            name.clone(),
+                            node.depends_on.iter().map(|d| d.name.clone()).collect(),
+                        ))
+                    })
+                    .collect(),
+                Err(_) => std::collections::HashMap::new(),
+            };
+
+        // Order dependencies before dependents.
+        //
+        // This is the *install* order, deliberately the opposite of the
+        // runtime manifest's parent-first merge order: a dependency's sysroot
+        // has to exist and be fully populated before a dependent can seed its
+        // rpmdb from it. Installing alphabetically would seed from an empty or
+        // half-built dependency and silently defeat de-duplication.
+        let extensions_to_install = {
+            let graph = crate::utils::ext_deps::DependencyGraph::from_composed(&composed, &target)?;
+            let requested: Vec<String> = extensions_to_install
+                .iter()
+                .map(|(n, _)| n.clone())
+                .collect();
+            match graph.resolve(&requested) {
+                Ok(closure) => {
+                    let position = |name: &str| {
+                        closure
+                            .order
+                            .iter()
+                            .position(|n| n == name)
+                            // Anything outside the graph keeps its relative
+                            // place after the ordered members.
+                            .unwrap_or(usize::MAX)
+                    };
+                    let mut ordered = extensions_to_install;
+                    ordered.sort_by_key(|(name, _)| position(name));
+                    if self.verbose {
+                        print_info(
+                            &format!(
+                                "Install order (dependencies first): {}",
+                                ordered
+                                    .iter()
+                                    .map(|(n, _)| n.as_str())
+                                    .collect::<Vec<_>>()
+                                    .join(" -> ")
+                            ),
+                            OutputLevel::Normal,
+                        );
+                    }
+                    ordered
+                }
+                // A graph that will not resolve is reported by the runtime
+                // build with full context. Installing extensions one by one
+                // still works, just without de-duplication, so do not block
+                // the whole command here.
+                Err(e) => {
+                    if self.verbose {
+                        print_info(
+                            &format!("Dependency ordering unavailable ({e}); installing as listed"),
+                            OutputLevel::Normal,
+                        );
+                    }
+                    extensions_to_install
+                }
+            }
+        };
+
         let ext_names: Vec<&str> = extensions_to_install
             .iter()
             .map(|(n, _)| n.as_str())
@@ -309,6 +388,7 @@ impl ExtInstallCommand {
                 config,
                 parsed,
                 &extensions_to_install,
+                &direct_deps,
                 &container_helper,
                 container_image,
                 &target,
@@ -346,6 +426,7 @@ impl ExtInstallCommand {
         config: &Config,
         parsed: &serde_yaml::Value,
         extensions_to_install: &[(String, ExtensionLocation)],
+        direct_deps: &std::collections::HashMap<String, Vec<String>>,
         container_helper: &SdkContainer,
         container_image: &str,
         target: &str,
@@ -403,6 +484,7 @@ impl ExtInstallCommand {
                     &src_dir,
                     runs_on_context,
                     effective_tui_context,
+                    direct_deps.get(ext_name).map(Vec::as_slice).unwrap_or(&[]),
                 )
                 .await?
             {
@@ -543,6 +625,7 @@ impl ExtInstallCommand {
         src_dir: &Path,
         runs_on_context: Option<&RunsOnContext>,
         effective_tui_context: &Option<TuiContext>,
+        direct_deps: &[String],
     ) -> Result<bool> {
         let sysroot = self.extension_sysroot(extension);
 
@@ -599,8 +682,48 @@ impl ExtInstallCommand {
 
         // Check if the sysroot exists (it may have just been cleaned above, or never created)
         let check_command = format!("[ -d $AVOCADO_EXT_SYSROOTS/{extension} ]");
+
+        // Seed this extension's rpmdb — the mechanism that de-duplicates
+        // shared packages.
+        //
+        // An extension's image is the *net-new files* over whatever its rpmdb
+        // already claims is installed. Seeding from the rootfs alone means a
+        // dependency's packages look absent, so dnf installs a second private
+        // copy and both images ship it. Seeding from the dependency's sysroot
+        // instead makes those packages look present, and dnf omits them.
+        //
+        // A chain composes naturally: mid seeds from base (rootfs ∪ base),
+        // app-b then seeds from mid (rootfs ∪ base ∪ mid). Topological install
+        // order guarantees the dependency's sysroot is already populated.
+        let seed_source = match direct_deps {
+            [] => "$AVOCADO_PREFIX/rootfs".to_string(),
+            [only] => format!("$AVOCADO_EXT_SYSROOTS/{only}"),
+            [first, rest @ ..] => {
+                // True diamond. Seeding from one dependency still de-duplicates
+                // that branch; packages unique to the others are not yet
+                // subtracted, so they ship twice. Correct, just not optimal —
+                // say so rather than let it look fully deduplicated.
+                print_warning(
+                    &format!(
+                        "Extension '{extension}' depends on {} extensions; \
+                         de-duplicating against '{first}' only. Packages unique to {} \
+                         may be duplicated in this image.",
+                        direct_deps.len(),
+                        rest.join(", ")
+                    ),
+                    OutputLevel::Normal,
+                );
+                format!("$AVOCADO_EXT_SYSROOTS/{first}")
+            }
+        };
+        if self.verbose && !direct_deps.is_empty() {
+            print_info(
+                &format!("Seeding '{extension}' rpmdb from {seed_source}"),
+                OutputLevel::Normal,
+            );
+        }
         let setup_command = format!(
-            "mkdir -p $AVOCADO_EXT_SYSROOTS/{extension}/var/lib && cp -rf $AVOCADO_PREFIX/rootfs/var/lib/rpm $AVOCADO_EXT_SYSROOTS/{extension}/var/lib"
+            "mkdir -p $AVOCADO_EXT_SYSROOTS/{extension}/var/lib && cp -rf {seed_source}/var/lib/rpm $AVOCADO_EXT_SYSROOTS/{extension}/var/lib"
         );
 
         let run_config = RunConfig {

--- a/src/commands/ext/install.rs
+++ b/src/commands/ext/install.rs
@@ -683,7 +683,20 @@ impl ExtInstallCommand {
             lock_file,
         );
 
-        if needs_clean_reinstall {
+        // The rpmdb seed is applied only when the sysroot is created, so a
+        // surviving sysroot keeps whatever it was seeded from originally.
+        //
+        // That silently defeats de-duplication: an extension first built
+        // before it had a dependency — or before its dependency changed —
+        // keeps a rootfs-seeded rpmdb, dnf sees the shared packages as absent,
+        // and installs a private copy again. The seed source is part of the
+        // sysroot's identity, so any reason to re-seed is a reason to recreate.
+        //
+        // Reaching here at all means the stamp was already judged stale (or
+        // stamps are off), so rebuilding a dependent is not extra work in the
+        // steady state.
+        let reseed_required = !direct_deps.is_empty();
+        if needs_clean_reinstall || self.force || reseed_required {
             // Clean the sysroot so it will be recreated fresh below
             let clean_command = format!(r#"rm -rf "$AVOCADO_EXT_SYSROOTS/{extension}""#);
 

--- a/src/commands/ext/package.rs
+++ b/src/commands/ext/package.rs
@@ -232,6 +232,10 @@ impl ExtPackageCommand {
             );
         }
 
+        // Project `depends_on` / `class` into RPM metadata (see below).
+        let dependency_metadata =
+            self.build_dependency_metadata(&ext_config, &rpm_metadata, &target)?;
+
         // Create main RPM package in container
         // This packages the extension's src_dir (directory containing avocado.yaml)
         let output_path = self
@@ -242,6 +246,7 @@ impl ExtPackageCommand {
                 &ext_config_path,
                 &package_files,
                 &cfg_basename,
+                &dependency_metadata,
             )
             .await?;
 
@@ -491,6 +496,49 @@ impl ExtPackageCommand {
     }
 
     /// Generate summary from extension name
+    /// Project the extension's `depends_on` and `class` into RPM metadata.
+    ///
+    /// Mirrors the existing `supported_targets` → `avocado-target(...)`
+    /// projection: a field of `avocado.yaml` becomes repo metadata, readable
+    /// from `primary.xml` without downloading the package. That is what lets
+    /// the dependency graph be inspected before anything is materialized.
+    ///
+    /// The `Requires:` lines do real work — because the nested layout installs
+    /// every extension into one shared includes installroot, a single
+    /// `dnf install` depsolves and materializes the whole dependency closure
+    /// in one transaction rather than N discovery rounds.
+    ///
+    /// Dependencies are named by the virtual capability `avocado-ext(<name>)`,
+    /// never by the bare RPM name: `source.package` lets a consumer publish an
+    /// extension under a different package name, which would break a literal
+    /// `Requires: <ext-name>`.
+    fn build_dependency_metadata(
+        &self,
+        ext_config: &serde_yaml::Value,
+        metadata: &RpmMetadata,
+        target: &str,
+    ) -> Result<String> {
+        use crate::utils::ext_deps::{rpm_capability, ExtensionClass, ExtensionDependency};
+
+        let mut lines = vec![format!(
+            "Provides: {} = {}",
+            rpm_capability(&self.extension),
+            metadata.version
+        )];
+
+        let class = ExtensionClass::from_ext_config(&self.extension, ext_config)?;
+        lines.push(format!("Provides: avocado-ext-class({})", class.as_str()));
+
+        if let Some(seq) = ext_config.get("depends_on").and_then(|v| v.as_sequence()) {
+            for entry in seq {
+                let dep = ExtensionDependency::parse_entry(&self.extension, entry, target)?;
+                lines.extend(dep.to_rpm_requires()?);
+            }
+        }
+
+        Ok(lines.join("\n"))
+    }
+
     fn generate_summary_from_name(&self, name: &str) -> String {
         // Convert kebab-case to title case
         let words: Vec<&str> = name.split('-').collect();
@@ -525,6 +573,7 @@ impl ExtPackageCommand {
     /// * `target` - The target architecture
     /// * `ext_config_path` - Path to the extension's config file
     /// * `package_files` - List of files/directories to package (supports glob patterns like * and **)
+    #[allow(clippy::too_many_arguments)]
     async fn create_rpm_package_in_container(
         &self,
         metadata: &RpmMetadata,
@@ -533,6 +582,7 @@ impl ExtPackageCommand {
         ext_config_path: &str,
         package_files: &[String],
         cfg_basename: &str,
+        dependency_metadata: &str,
     ) -> Result<PathBuf> {
         let container_image = config
             .get_sdk_image()
@@ -730,6 +780,12 @@ Provides: avocado-ext-layout(nested)
 # query target compatibility without downloading the RPM, and so the feed server can route
 # it to the correct per-target -ext feed(s). "*" means all targets (cross-target).
 {target_provides}
+# Self-describe the inter-extension dependency edges, derived from avocado.yaml
+# `depends_on` / `class`. Dependents require the virtual `avocado-ext(<name>)`
+# capability rather than the RPM name, so a `source.package` rename can't break the
+# edge. Because nested packages share one includes installroot, these Requires let a
+# single `dnf install` materialize the whole closure in one transaction.
+{dependency_metadata}
 
 %description
 {description}
@@ -786,6 +842,7 @@ rm -rf "$TMPDIR"
             description = metadata.description,
             arch = metadata.arch,
             target_provides = target_provides,
+            dependency_metadata = dependency_metadata,
             rpm_filename = rpm_filename,
             container_src_dir = container_src_dir,
             package_files_str = package_files_str,
@@ -979,6 +1036,128 @@ struct RpmMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn dep_metadata(ext_name: &str, ext_yaml: &str) -> String {
+        let cmd = ExtPackageCommand::new(
+            "test.yaml".to_string(),
+            ext_name.to_string(),
+            Some("qemux86-64".to_string()),
+            None,
+            false,
+            None,
+            None,
+        );
+        let ext_config: serde_yaml::Value = serde_yaml::from_str(ext_yaml).unwrap();
+        let metadata = RpmMetadata {
+            name: ext_name.to_string(),
+            version: "0.4.0".to_string(),
+            release: "r0".to_string(),
+            summary: String::new(),
+            description: String::new(),
+            license: String::new(),
+            arch: "x86_64".to_string(),
+            vendor: String::new(),
+            group: String::new(),
+            url: None,
+        };
+        cmd.build_dependency_metadata(&ext_config, &metadata, "qemux86-64")
+            .unwrap()
+    }
+
+    #[test]
+    fn test_dependency_metadata_provides_capability_and_class() {
+        let spec = dep_metadata("app-a", "types: [sysext]\n");
+        assert!(
+            spec.contains("Provides: avocado-ext(app-a) = 0.4.0"),
+            "{spec}"
+        );
+        // class defaults to application when unset
+        assert!(
+            spec.contains("Provides: avocado-ext-class(application)"),
+            "{spec}"
+        );
+        assert!(!spec.contains("Requires:"), "{spec}");
+    }
+
+    #[test]
+    fn test_dependency_metadata_marks_platform_class() {
+        let spec = dep_metadata("weston-base", "class: platform\n");
+        assert!(
+            spec.contains("Provides: avocado-ext-class(platform)"),
+            "{spec}"
+        );
+    }
+
+    #[test]
+    fn test_dependency_metadata_emits_requires_on_virtual_capability() {
+        // Requires must name avocado-ext(...), never the bare RPM name, so a
+        // `source.package` rename can't break the edge.
+        let spec = dep_metadata("app-a", "depends_on: [weston-base]\n");
+        assert!(
+            spec.contains("Requires: avocado-ext(weston-base)"),
+            "{spec}"
+        );
+        assert!(!spec.contains("Requires: weston-base"), "{spec}");
+    }
+
+    #[test]
+    fn test_dependency_metadata_expands_a_version_range() {
+        let spec = dep_metadata(
+            "app-a",
+            "depends_on:\n  - { name: weston-base, version: \"^1.2.0\" }\n",
+        );
+        assert!(
+            spec.contains("Requires: avocado-ext(weston-base) >= 1.2.0"),
+            "{spec}"
+        );
+        assert!(
+            spec.contains("Requires: avocado-ext(weston-base) < 2.0.0"),
+            "{spec}"
+        );
+    }
+
+    #[test]
+    fn test_dependency_metadata_interpolates_templated_dep_names() {
+        let spec = dep_metadata(
+            "app-a",
+            "depends_on: [\"avocado-bsp-{{ avocado.target }}\"]\n",
+        );
+        assert!(
+            spec.contains("Requires: avocado-ext(avocado-bsp-qemux86-64)"),
+            "{spec}"
+        );
+    }
+
+    #[test]
+    fn test_dependency_metadata_rejects_a_bad_version_requirement() {
+        let cmd = ExtPackageCommand::new(
+            "test.yaml".to_string(),
+            "app-a".to_string(),
+            Some("qemux86-64".to_string()),
+            None,
+            false,
+            None,
+            None,
+        );
+        let ext_config: serde_yaml::Value =
+            serde_yaml::from_str("depends_on:\n  - { name: weston-base, version: \"nonsense\" }\n")
+                .unwrap();
+        let metadata = RpmMetadata {
+            name: "app-a".to_string(),
+            version: "0.4.0".to_string(),
+            release: "r0".to_string(),
+            summary: String::new(),
+            description: String::new(),
+            license: String::new(),
+            arch: "x86_64".to_string(),
+            vendor: String::new(),
+            group: String::new(),
+            url: None,
+        };
+        assert!(cmd
+            .build_dependency_metadata(&ext_config, &metadata, "qemux86-64")
+            .is_err());
+    }
 
     #[test]
     fn test_generate_summary_from_name() {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,6 +1,7 @@
 //! Install command implementation that runs SDK, extension, and runtime installs.
 
 use anyhow::{Context, Result};
+use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -15,6 +16,37 @@ use crate::utils::{
     target::validate_and_log_target,
     tui::{TaskId, TaskRenderer, TaskStatus},
 };
+
+/// DAG edges for the ext install tasks: each extension waits on the
+/// dependencies whose sysroots it seeds its rpmdb from.
+///
+/// Edges naming an extension that was not registered as a task are dropped —
+/// waiting on a task that never runs would hang the whole install rather than
+/// just skip de-duplication.
+fn ext_install_edges(
+    ext_task_ids: &[TaskId],
+    direct_deps: &HashMap<String, Vec<String>>,
+) -> Vec<(TaskId, Vec<TaskId>)> {
+    let registered: HashSet<&TaskId> = ext_task_ids.iter().collect();
+    ext_task_ids
+        .iter()
+        .map(|id| {
+            let TaskId::ExtInstall(name) = id else {
+                return (id.clone(), vec![]);
+            };
+            let deps = direct_deps
+                .get(name)
+                .map(|deps| {
+                    deps.iter()
+                        .map(|d| TaskId::ExtInstall(d.clone()))
+                        .filter(|t| registered.contains(t))
+                        .collect()
+                })
+                .unwrap_or_default();
+            (id.clone(), deps)
+        })
+        .collect()
+}
 
 /// Represents an extension dependency
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -255,8 +287,58 @@ impl InstallCommand {
         let parsed = &composed.merged_value;
 
         // Determine which extensions and runtimes to install
-        let extensions_to_install = self.find_required_extensions(&composed, &_target)?;
+        let mut extensions_to_install = self.find_required_extensions(&composed, &_target)?;
         let target_runtimes = self.find_target_relevant_runtimes(config, parsed, &_target)?;
+
+        // Expand `depends_on`. A runtime lists only what its author cares
+        // about, so a shared platform base is named nowhere here — it would
+        // never be installed, and its dependents would have no populated
+        // sysroot to seed their rpmdb from. Pulling the closure in also gives
+        // the DAG below its edges: closure order is dependencies-first, so
+        // pushing in that order registers a base ahead of what needs it.
+        let ext_deps_edges: HashMap<String, Vec<String>> =
+            match crate::utils::ext_deps::DependencyGraph::from_composed(&composed, &_target) {
+                Ok(graph) => {
+                    let authored: Vec<String> = extensions_to_install
+                        .iter()
+                        .map(|e| {
+                            let ExtensionDependency::Local(name) = e;
+                            name.clone()
+                        })
+                        .collect();
+                    match graph.resolve(&authored) {
+                        Ok(closure) => {
+                            let already: HashSet<&String> = authored.iter().collect();
+                            for name in &closure.order {
+                                if !already.contains(name) {
+                                    extensions_to_install
+                                        .push(ExtensionDependency::Local(name.clone()));
+                                }
+                            }
+                            closure
+                                .order
+                                .iter()
+                                .filter_map(|name| {
+                                    let node = graph.get(name)?;
+                                    if node.depends_on.is_empty() {
+                                        return None;
+                                    }
+                                    Some((
+                                        name.clone(),
+                                        node.depends_on.iter().map(|d| d.name.clone()).collect(),
+                                    ))
+                                })
+                                .collect()
+                        }
+                        // A graph that will not resolve is reported with full
+                        // context by `runtime build`. Installing the authored
+                        // list flat is exactly what happened before
+                        // `depends_on` existed, so do not block the install.
+                        Err(_) => HashMap::new(),
+                    }
+                }
+                Err(_) => HashMap::new(),
+            };
 
         // Register ext/runtime tasks now that we know what was fetched.
         // (Sysroot tasks were already registered upfront.)
@@ -287,8 +369,8 @@ impl InstallCommand {
             max_parallel
         };
 
-        // Build DAG: ext installs have no inter-dependencies (parallel),
-        // runtime installs depend on all ext installs completing first.
+        // Build DAG: ext installs run in parallel except along `depends_on`
+        // edges, runtime installs depend on all ext installs completing first.
         if !extensions_to_install.is_empty() || !target_runtimes.is_empty() {
             let mut graph = TaskGraph::new();
 
@@ -300,8 +382,8 @@ impl InstallCommand {
                 })
                 .collect();
 
-            for id in &ext_task_ids {
-                graph.add_task(id.clone(), vec![]);
+            for (id, deps) in ext_install_edges(&ext_task_ids, &ext_deps_edges) {
+                graph.add_task(id, deps);
             }
 
             for rt in &target_runtimes {
@@ -372,7 +454,10 @@ impl InstallCommand {
                                 .with_runs_on(runs_on, nfs_port)
                                 .with_sdk_arch(sdk_arch)
                                 .with_composed_config(composed)
-                                .with_runtime(dual_write_runtime);
+                                .with_runtime(dual_write_runtime)
+                                // The DAG above scheduled every dependency as
+                                // its own task, ordered ahead of this one.
+                                .with_deps_scheduled(true);
                                 if let Some(ctx) = tui_ctx {
                                     cmd = cmd.with_tui_context(ctx);
                                 }
@@ -802,6 +887,25 @@ fn scope_label(scope: &PackageScope) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ext_install_waits_on_the_base_it_seeds_from() {
+        let base = TaskId::ExtInstall("weston-base".to_string());
+        let app = TaskId::ExtInstall("kiosk-a".to_string());
+        let deps = HashMap::from([(
+            "kiosk-a".to_string(),
+            // The second name is deliberately not a registered task.
+            vec!["weston-base".to_string(), "never-scheduled".to_string()],
+        )]);
+
+        let edges: HashMap<TaskId, Vec<TaskId>> =
+            ext_install_edges(&[base.clone(), app.clone()], &deps)
+                .into_iter()
+                .collect();
+
+        assert_eq!(edges[&app], vec![base.clone()]);
+        assert!(edges[&base].is_empty());
+    }
 
     #[test]
     fn test_new() {

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -214,7 +214,6 @@ impl RuntimeBuildCommand {
 
     /// Internal implementation of the build logic
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::too_many_arguments)]
     async fn execute_build_internal(
         &self,
         config: &crate::utils::config::Config,
@@ -2720,7 +2719,9 @@ sign_amf "$AVOCADO_MANIFEST_PATH"
                 print_warning(&warning, OutputLevel::Normal);
             }
 
-            let resolved = graph.resolve_runtime_list(&authored)?;
+            // `closure` above already validated the graph, so order without
+            // re-walking it.
+            let resolved = graph.order_runtime_list(&authored);
 
             if self.verbose {
                 let implied: Vec<&str> = resolved

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -5,7 +5,7 @@ use crate::utils::config::get_post_install;
 use crate::utils::{
     config::{ComposedConfig, Config, ImageConfig},
     container::{RunConfig, SdkContainer, TuiContext},
-    output::{print_error, print_info, print_success, OutputLevel},
+    output::{print_error, print_info, print_success, print_warning, OutputLevel},
     permissions::{mapping_from_hashmap, render_users_groups_script},
     runs_on::RunsOnContext,
     stamps::{
@@ -182,6 +182,7 @@ impl RuntimeBuildCommand {
             .execute_build_internal(
                 config,
                 parsed,
+                &composed,
                 container_image,
                 &target_arch,
                 &merged_container_args,
@@ -213,10 +214,12 @@ impl RuntimeBuildCommand {
 
     /// Internal implementation of the build logic
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     async fn execute_build_internal(
         &self,
         config: &crate::utils::config::Config,
         parsed: &serde_yaml::Value,
+        composed: &ComposedConfig,
         container_image: &str,
         target_arch: &str,
         merged_container_args: &Option<Vec<String>>,
@@ -492,6 +495,7 @@ impl RuntimeBuildCommand {
         let resolved_extensions = self
             .collect_runtime_extensions(
                 parsed,
+                composed,
                 config,
                 &self.runtime_name,
                 target_arch,
@@ -2654,10 +2658,20 @@ sign_amf "$AVOCADO_MANIFEST_PATH"
     /// Returns a list of versioned extension names in the format "ext_name-version"
     /// (e.g., "my-ext-1.0.0"). This ensures AVOCADO_EXT_LIST and the build script
     /// use exact versions from the configuration, not wildcards.
+    ///
+    /// The runtime's `extensions:` list is **author intent**, not the final set:
+    /// each entry's `depends_on` closure is expanded here, so an author names
+    /// only the extensions they care about and the platform bases those depend
+    /// on come along automatically.
+    ///
+    /// Order is parent-first, dependencies flattened underneath — see
+    /// [`crate::utils::ext_deps::DependencyGraph::resolve_runtime_list`]. This
+    /// is merge-priority order, deliberately the opposite of install order.
     #[allow(clippy::too_many_arguments)]
     async fn collect_runtime_extensions(
         &self,
         parsed: &serde_yaml::Value,
+        composed: &ComposedConfig,
         config: &crate::utils::config::Config,
         runtime_name: &str,
         target_arch: &str,
@@ -2683,24 +2697,63 @@ sign_amf "$AVOCADO_MANIFEST_PATH"
             });
 
         if let Some(ext_seq) = ext_list {
-            for ext in ext_seq {
-                if let Some(spec) =
-                    crate::utils::runtime_extension::RuntimeExtensionSpec::parse_entry(ext)
-                {
-                    let ext_name = spec.name.as_str();
-                    let version = self
-                        .resolve_extension_version(
-                            parsed,
-                            config,
-                            config_path,
-                            ext_name,
-                            container_image,
-                            target_arch,
-                            container_args.clone(),
-                        )
-                        .await?;
-                    extensions.push(format!("{ext_name}-{version}"));
+            // What the author actually wrote, in their order. Names are
+            // interpolated so they match the dependency graph's keys.
+            let authored: Vec<String> = ext_seq
+                .iter()
+                .filter_map(crate::utils::runtime_extension::RuntimeExtensionSpec::parse_entry)
+                .map(|spec| crate::utils::interpolation::interpolate_name(&spec.name, target_arch))
+                .collect();
+
+            // Expand `depends_on`. Built from the composed config so a remote
+            // extension that was never fetched is reported as such rather than
+            // silently resolving as dependency-free.
+            let graph =
+                crate::utils::ext_deps::DependencyGraph::from_composed(composed, target_arch)?;
+
+            // Validate the closure and surface advisory lints once, here,
+            // where the runtime being built can be named.
+            let closure = graph.resolve(&authored).with_context(|| {
+                format!("Failed to resolve extension dependencies for runtime '{runtime_name}'")
+            })?;
+            for warning in graph.lint(&closure) {
+                print_warning(&warning, OutputLevel::Normal);
+            }
+
+            let resolved = graph.resolve_runtime_list(&authored)?;
+
+            if self.verbose {
+                let implied: Vec<&str> = resolved
+                    .iter()
+                    .filter(|e| !e.authored)
+                    .map(|e| e.name.as_str())
+                    .collect();
+                if !implied.is_empty() {
+                    print_info(
+                        &format!(
+                            "Runtime '{runtime_name}': pulled in {} dependency extension(s): {}",
+                            implied.len(),
+                            implied.join(", ")
+                        ),
+                        OutputLevel::Normal,
+                    );
                 }
+            }
+
+            for entry in resolved {
+                let ext_name = entry.name.as_str();
+                let version = self
+                    .resolve_extension_version(
+                        parsed,
+                        config,
+                        config_path,
+                        ext_name,
+                        container_image,
+                        target_arch,
+                        container_args.clone(),
+                    )
+                    .await?;
+                extensions.push(format!("{ext_name}-{version}"));
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2798,6 +2798,7 @@ async fn main() -> Result<()> {
                 config,
                 verbose,
                 force,
+                locked,
                 extension,
                 target,
                 container_args,
@@ -2810,7 +2811,8 @@ async fn main() -> Result<()> {
                     target.or(cli.target.clone()),
                     container_args,
                 )
-                .with_sdk_arch(cli.sdk_arch.clone());
+                .with_sdk_arch(cli.sdk_arch.clone())
+                .with_locked(locked);
                 fetch_cmd.execute().await?;
                 Ok(())
             }
@@ -4279,6 +4281,10 @@ enum ExtCommands {
         /// Force re-fetch even if already installed
         #[arg(short, long)]
         force: bool,
+        /// Fail instead of updating avocado.lock when a locked dependency
+        /// cannot satisfy a new requirement. Use this in CI.
+        #[arg(long)]
+        locked: bool,
         /// Extension name (deprecated, use positional argument)
         #[arg(short = 'e', long = "extension", hide = true)]
         extension: Option<String>,

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -1967,7 +1967,23 @@ impl Config {
         }
 
         // For each remote extension, try to read its config
-        for (ext_name, source) in remote_extensions {
+        // Worklist rather than a fixed list. The depsolver can install
+        // extensions the consumer never declared — `app-a` requiring
+        // `avocado-ext(weston-base)` lands weston-base in `includes/` on its
+        // own — and those arrive with no declaration anywhere in the config.
+        // Discovery driven purely by declarations would leave them physically
+        // present but invisible, so every `depends_on` seen while merging is
+        // queued and read from the installroot with the same machinery.
+        //
+        // Scoped to the dependency closure, not everything in `includes/`: a
+        // stale extension left on disk after being removed from the config
+        // must not resurrect itself.
+        let mut queue: std::collections::VecDeque<(String, ExtensionSource)> =
+            remote_extensions.into_iter().collect();
+        let mut queued: std::collections::HashSet<String> =
+            queue.iter().map(|(n, _)| n.clone()).collect();
+
+        while let Some((ext_name, source)) = queue.pop_front() {
             // For a `type: path` source, resolve its host dir directly from the
             // config declaration (relative to src_dir) — the config is the
             // source of truth, so no separate state file is consulted.
@@ -2218,6 +2234,50 @@ impl Config {
                     ));
                 }
             };
+
+            // Queue this extension's own `depends_on` targets. They may live in
+            // a different repo entirely, so they will not be found among its
+            // siblings — but if the depsolver installed them they are sitting
+            // in `includes/` and the next iteration reads them from there.
+            // A dependency that is not installed simply fails its read and is
+            // skipped; the resolver then reports it by name with the chain.
+            if let Some(this_ext) = ext_config
+                .get("extensions")
+                .and_then(|e| e.as_mapping())
+                .and_then(|m| m.get(serde_yaml::Value::String(ext_name.clone())))
+            {
+                for dep_name in crate::utils::ext_deps::dependency_names(this_ext) {
+                    if queued.contains(&dep_name) {
+                        continue;
+                    }
+                    // Already declared by the consumer — their declaration and
+                    // its own source win; nothing to discover.
+                    if main_config
+                        .get("extensions")
+                        .and_then(|e| e.as_mapping())
+                        .map(|m| Self::find_matching_ext_key(m, &dep_name).is_some())
+                        .unwrap_or(false)
+                    {
+                        continue;
+                    }
+                    if verbose {
+                        eprintln!(
+                            "[DEBUG] Queuing dependency '{dep_name}' of '{ext_name}' for discovery"
+                        );
+                    }
+                    queued.insert(dep_name.clone());
+                    // Version "*" — whatever the depsolver actually installed.
+                    queue.push_back((
+                        dep_name,
+                        ExtensionSource::Package {
+                            version: "*".to_string(),
+                            package: None,
+                            repo_name: None,
+                            include: None,
+                        },
+                    ));
+                }
+            }
 
             // Record this extension's source path
             // For path-based extensions, use the actual host path — recording
@@ -2490,6 +2550,67 @@ impl Config {
         }
     }
 
+    /// Pull in extension declarations that the just-merged extension
+    /// `depends_on`, when they are defined alongside it in the same external
+    /// config.
+    ///
+    /// A remote extension's `avocado.yaml` normally declares both itself and
+    /// the platform bases it binds to:
+    ///
+    /// ```yaml
+    /// extensions:
+    ///   app-a:
+    ///     depends_on: [weston-base]
+    ///   weston-base:
+    ///     source: { type: package, version: "1.2.0" }
+    /// ```
+    ///
+    /// [`Self::merge_external_config`] otherwise merges *only*
+    /// `extensions.app-a`, so `weston-base` would never appear in the composed
+    /// config — never be discovered as a remote extension, never be fetched,
+    /// and the dependency would be unresolvable no matter how many times
+    /// `avocado ext fetch` runs.
+    ///
+    /// Scoped deliberately to the `depends_on` closure rather than every
+    /// sibling: a remote repo may define a whole catalog of extensions, and
+    /// dumping all of them into the consumer's namespace would be a surprising
+    /// side effect of depending on one. Consumer declarations always win — an
+    /// extension already present in the main config is left untouched, so the
+    /// author keeps the final say on version and source.
+    fn merge_external_dependency_declarations(
+        main_ext_map: &mut serde_yaml::Mapping,
+        external_ext: &serde_yaml::Mapping,
+        root_ext_value: &serde_yaml::Value,
+    ) {
+        let mut queue: Vec<String> = crate::utils::ext_deps::dependency_names(root_ext_value);
+        let mut visited: std::collections::HashSet<String> = queue.iter().cloned().collect();
+
+        while let Some(dep_name) = queue.pop() {
+            // The dependency name and the sibling key come from the same file,
+            // so any `{{ … }}` templating is textually identical on both sides
+            // and a direct key match is sufficient — no interpolation needed.
+            let dep_key = serde_yaml::Value::String(dep_name.clone());
+            let Some(dep_value) = external_ext.get(&dep_key) else {
+                continue;
+            };
+
+            // Already declared by the consumer (possibly under a template
+            // key) — their declaration wins, and its own dependencies will be
+            // resolved from wherever they declared it.
+            if Self::find_matching_ext_key(main_ext_map, &dep_name).is_some() {
+                continue;
+            }
+
+            for next in crate::utils::ext_deps::dependency_names(dep_value) {
+                if visited.insert(next.clone()) {
+                    queue.push(next);
+                }
+            }
+
+            main_ext_map.insert(dep_key, dep_value.clone());
+        }
+    }
+
     /// Merge an external config into the main config.
     ///
     /// Always merges:
@@ -2571,6 +2692,8 @@ impl Config {
                     });
 
                 if let Some(ext_value) = ext_value {
+                    let ext_value = ext_value.clone();
+
                     // Try to find the existing key in main config that matches ext_name.
                     // This handles template keys like "avocado-bsp-{{ avocado.target }}"
                     // that interpolate to "avocado-bsp-raspberrypi4".
@@ -2581,12 +2704,18 @@ impl Config {
                         if let Some(existing_ext) = main_ext_map.get_mut(&existing_key) {
                             // Deep-merge: add fields from remote that don't exist in main
                             // Main config values take precedence on conflicts
-                            Self::deep_merge_ext_section(existing_ext, ext_value);
+                            Self::deep_merge_ext_section(existing_ext, &ext_value);
                         }
                     } else {
                         // Extension not in main config, just add it
                         main_ext_map.insert(ext_key, ext_value.clone());
                     }
+
+                    Self::merge_external_dependency_declarations(
+                        main_ext_map,
+                        external_ext,
+                        &ext_value,
+                    );
                 }
             }
         }
@@ -9327,6 +9456,186 @@ extensions:
         let ext_section = main_config.get("extensions").unwrap().as_mapping().unwrap();
         assert!(ext_section.contains_key(serde_yaml::Value::String("local-ext".to_string())));
         assert!(ext_section.contains_key(serde_yaml::Value::String("external-ext".to_string())));
+    }
+
+    /// Helper: run `merge_external_config` and return the resulting
+    /// `extensions:` mapping.
+    fn merge_and_get_ext_section(
+        main: &str,
+        external: &str,
+        ext_name: &str,
+    ) -> serde_yaml::Mapping {
+        let mut main_config: serde_yaml::Value = serde_yaml::from_str(main).unwrap();
+        let external_config: serde_yaml::Value = serde_yaml::from_str(external).unwrap();
+        Config::merge_external_config(&mut main_config, &external_config, ext_name, &[], &[]);
+        main_config
+            .get("extensions")
+            .unwrap()
+            .as_mapping()
+            .unwrap()
+            .clone()
+    }
+
+    fn ext_entry<'a>(
+        section: &'a serde_yaml::Mapping,
+        name: &str,
+    ) -> Option<&'a serde_yaml::Value> {
+        section.get(serde_yaml::Value::String(name.to_string()))
+    }
+
+    #[test]
+    fn test_depends_on_target_declared_alongside_is_pulled_in() {
+        // A remote extension normally declares both itself and the platform
+        // base it binds to. Without pulling the base in, it never appears in
+        // the composed config, is never discovered as a remote extension, and
+        // is never fetched — the dependency stays unresolvable forever.
+        let external = r#"
+extensions:
+  app-a:
+    types: [sysext]
+    depends_on: [weston-base]
+  weston-base:
+    class: platform
+    source: { type: package, version: "1.2.0" }
+"#;
+        let section = merge_and_get_ext_section("extensions: {}\n", external, "app-a");
+
+        assert!(ext_entry(&section, "app-a").is_some());
+        let base = ext_entry(&section, "weston-base").expect("dependency should be pulled in");
+        assert_eq!(
+            base.get("source")
+                .and_then(|s| s.get("type"))
+                .and_then(|v| v.as_str()),
+            Some("package")
+        );
+    }
+
+    #[test]
+    fn test_depends_on_pull_in_is_transitive_within_one_config() {
+        let external = r#"
+extensions:
+  app-a:
+    depends_on: [mid]
+  mid:
+    class: platform
+    depends_on: [base]
+    source: { type: package, version: "2.0.0" }
+  base:
+    class: platform
+    source: { type: package, version: "3.0.0" }
+"#;
+        let section = merge_and_get_ext_section("extensions: {}\n", external, "app-a");
+
+        assert!(ext_entry(&section, "mid").is_some());
+        assert!(
+            ext_entry(&section, "base").is_some(),
+            "transitive dep missing"
+        );
+    }
+
+    #[test]
+    fn test_unrelated_siblings_are_not_pulled_in() {
+        // A remote repo may define a whole catalog. Depending on one extension
+        // must not drag the rest into the consumer's namespace.
+        let external = r#"
+extensions:
+  app-a:
+    depends_on: [weston-base]
+  weston-base:
+    class: platform
+  unrelated-thing:
+    types: [sysext]
+  another-unrelated:
+    types: [confext]
+"#;
+        let section = merge_and_get_ext_section("extensions: {}\n", external, "app-a");
+
+        assert!(ext_entry(&section, "weston-base").is_some());
+        assert!(ext_entry(&section, "unrelated-thing").is_none());
+        assert!(ext_entry(&section, "another-unrelated").is_none());
+    }
+
+    #[test]
+    fn test_consumer_declaration_of_a_dependency_wins() {
+        // The author pinned their own version/source for the base. Pulling in
+        // the remote's declaration on top would silently override their pin.
+        let main = r#"
+extensions:
+  weston-base:
+    source: { type: package, version: "9.9.9" }
+"#;
+        let external = r#"
+extensions:
+  app-a:
+    depends_on: [weston-base]
+  weston-base:
+    source: { type: package, version: "1.2.0" }
+"#;
+        let section = merge_and_get_ext_section(main, external, "app-a");
+
+        let base = ext_entry(&section, "weston-base").unwrap();
+        assert_eq!(
+            base.get("source")
+                .and_then(|s| s.get("version"))
+                .and_then(|v| v.as_str()),
+            Some("9.9.9"),
+            "consumer's pin must survive"
+        );
+    }
+
+    #[test]
+    fn test_depends_on_pull_in_handles_all_entry_shapes() {
+        let external = r#"
+extensions:
+  app-a:
+    depends_on:
+      - plain-base
+      - { name: explicit-base, version: ">=1.0.0" }
+      - { shorthand-base: "^2" }
+  plain-base: { class: platform }
+  explicit-base: { class: platform }
+  shorthand-base: { class: platform }
+"#;
+        let section = merge_and_get_ext_section("extensions: {}\n", external, "app-a");
+
+        assert!(ext_entry(&section, "plain-base").is_some());
+        assert!(ext_entry(&section, "explicit-base").is_some());
+        assert!(ext_entry(&section, "shorthand-base").is_some());
+    }
+
+    #[test]
+    fn test_depends_on_naming_an_absent_sibling_is_not_an_error_here() {
+        // The dependency may legitimately live in the consumer's config or a
+        // different feed. Composition stays silent; the resolver produces the
+        // "not defined" diagnostic, where it can name the whole chain.
+        let external = r#"
+extensions:
+  app-a:
+    depends_on: [elsewhere-base]
+"#;
+        let section = merge_and_get_ext_section("extensions: {}\n", external, "app-a");
+
+        assert!(ext_entry(&section, "app-a").is_some());
+        assert!(ext_entry(&section, "elsewhere-base").is_none());
+    }
+
+    #[test]
+    fn test_depends_on_cycle_between_siblings_terminates() {
+        // Cycles are the resolver's diagnostic to produce, but composition
+        // must not hang or blow the stack on the way there.
+        let external = r#"
+extensions:
+  app-a:
+    depends_on: [b]
+  b:
+    depends_on: [c]
+  c:
+    depends_on: [b]
+"#;
+        let section = merge_and_get_ext_section("extensions: {}\n", external, "app-a");
+
+        assert!(ext_entry(&section, "b").is_some());
+        assert!(ext_entry(&section, "c").is_some());
     }
 
     #[test]

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -4719,6 +4719,17 @@ impl Config {
     /// Find an extension in the full dependency tree (local and external)
     /// This is a comprehensive search that looks through all runtime dependencies
     /// and their transitive extension dependencies
+    /// Whether `extensions.<name>` exists in an already-interpolated value.
+    fn find_ext_key(parsed: &serde_yaml::Value, extension_name: &str) -> Option<()> {
+        parsed
+            .get("extensions")?
+            .as_mapping()?
+            .keys()
+            .filter_map(|k| k.as_str())
+            .any(|k| k == extension_name)
+            .then_some(())
+    }
+
     pub fn find_extension_in_dependency_tree(
         &self,
         config_path: &str,
@@ -4726,8 +4737,24 @@ impl Config {
         target: &str,
     ) -> Result<Option<ExtensionLocation>> {
         let content = std::fs::read_to_string(config_path)?;
-        let parsed =
+        let mut parsed =
             Self::parse_config_value_with_interpolation(config_path, &content, Some(target))?;
+
+        // Reading only the on-disk file misses extensions the depsolver pulled
+        // in: a `depends_on` target is named nowhere in the consumer's yaml, so
+        // `ext install <that name>` reported "not found in configuration" for
+        // an extension `ext list` had just shown. Fall back to the composed
+        // value, which merges the installroot.
+        //
+        // Composition is the slower path, so it is only consulted when the
+        // cheap lookup comes up empty.
+        if Self::find_ext_key(&parsed, extension_name).is_none() {
+            if let Ok(composed) = Self::load_composed(config_path, Some(target)) {
+                if Self::find_ext_key(&composed.merged_value, extension_name).is_some() {
+                    parsed = composed.merged_value;
+                }
+            }
+        }
 
         // First check if it's defined in the ext section.
         // Keys are already interpolated by parse_config_value_with_interpolation.

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -2241,10 +2241,15 @@ impl Config {
             // in `includes/` and the next iteration reads them from there.
             // A dependency that is not installed simply fails its read and is
             // skipped; the resolver then reports it by name with the chain.
+            // Template-aware: a remote extension may key its own section with
+            // a template (`avocado-bsp-{{ avocado.target }}`) while `ext_name`
+            // is already interpolated. An exact-key lookup silently misses
+            // those, and their `depends_on` targets would never be queued —
+            // which is precisely the BSP-shaped case.
             if let Some(this_ext) = ext_config
                 .get("extensions")
                 .and_then(|e| e.as_mapping())
-                .and_then(|m| m.get(serde_yaml::Value::String(ext_name.clone())))
+                .and_then(|m| Self::find_matching_ext_key(m, &ext_name).and_then(|k| m.get(&k)))
             {
                 for dep_name in crate::utils::ext_deps::dependency_names(this_ext) {
                     if queued.contains(&dep_name) {

--- a/src/utils/ext_deps.rs
+++ b/src/utils/ext_deps.rs
@@ -818,7 +818,17 @@ impl DependencyGraph {
         // Validate the whole closure up front — reuses the cycle, missing-dep,
         // and unfetched-stub diagnostics rather than reimplementing them.
         self.resolve(authored)?;
+        Ok(self.order_runtime_list(authored))
+    }
 
+    /// Order an already-validated closure. Callers that resolved for another
+    /// reason (linting, diagnostics) use this to avoid walking the graph twice.
+    ///
+    /// Ordering only reads edges, so it cannot surface a cycle or a missing
+    /// dependency — passing an unvalidated set here would silently truncate
+    /// rather than report. Use [`Self::resolve_runtime_list`] unless a
+    /// successful [`Self::resolve`] is already in hand.
+    pub fn order_runtime_list(&self, authored: &[String]) -> Vec<RuntimeEntry> {
         let authored_set: HashSet<&str> = authored.iter().map(String::as_str).collect();
         let mut emitted: HashSet<String> = HashSet::new();
         let mut out: Vec<RuntimeEntry> = Vec::new();
@@ -835,7 +845,7 @@ impl DependencyGraph {
             self.push_implied(name, &authored_set, &mut emitted, &mut out);
         }
 
-        Ok(out)
+        out
     }
 
     fn push_implied(

--- a/src/utils/ext_deps.rs
+++ b/src/utils/ext_deps.rs
@@ -332,6 +332,100 @@ impl ExtensionDependency {
     }
 }
 
+/// Whether moving from `was` to `now` is a downgrade, by rpm version ordering.
+///
+/// Used to distinguish a dependency being pulled *forward* (routine — the lock
+/// records a solution, and a changed constraint means a new solution) from one
+/// being dragged *backward*, which has no benign reading: it means something
+/// old is constraining a shared base below what is already deployed.
+///
+/// Implements rpmvercmp's segment rule rather than semver: these are RPM
+/// `VERSION-RELEASE` strings, where `1.10 > 1.9` and a numeric segment always
+/// outranks an alphabetic one. A `~` segment sorts *before* everything, which
+/// is how pre-releases order.
+pub fn is_rpm_downgrade(was: &str, now: &str) -> bool {
+    rpm_vercmp(was, now) == std::cmp::Ordering::Greater
+}
+
+/// Compare two RPM version strings, rpmvercmp-style.
+fn rpm_vercmp(a: &str, b: &str) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+
+    let mut a = a.chars().peekable();
+    let mut b = b.chars().peekable();
+
+    loop {
+        // `~` sorts before everything, including the empty string.
+        let a_tilde = a.peek() == Some(&'~');
+        let b_tilde = b.peek() == Some(&'~');
+        if a_tilde || b_tilde {
+            match (a_tilde, b_tilde) {
+                (true, true) => {
+                    a.next();
+                    b.next();
+                    continue;
+                }
+                (true, false) => return Ordering::Less,
+                (false, true) => return Ordering::Greater,
+                _ => unreachable!(),
+            }
+        }
+
+        // Skip separators.
+        while a.peek().is_some_and(|c| !c.is_alphanumeric() && *c != '~') {
+            a.next();
+        }
+        while b.peek().is_some_and(|c| !c.is_alphanumeric() && *c != '~') {
+            b.next();
+        }
+
+        match (a.peek().copied(), b.peek().copied()) {
+            (None, None) => return Ordering::Equal,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some(ca), Some(cb)) => {
+                let a_num = ca.is_ascii_digit();
+                let b_num = cb.is_ascii_digit();
+                // A numeric segment always outranks an alphabetic one.
+                if a_num != b_num {
+                    return if a_num {
+                        Ordering::Greater
+                    } else {
+                        Ordering::Less
+                    };
+                }
+
+                let take = |it: &mut std::iter::Peekable<std::str::Chars>, numeric: bool| {
+                    let mut s = String::new();
+                    while let Some(&c) = it.peek() {
+                        if numeric && c.is_ascii_digit() || !numeric && c.is_alphabetic() {
+                            s.push(c);
+                            it.next();
+                        } else {
+                            break;
+                        }
+                    }
+                    s
+                };
+                let sa = take(&mut a, a_num);
+                let sb = take(&mut b, b_num);
+
+                let ord = if a_num {
+                    // Strip leading zeros, then longer digit run wins.
+                    let ta = sa.trim_start_matches('0');
+                    let tb = sb.trim_start_matches('0');
+                    ta.len().cmp(&tb.len()).then_with(|| ta.cmp(tb))
+                } else {
+                    sa.cmp(&sb)
+                };
+                if ord != Ordering::Equal {
+                    return ord;
+                }
+            }
+        }
+    }
+}
+
 /// Extract just the extension *names* from a `depends_on:` list, ignoring
 /// version constraints and tolerating malformed entries.
 ///
@@ -1156,6 +1250,65 @@ mod tests {
         let err = g.resolve(&roots(&["ghost"])).unwrap_err().to_string();
         assert!(err.contains("'ghost' is not defined"), "{err}");
         assert!(!err.contains("Required by"), "{err}");
+    }
+
+    // ---- rpm version ordering (downgrade detection) ----------------------
+
+    #[test]
+    fn forward_moves_are_not_downgrades() {
+        assert!(!is_rpm_downgrade("1.2.0-r0", "1.3.0-r0"));
+        assert!(!is_rpm_downgrade("1.2.0-r0", "2.0.0-r0"));
+        // Release bump only.
+        assert!(!is_rpm_downgrade("1.2.0-r0", "1.2.0-r1"));
+    }
+
+    #[test]
+    fn backward_moves_are_downgrades() {
+        assert!(is_rpm_downgrade("1.3.0-r0", "1.2.0-r0"));
+        assert!(is_rpm_downgrade("2.0.0-r0", "1.9.9-r0"));
+        assert!(is_rpm_downgrade("1.2.0-r1", "1.2.0-r0"));
+    }
+
+    #[test]
+    fn equal_versions_are_not_downgrades() {
+        assert!(!is_rpm_downgrade("1.2.0-r0", "1.2.0-r0"));
+    }
+
+    #[test]
+    fn numeric_segments_compare_numerically_not_lexically() {
+        // The classic rpm/semver trap: "1.10" > "1.9" despite sorting lower
+        // as a string. Getting this wrong would flag a routine upgrade as a
+        // downgrade and block the build.
+        assert!(!is_rpm_downgrade("1.9.0-r0", "1.10.0-r0"));
+        assert!(is_rpm_downgrade("1.10.0-r0", "1.9.0-r0"));
+    }
+
+    #[test]
+    fn leading_zeros_do_not_change_ordering() {
+        assert!(!is_rpm_downgrade("1.02.0-r0", "1.2.0-r0"));
+        assert!(!is_rpm_downgrade("1.2.0-r0", "1.02.0-r0"));
+    }
+
+    #[test]
+    fn tilde_sorts_before_its_release_like_a_prerelease() {
+        // rpm's `~` is how our caret expansion encodes pre-releases, so
+        // 1.2.0~rc.1 must precede 1.2.0 — moving rc -> final is an upgrade,
+        // and final -> rc is a downgrade.
+        assert!(!is_rpm_downgrade("1.2.0~rc.1-r0", "1.2.0-r0"));
+        assert!(is_rpm_downgrade("1.2.0-r0", "1.2.0~rc.1-r0"));
+    }
+
+    #[test]
+    fn numeric_outranks_alphabetic() {
+        // rpmvercmp: a digit segment beats a letter segment.
+        assert!(is_rpm_downgrade("1.2.1-r0", "1.2.a-r0"));
+        assert!(!is_rpm_downgrade("1.2.a-r0", "1.2.1-r0"));
+    }
+
+    #[test]
+    fn a_longer_version_with_equal_prefix_is_newer() {
+        assert!(!is_rpm_downgrade("1.2-r0", "1.2.1-r0"));
+        assert!(is_rpm_downgrade("1.2.1-r0", "1.2-r0"));
     }
 
     // ---- RPM realization -------------------------------------------------

--- a/src/utils/ext_deps.rs
+++ b/src/utils/ext_deps.rs
@@ -766,11 +766,51 @@ impl DependencyGraph {
         chain.push(&node.name);
         for dep in &node.depends_on {
             self.visit(&dep.name, marks, chain, order)?;
+            self.check_edge_version(&node.name, dep)?;
         }
         chain.pop();
         marks.insert(&node.name, Mark::Done);
         order.push(node.name.clone());
 
+        Ok(())
+    }
+
+    /// Reject an edge whose constraint cannot hold against the version its
+    /// target declares.
+    ///
+    /// Only RPM-backed edges are checked by anything else: `ext package`
+    /// emits `Requires: avocado-ext(base) >= …` and dnf enforces it at
+    /// install. An inline, `path`, or `git` extension never reaches a solver,
+    /// so `depends_on: { name: base, version: "^2" }` against a base
+    /// declaring `version: "1.0.0"` would otherwise resolve, install, and
+    /// ship — the constraint silently doing nothing.
+    ///
+    /// Two cases are deliberately not errors, because in both there is
+    /// nothing to compare against:
+    /// - the target declares no `version:` at all — most inline extensions
+    ///   don't, and it is `ext build` that requires one;
+    /// - the target's version is not parseable as strict semver.
+    ///   [`crate::utils::version::validate_semver`] is looser (it accepts a
+    ///   fourth component), so refusing here would reject configs that build
+    ///   fine today. RPM still compares them at install.
+    fn check_edge_version(&self, from: &str, dep: &ExtensionDependency) -> Result<()> {
+        let Some(req) = dep.version_req()? else {
+            return Ok(());
+        };
+        let Some(raw) = self.nodes.get(&dep.name).and_then(|n| n.version.as_deref()) else {
+            return Ok(());
+        };
+        let Ok(version) = semver::Version::parse(raw) else {
+            return Ok(());
+        };
+        if !req.matches(&version) {
+            bail!(
+                "Extension '{from}' requires '{}' {req}, but '{}' declares version {raw}.\n\
+                 Relax the `depends_on` constraint or update the dependency.",
+                dep.name,
+                dep.name,
+            );
+        }
         Ok(())
     }
 
@@ -1260,6 +1300,53 @@ mod tests {
         let err = g.resolve(&roots(&["ghost"])).unwrap_err().to_string();
         assert!(err.contains("'ghost' is not defined"), "{err}");
         assert!(!err.contains("Required by"), "{err}");
+    }
+
+    // ---- edge version constraints ----------------------------------------
+
+    #[test]
+    fn unsatisfiable_constraint_is_rejected() {
+        // Nothing else would catch this: only an RPM-backed edge gets a
+        // `Requires:` line for dnf to enforce.
+        let g = graph(
+            "extensions:\n\
+             \x20 base: { version: \"1.0.0\" }\n\
+             \x20 app-a:\n\
+             \x20   depends_on:\n\
+             \x20     - { name: base, version: \"^2\" }\n",
+        );
+        let err = g.resolve(&roots(&["app-a"])).unwrap_err().to_string();
+        assert!(err.contains("'app-a' requires 'base'"), "{err}");
+        assert!(err.contains("declares version 1.0.0"), "{err}");
+    }
+
+    #[test]
+    fn satisfied_constraint_resolves() {
+        let g = graph(
+            "extensions:\n\
+             \x20 base: { version: \"1.4.2\" }\n\
+             \x20 app-a:\n\
+             \x20   depends_on:\n\
+             \x20     - { name: base, version: \">=1.2.0\" }\n",
+        );
+        let c = g.resolve(&roots(&["app-a"])).unwrap();
+        assert_eq!(c.order, vec!["base", "app-a"]);
+    }
+
+    #[test]
+    fn unverifiable_versions_are_left_to_rpm() {
+        // No `version:` to compare against, and a version too loose for strict
+        // semver — neither is an error here (see `check_edge_version`).
+        let g = graph(
+            "extensions:\n\
+             \x20 base: {}\n\
+             \x20 four-part: { version: \"1.2.3.4\" }\n\
+             \x20 app-a:\n\
+             \x20   depends_on:\n\
+             \x20     - { name: base, version: \"^2\" }\n\
+             \x20     - { name: four-part, version: \"^9\" }\n",
+        );
+        assert!(g.resolve(&roots(&["app-a"])).is_ok());
     }
 
     // ---- rpm version ordering (downgrade detection) ----------------------

--- a/src/utils/ext_deps.rs
+++ b/src/utils/ext_deps.rs
@@ -1,0 +1,1531 @@
+//! Inter-extension dependencies — declaration, closure expansion, ordering.
+//!
+//! An extension can declare that it is only meaningful when another extension
+//! is merged alongside it. The canonical spelling is `depends_on`:
+//!
+//! ```yaml
+//! extensions:
+//!   weston-base:              # the shared platform base
+//!     version: "1.2.0"
+//!     class: platform
+//!     packages: { weston: '*', wayland: '*' }
+//!
+//!   app-a:                    # binds to it
+//!     version: "0.4.0"
+//!     depends_on:
+//!       - weston-base                            # any version
+//!       - { name: gfx-core, version: ">=1.2.0" } # constrained
+//! ```
+//!
+//! A distinct verb — not overloading the word `extensions`, not buried under
+//! `packages`, and not colliding with RPM's own `Requires:` — so the
+//! extension-to-extension edge is unmistakable at a glance.
+//!
+//! # Where resolution happens
+//!
+//! Resolution is a **build-side** concern. The author lists *intent* (just the
+//! extensions they care about); the build expands the `depends_on` closure and
+//! seals the complete ordered set into the runtime manifest. The device never
+//! runs a solver — it only verifies and merges what the manifest already spells
+//! out. Everything in this module therefore runs on the host, and every failure
+//! it can produce is a build-time failure.
+//!
+//! # Two orderings, deliberately opposite
+//!
+//! - [`DependencyGraph::resolve`] orders **dependencies first**. This is an
+//!   *install* order: a dependency's sysroot must exist before anything can be
+//!   seeded from it.
+//! - [`DependencyGraph::resolve_runtime_list`] orders **parents first**, each
+//!   followed by what it pulls in. This is a *merge priority* order: avocadoctl
+//!   treats earlier entries as higher priority, so an application must precede
+//!   the platform base it depends on in order to win a file conflict against
+//!   it.
+//!
+//! Using one for the other silently inverts merge precedence, so they are named
+//! for their job rather than for their shape.
+//!
+//! # What this module does *not* do
+//!
+//! It resolves names and order only. Seeding an extension's rpmdb from its
+//! dependencies (the mechanism that makes shared packages ship exactly once),
+//! comparing version constraints against what a dependency actually shipped,
+//! and content-pinning the sealed edges are separate, later stages that
+//! consume the [`ResolvedClosure`] produced here.
+
+// Resolve-only stage: the graph, its errors, and its lints are complete and
+// tested, but no command calls them yet. The call sites (`ext install`
+// ordering, `runtime build` closure sealing, `ext tree`) land in the following
+// stages; drop this allow once the first one is wired up.
+#![allow(dead_code)]
+
+use anyhow::{bail, Context, Result};
+use semver::VersionReq;
+use serde_yaml::Value;
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::utils::config::ComposedConfig;
+use crate::utils::interpolation::interpolate_name;
+
+/// The role an extension plays in the dependency graph.
+///
+/// `depends_on` targets are *expected* to be `platform` — shared, ABI-stable
+/// bases (a weston base, the `avocado-bsp-<board>` layer) released on a slower
+/// cadence than the applications binding to them. An application depending on
+/// another application is a smell (the shared part wants factoring out), so it
+/// draws a lint warning rather than a hard error: it is a convention that keeps
+/// the common case legible, not a gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExtensionClass {
+    /// Default. A leaf extension that delivers a feature.
+    #[default]
+    Application,
+    /// A shared, ABI-stable base that other extensions depend on.
+    Platform,
+}
+
+impl ExtensionClass {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Application => "application",
+            Self::Platform => "platform",
+        }
+    }
+
+    /// Read `class:` off an extension's config block. Absent → `application`.
+    ///
+    /// An unrecognized value is an error, not a silent fall back to the
+    /// default: a typo'd `class: platfrom` that quietly became an application
+    /// would disable the very lint the key exists to drive.
+    pub fn from_ext_config(ext_name: &str, ext: &Value) -> Result<Self> {
+        let Some(raw) = ext.get("class") else {
+            return Ok(Self::default());
+        };
+        let as_str = raw.as_str().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Extension '{ext_name}': `class` must be a string, one of \
+                 'application' or 'platform'."
+            )
+        })?;
+        match as_str {
+            "application" => Ok(Self::Application),
+            "platform" => Ok(Self::Platform),
+            other => bail!(
+                "Extension '{ext_name}': unknown `class` value '{other}'. \
+                 Expected 'application' (the default) or 'platform'."
+            ),
+        }
+    }
+}
+
+/// One entry in an extension's `depends_on:` list.
+///
+/// Three spellings are accepted, all unambiguous:
+///
+/// | YAML                                        | Meaning                     |
+/// |---------------------------------------------|-----------------------------|
+/// | `- weston-base`                             | any version                 |
+/// | `- { name: weston-base, version: ">=1.2" }` | explicit form               |
+/// | `- { weston-base: ">=1.2" }`                | single-key shorthand        |
+///
+/// The explicit form is recognized by the presence of a `name` key, which is
+/// also the escape hatch for an extension literally named `name`.
+///
+/// `version` is a standard semver *requirement* (`>=1.2.0`, `^1.2`, `*`,
+/// `>=1.2, <2`), the same syntax `cli_requirement` uses. Note that a bare
+/// `1.2.0` therefore means `^1.2.0`, not an exact pin — write `=1.2.0` for
+/// that.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtensionDependency {
+    /// Target extension name, already interpolated (no `{{ … }}` left).
+    pub name: String,
+    /// Semver requirement, or `None` for "any version".
+    pub version: Option<String>,
+}
+
+impl ExtensionDependency {
+    /// Parse one `depends_on:` entry. `target` interpolates template names
+    /// such as `avocado-bsp-{{ avocado.target }}`.
+    pub fn parse_entry(ext_name: &str, value: &Value, target: &str) -> Result<Self> {
+        // `- weston-base`
+        if let Some(s) = value.as_str() {
+            return Ok(Self {
+                name: interpolate_name(s, target),
+                version: None,
+            });
+        }
+
+        let mapping = value.as_mapping().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Extension '{ext_name}': each `depends_on` entry must be an extension \
+                 name or a mapping, got {}.",
+                describe(value)
+            )
+        })?;
+
+        // `- { name: weston-base, version: ">=1.2.0" }`
+        if let Some(name_val) = mapping.get("name") {
+            let name = name_val.as_str().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Extension '{ext_name}': `depends_on` entry has a non-string `name`."
+                )
+            })?;
+            let version = match mapping.get("version") {
+                Some(v) => Some(require_version_string(ext_name, name, v)?),
+                None => None,
+            };
+            return Self::new(ext_name, interpolate_name(name, target), version);
+        }
+
+        // `- { weston-base: ">=1.2.0" }` / `- { weston-base: { version: … } }`
+        if mapping.len() != 1 {
+            bail!(
+                "Extension '{ext_name}': ambiguous `depends_on` entry with {} keys. \
+                 Use `- {{ name: <ext>, version: <req> }}` for the explicit form.",
+                mapping.len()
+            );
+        }
+        let (key, opts) = mapping.iter().next().expect("len checked above");
+        let name = key.as_str().ok_or_else(|| {
+            anyhow::anyhow!("Extension '{ext_name}': `depends_on` entry has a non-string key.")
+        })?;
+        let version = if opts.is_null() {
+            None
+        } else if let Some(sub) = opts.as_mapping() {
+            match sub.get("version") {
+                Some(v) => Some(require_version_string(ext_name, name, v)?),
+                None => None,
+            }
+        } else {
+            Some(require_version_string(ext_name, name, opts)?)
+        };
+        Self::new(ext_name, interpolate_name(name, target), version)
+    }
+
+    fn new(ext_name: &str, name: String, version: Option<String>) -> Result<Self> {
+        if name.trim().is_empty() {
+            bail!("Extension '{ext_name}': `depends_on` entry has an empty extension name.");
+        }
+        let dep = Self { name, version };
+        // Validate the constraint here so a typo fails at parse with the
+        // offending extension named, rather than deep inside the resolver.
+        dep.version_req()?;
+        Ok(dep)
+    }
+
+    /// The parsed semver requirement, or `None` for "any version".
+    pub fn version_req(&self) -> Result<Option<VersionReq>> {
+        self.version
+            .as_deref()
+            .map(|raw| {
+                VersionReq::parse(raw).with_context(|| {
+                    format!(
+                        "Invalid version requirement '{raw}' on dependency '{}'. \
+                         Expected semver requirement syntax (e.g. '>=1.2.0', '^1.2', '*').",
+                        self.name
+                    )
+                })
+            })
+            .transpose()
+    }
+}
+
+/// The RPM virtual capability an extension provides, and that its dependents
+/// require.
+///
+/// Indirection through a virtual provide rather than the bare RPM name is
+/// deliberate: `source.package` lets a consumer publish an extension under a
+/// different RPM name, which would break a literal `Requires: <ext-name>`.
+/// The provide is stable regardless of what the package is called.
+pub fn rpm_capability(ext_name: &str) -> String {
+    format!("avocado-ext({ext_name})")
+}
+
+/// Translate a semver requirement into RPM version comparisons.
+///
+/// Returns `(operator, version)` pairs that must *all* hold — RPM expresses a
+/// range as several `Requires:` lines on the same capability, so `^1.2.3`
+/// becomes `>= 1.2.3` plus `< 2.0.0`. An unconstrained requirement (`*`)
+/// returns empty, meaning a bare unversioned `Requires:`.
+///
+/// Semver's caret/tilde/wildcard have no RPM equivalent, so they are expanded
+/// into explicit bounds here rather than approximated at the call site.
+pub fn rpm_version_constraints(req: &VersionReq) -> Vec<(&'static str, String)> {
+    use semver::Op;
+
+    let mut out = Vec::new();
+    for c in &req.comparators {
+        let minor = c.minor.unwrap_or(0);
+        let patch = c.patch.unwrap_or(0);
+        let at = |ma: u64, mi: u64, pa: u64| format!("{ma}.{mi}.{pa}");
+        let lower = if c.pre.is_empty() {
+            at(c.major, minor, patch)
+        } else {
+            format!("{}.{}.{}~{}", c.major, minor, patch, c.pre)
+        };
+
+        match c.op {
+            Op::Exact => out.push(("=", lower)),
+            Op::Greater => out.push((">", lower)),
+            Op::GreaterEq => out.push((">=", lower)),
+            Op::Less => out.push(("<", lower)),
+            Op::LessEq => out.push(("<=", lower)),
+            // ^1.2.3 → >=1.2.3, <2.0.0 | ^0.2.3 → >=0.2.3, <0.3.0
+            // ^0.0.3 → >=0.0.3, <0.0.4 — leading zeros narrow the range.
+            Op::Caret => {
+                out.push((">=", lower));
+                let upper = if c.major > 0 {
+                    at(c.major + 1, 0, 0)
+                } else if c.minor.is_none() {
+                    at(1, 0, 0)
+                } else if minor > 0 || c.patch.is_none() {
+                    at(0, minor + 1, 0)
+                } else {
+                    at(0, 0, patch + 1)
+                };
+                out.push(("<", upper));
+            }
+            // ~1.2.3 and ~1.2 → >=…, <1.3.0 | ~1 → >=1.0.0, <2.0.0
+            Op::Tilde => {
+                out.push((">=", lower));
+                let upper = if c.minor.is_some() {
+                    at(c.major, minor + 1, 0)
+                } else {
+                    at(c.major + 1, 0, 0)
+                };
+                out.push(("<", upper));
+            }
+            // `1.*` → >=1.0.0, <2.0.0 | `1.2.*` → >=1.2.0, <1.3.0 | `*` → none
+            Op::Wildcard => {
+                if c.minor.is_some() {
+                    out.push((">=", lower));
+                    out.push(("<", at(c.major, minor + 1, 0)));
+                } else {
+                    out.push((">=", at(c.major, 0, 0)));
+                    out.push(("<", at(c.major + 1, 0, 0)));
+                }
+            }
+            // semver is non_exhaustive; an unknown operator is better dropped
+            // than mistranslated into a wrong bound.
+            _ => {}
+        }
+    }
+    out
+}
+
+impl ExtensionDependency {
+    /// The `Requires:` lines this edge contributes to a generated spec.
+    ///
+    /// Multiple lines for a range; one bare line when unconstrained.
+    pub fn to_rpm_requires(&self) -> Result<Vec<String>> {
+        let cap = rpm_capability(&self.name);
+        let Some(req) = self.version_req()? else {
+            return Ok(vec![format!("Requires: {cap}")]);
+        };
+        let constraints = rpm_version_constraints(&req);
+        if constraints.is_empty() {
+            return Ok(vec![format!("Requires: {cap}")]);
+        }
+        Ok(constraints
+            .into_iter()
+            .map(|(op, v)| format!("Requires: {cap} {op} {v}"))
+            .collect())
+    }
+}
+
+/// Extract just the extension *names* from a `depends_on:` list, ignoring
+/// version constraints and tolerating malformed entries.
+///
+/// Deliberately lenient, and deliberately separate from
+/// [`ExtensionDependency::parse_entry`]: this runs during config composition,
+/// before the graph is built, to answer the narrow question "which sibling
+/// extension declarations do I need to pull in?". Composition is not the right
+/// place to reject a malformed `depends_on` — that diagnostic belongs to
+/// [`DependencyGraph::from_extensions_section`], which sees the whole picture
+/// and can name the offending extension. An entry this skips simply fails
+/// later, with a better message.
+pub fn dependency_names(ext_value: &Value) -> Vec<String> {
+    let Some(seq) = ext_value.get("depends_on").and_then(|d| d.as_sequence()) else {
+        return Vec::new();
+    };
+    seq.iter()
+        .filter_map(|entry| {
+            if let Some(s) = entry.as_str() {
+                return Some(s.to_string());
+            }
+            let mapping = entry.as_mapping()?;
+            if let Some(name) = mapping.get("name").and_then(|v| v.as_str()) {
+                return Some(name.to_string());
+            }
+            if mapping.len() == 1 {
+                return mapping.iter().next()?.0.as_str().map(str::to_string);
+            }
+            None
+        })
+        .collect()
+}
+
+fn require_version_string(ext_name: &str, dep_name: &str, v: &Value) -> Result<String> {
+    v.as_str().map(str::to_string).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Extension '{ext_name}': `depends_on` entry for '{dep_name}' has a \
+             non-string `version`. Quote it (e.g. version: \">=1.2.0\")."
+        )
+    })
+}
+
+fn describe(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "a boolean",
+        Value::Number(_) => "a number",
+        Value::String(_) => "a string",
+        Value::Sequence(_) => "a list",
+        Value::Mapping(_) => "a mapping",
+        Value::Tagged(_) => "a tagged value",
+    }
+}
+
+/// Where an extension's definition came from — and, crucially, whether it
+/// arrived at all.
+///
+/// An extension reaches the config in one of several ways, and they differ in
+/// *when* the extension's own `avocado.yaml` (the file that carries its
+/// `depends_on`) becomes readable:
+///
+/// - **inline** — written directly in the consumer's `avocado.yaml`. Always
+///   available.
+/// - **`source: { type: path }`** — read straight off the host path at compose
+///   time. Available without any fetch.
+/// - **`source: { type: git | package }`** — only readable after the extension
+///   has been fetched into `$AVOCADO_PREFIX/<target>/includes/<ext>/`. Before
+///   that, `Config::load_composed` finds nothing to merge and the extension is
+///   left as a bare `source:` stub.
+///
+/// That last case is the dangerous one: a stub has no `depends_on` key, which
+/// is indistinguishable *by shape* from an extension that genuinely has no
+/// dependencies. Resolving it as dependency-free would silently drop its whole
+/// subtree from the closure and ship an image missing its platform base. So
+/// the graph tracks it explicitly and [`DependencyGraph::resolve`] refuses to
+/// walk through it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExtensionOrigin {
+    /// Definition was read — inline, or a remote whose config was merged.
+    Defined,
+    /// Declared via `source:`, but its config was never merged. The string is
+    /// the declared source type (`git`, `package`, `path`, …) for diagnostics.
+    Unfetched(String),
+}
+
+/// One extension as the dependency graph sees it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtensionNode {
+    /// Interpolated extension name — the graph's key.
+    pub name: String,
+    pub class: ExtensionClass,
+    /// The extension's own `version:`, if it declares one.
+    pub version: Option<String>,
+    /// Outgoing edges, in declaration order. Empty and meaningless when
+    /// `origin` is [`ExtensionOrigin::Unfetched`].
+    pub depends_on: Vec<ExtensionDependency>,
+    pub origin: ExtensionOrigin,
+}
+
+/// The `extensions:` section viewed as a dependency graph.
+///
+/// Build it from the **composed** merged config, never the raw on-disk
+/// consumer yaml: a remote extension carries only a `source:` block in the
+/// consumer's file, and its real fields — including its `depends_on` — are
+/// merged in by `Config::load_composed`.
+#[derive(Debug, Clone, Default)]
+pub struct DependencyGraph {
+    /// Keyed by interpolated name. `BTreeMap` so any full-graph iteration
+    /// (lints, diagnostics) is deterministic.
+    nodes: BTreeMap<String, ExtensionNode>,
+}
+
+impl DependencyGraph {
+    /// Build the graph from a composed config — the normal entry point.
+    ///
+    /// Uses `ComposedConfig::extension_sources` to tell a merged remote
+    /// extension from an unfetched stub: `load_composed` records every
+    /// extension against the main config first, then *overwrites* the entry
+    /// with the extension's own config path once it successfully merges that
+    /// extension's `avocado.yaml`. An extension that declares a `source:` but
+    /// still points at the main config was therefore never fetched.
+    pub fn from_composed(composed: &ComposedConfig, target: &str) -> Result<Self> {
+        let Some(extensions) = composed.merged_value.get("extensions") else {
+            return Ok(Self::default());
+        };
+
+        let mut unfetched = HashSet::new();
+        if let Some(mapping) = extensions.as_mapping() {
+            for (key, ext) in mapping {
+                let Some(raw_name) = key.as_str() else {
+                    continue;
+                };
+                if ext.get("source").is_none() {
+                    continue;
+                }
+                let merged_from = composed
+                    .extension_sources
+                    .get(raw_name)
+                    .or_else(|| {
+                        composed
+                            .extension_sources
+                            .get(&interpolate_name(raw_name, target))
+                    })
+                    .map(String::as_str);
+                if merged_from.is_none() || merged_from == Some(composed.config_path.as_str()) {
+                    unfetched.insert(interpolate_name(raw_name, target));
+                }
+            }
+        }
+
+        Self::from_extensions_section(extensions, target, &unfetched)
+    }
+
+    /// Build the graph from an `extensions:` mapping, given the set of
+    /// extension names known to be declared-but-unfetched.
+    ///
+    /// Prefer [`Self::from_composed`], which derives that set for you. This
+    /// form exists for callers that already know their content is complete
+    /// (and for tests); passing an empty set asserts exactly that.
+    ///
+    /// Every key and every `depends_on` name is interpolated against `target`
+    /// up front, so the graph holds concrete names and all downstream matching
+    /// is plain string equality — no template-aware lookup at each call site.
+    pub fn from_extensions_section(
+        extensions: &Value,
+        target: &str,
+        unfetched: &HashSet<String>,
+    ) -> Result<Self> {
+        let mut nodes = BTreeMap::new();
+
+        let Some(mapping) = extensions.as_mapping() else {
+            // No `extensions:` section, or a malformed one — an empty graph.
+            // Callers that need a specific extension get a precise
+            // "not defined" error from `resolve`.
+            return Ok(Self { nodes });
+        };
+
+        for (key, ext) in mapping {
+            let Some(raw_name) = key.as_str() else {
+                continue;
+            };
+            let name = interpolate_name(raw_name, target);
+
+            let class = ExtensionClass::from_ext_config(&name, ext)?;
+            let version = ext
+                .get("version")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+
+            let origin = if unfetched.contains(&name) {
+                let source_type = ext
+                    .get("source")
+                    .and_then(|s| s.get("type"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("remote");
+                ExtensionOrigin::Unfetched(source_type.to_string())
+            } else {
+                ExtensionOrigin::Defined
+            };
+
+            let mut depends_on = Vec::new();
+            if let Some(list) = ext.get("depends_on") {
+                let seq = list.as_sequence().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Extension '{name}': `depends_on` must be a list, got {}.",
+                        describe(list)
+                    )
+                })?;
+                for entry in seq {
+                    let dep = ExtensionDependency::parse_entry(&name, entry, target)?;
+                    if dep.name == name {
+                        bail!("Extension '{name}' declares a `depends_on` edge to itself.");
+                    }
+                    depends_on.push(dep);
+                }
+            }
+
+            nodes.insert(
+                name.clone(),
+                ExtensionNode {
+                    name,
+                    class,
+                    version,
+                    depends_on,
+                    origin,
+                },
+            );
+        }
+
+        Ok(Self { nodes })
+    }
+
+    pub fn get(&self, name: &str) -> Option<&ExtensionNode> {
+        self.nodes.get(name)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    /// Expand `roots` to their transitive `depends_on` closure and return it
+    /// topologically ordered, **dependencies before dependents**.
+    ///
+    /// Ordering is a depth-first post-order over roots in author order, so it
+    /// is fully deterministic: a dependency lands as early as its own
+    /// dependencies allow, and otherwise ties break by the order the author
+    /// wrote things. Under de-duplication the extensions' files are disjoint,
+    /// so order is not load-bearing for merge correctness — but a stable order
+    /// keeps the sealed manifest reproducible and diffable, and it is exactly
+    /// the order in which extensions must be *installed* for each one's
+    /// sysroot to exist before its dependents are seeded from it.
+    ///
+    /// Errors, both naming the chain that led there:
+    /// - a dependency that is not defined in `extensions:`,
+    /// - a cycle (reported with the full path, not silently truncated).
+    pub fn resolve(&self, roots: &[String]) -> Result<ResolvedClosure> {
+        let mut unique_roots = Vec::new();
+        let mut seen = HashSet::new();
+        for root in roots {
+            if seen.insert(root.as_str()) {
+                unique_roots.push(root.clone());
+            }
+        }
+
+        let mut marks: HashMap<&str, Mark> = HashMap::new();
+        let mut chain: Vec<&str> = Vec::new();
+        let mut order: Vec<String> = Vec::new();
+
+        for root in &unique_roots {
+            self.visit(root, &mut marks, &mut chain, &mut order)?;
+        }
+
+        Ok(ResolvedClosure {
+            order,
+            roots: unique_roots,
+        })
+    }
+
+    fn visit<'a>(
+        &'a self,
+        name: &'a str,
+        marks: &mut HashMap<&'a str, Mark>,
+        chain: &mut Vec<&'a str>,
+        order: &mut Vec<String>,
+    ) -> Result<()> {
+        match marks.get(name) {
+            Some(Mark::Done) => return Ok(()),
+            // Back-edge onto an extension still open on the stack: a cycle.
+            Some(Mark::InProgress) => {
+                let start = chain.iter().position(|n| *n == name).unwrap_or(0);
+                let mut path: Vec<&str> = chain[start..].to_vec();
+                path.push(name);
+                bail!(
+                    "Dependency cycle between extensions: {}.\n\
+                     Extensions cannot depend on each other in a loop — factor the \
+                     shared part into a separate `class: platform` extension.",
+                    path.join(" -> ")
+                );
+            }
+            None => {}
+        }
+
+        let node = self.nodes.get(name).ok_or_else(|| {
+            let chain_note = if chain.is_empty() {
+                String::new()
+            } else {
+                format!("\nRequired by: {} -> {name}", chain.join(" -> "))
+            };
+            anyhow::anyhow!(
+                "Extension '{name}' is not defined in `extensions:` and could not be \
+                 resolved from the target's feed.{chain_note}"
+            )
+        })?;
+
+        // A `git`/`package` extension that has not been fetched is a bare
+        // `source:` stub: its `depends_on` is not merely empty, it is unknown.
+        // Walking through it would silently drop its subtree from the closure
+        // and produce an image missing its platform base, so stop here instead.
+        if let ExtensionOrigin::Unfetched(source_type) = &node.origin {
+            let chain_note = if chain.is_empty() {
+                String::new()
+            } else {
+                format!("\nRequired by: {} -> {name}", chain.join(" -> "))
+            };
+            let remedy = if source_type == "path" {
+                "Its `source: { type: path }` directory has no readable avocado.yaml \
+                 — check the path is correct and the file exists."
+            } else {
+                "Run `avocado ext fetch` to fetch it before resolving dependencies."
+            };
+            bail!(
+                "Extension '{name}' declares `source: {{ type: {source_type} }}` but its \
+                 configuration has not been merged, so its dependencies are unknown.\n\
+                 {remedy}{chain_note}"
+            );
+        }
+
+        marks.insert(&node.name, Mark::InProgress);
+        chain.push(&node.name);
+        for dep in &node.depends_on {
+            self.visit(&dep.name, marks, chain, order)?;
+        }
+        chain.pop();
+        marks.insert(&node.name, Mark::Done);
+        order.push(node.name.clone());
+
+        Ok(())
+    }
+
+    /// Expand a runtime's authored extension list into the complete set to
+    /// ship, ordered for **merge priority**.
+    ///
+    /// The author places only what they care about; each entry is followed by
+    /// the dependencies it pulls in, flattened depth-first:
+    ///
+    /// ```text
+    /// authored: [app-a, app-b]      ->  app-a        (authored)
+    ///                                     base       (implied by app-a)
+    ///                                   app-b        (authored)
+    ///                                     mid        (implied by app-b)
+    ///                                       base     (already placed, skipped)
+    /// ```
+    ///
+    /// # Why parent-first, when installation is dependency-first
+    ///
+    /// These are deliberately opposite orderings for two different jobs.
+    ///
+    /// [`Self::resolve`] orders dependencies *first* because that is an
+    /// **install** order: a dependency's sysroot has to exist before anything
+    /// can be seeded from it.
+    ///
+    /// This list is a **merge priority** order. avocadoctl computes
+    /// `merge_idx = ext_count - 1 - index`, so earlier means higher priority.
+    /// Putting the parent first lets an application win a file conflict
+    /// against the platform base it depends on — the specific thing beats the
+    /// shared thing it was built on. Dependencies-first would invert that and
+    /// let a base silently shadow its dependent.
+    ///
+    /// # The author's own placement is truth
+    ///
+    /// If the author lists an extension that would also have been implied,
+    /// their entry wins: it is emitted once, at the position they chose, with
+    /// the options they set. The expansion never re-places it. That keeps
+    /// `- weston-base: {{ enabled: false }}` meaningful even though something
+    /// else depends on it.
+    ///
+    /// The graph is validated by [`Self::resolve`] first, so cycles, missing
+    /// dependencies, and unfetched stubs are all reported before any ordering
+    /// happens.
+    pub fn resolve_runtime_list(&self, authored: &[String]) -> Result<Vec<RuntimeEntry>> {
+        // Validate the whole closure up front — reuses the cycle, missing-dep,
+        // and unfetched-stub diagnostics rather than reimplementing them.
+        self.resolve(authored)?;
+
+        let authored_set: HashSet<&str> = authored.iter().map(String::as_str).collect();
+        let mut emitted: HashSet<String> = HashSet::new();
+        let mut out: Vec<RuntimeEntry> = Vec::new();
+
+        for name in authored {
+            if !emitted.insert(name.clone()) {
+                // The author listed the same extension twice; keep the first.
+                continue;
+            }
+            out.push(RuntimeEntry {
+                name: name.clone(),
+                authored: true,
+            });
+            self.push_implied(name, &authored_set, &mut emitted, &mut out);
+        }
+
+        Ok(out)
+    }
+
+    fn push_implied(
+        &self,
+        name: &str,
+        authored_set: &HashSet<&str>,
+        emitted: &mut HashSet<String>,
+        out: &mut Vec<RuntimeEntry>,
+    ) {
+        let Some(node) = self.nodes.get(name) else {
+            return;
+        };
+        for dep in &node.depends_on {
+            // The author placed this one themselves — theirs is truth, and it
+            // is emitted at their position rather than here.
+            if authored_set.contains(dep.name.as_str()) {
+                continue;
+            }
+            if !emitted.insert(dep.name.clone()) {
+                continue;
+            }
+            out.push(RuntimeEntry {
+                name: dep.name.clone(),
+                authored: false,
+            });
+            // Safe to recurse: `resolve` already proved the graph acyclic.
+            self.push_implied(&dep.name, authored_set, emitted, out);
+        }
+    }
+
+    /// Advisory checks over a resolved closure. Warnings, never failures —
+    /// these describe smells, not broken builds.
+    pub fn lint(&self, closure: &ResolvedClosure) -> Vec<String> {
+        let mut warnings = Vec::new();
+
+        for name in &closure.order {
+            let Some(node) = self.nodes.get(name) else {
+                continue;
+            };
+            if node.class != ExtensionClass::Application {
+                continue;
+            }
+            for dep in &node.depends_on {
+                let Some(dep_node) = self.nodes.get(&dep.name) else {
+                    continue;
+                };
+                if dep_node.class == ExtensionClass::Application {
+                    warnings.push(format!(
+                        "Extension '{}' (class: application) depends on '{}', which is also \
+                         class: application. Shared bases are normally `class: platform` — \
+                         consider factoring the shared part out, or mark '{}' as platform.",
+                        node.name, dep_node.name, dep_node.name
+                    ));
+                }
+            }
+        }
+
+        warnings
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Mark {
+    /// Open on the DFS stack — reaching it again is a back-edge.
+    InProgress,
+    /// Fully emitted into `order`.
+    Done,
+}
+
+/// One entry in a runtime's resolved extension list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeEntry {
+    pub name: String,
+    /// `true` when the author placed it in `runtimes.<name>.extensions`,
+    /// `false` when it was pulled in as a dependency. Drives `ext tree` and
+    /// answers "why is this in my image?".
+    pub authored: bool,
+}
+
+/// A `depends_on` closure, expanded and ordered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedClosure {
+    /// The full closure, dependencies before dependents. Each extension
+    /// appears exactly once.
+    pub order: Vec<String>,
+    /// The extensions that were asked for, deduplicated, in author order.
+    pub roots: Vec<String>,
+}
+
+impl ResolvedClosure {
+    /// Closure members that were pulled in as dependencies rather than
+    /// requested by the author — what `avocado ext tree` highlights, and the
+    /// answer to "why is this extension in my image?".
+    pub fn implied(&self) -> Vec<&str> {
+        self.order
+            .iter()
+            .map(String::as_str)
+            .filter(|name| !self.roots.iter().any(|r| r == name))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn graph(yaml: &str) -> DependencyGraph {
+        graph_for(yaml, "qemux86-64")
+    }
+
+    fn graph_for(yaml: &str, target: &str) -> DependencyGraph {
+        let v: Value = serde_yaml::from_str(yaml).unwrap();
+        DependencyGraph::from_extensions_section(
+            v.get("extensions").unwrap(),
+            target,
+            &HashSet::new(),
+        )
+        .unwrap()
+    }
+
+    /// Graph where `unfetched` names are declared-but-not-merged stubs.
+    fn graph_unfetched(yaml: &str, unfetched: &[&str]) -> DependencyGraph {
+        let v: Value = serde_yaml::from_str(yaml).unwrap();
+        let set: HashSet<String> = unfetched.iter().map(|s| s.to_string()).collect();
+        DependencyGraph::from_extensions_section(v.get("extensions").unwrap(), "qemux86-64", &set)
+            .unwrap()
+    }
+
+    fn graph_err(yaml: &str) -> String {
+        let v: Value = serde_yaml::from_str(yaml).unwrap();
+        DependencyGraph::from_extensions_section(
+            v.get("extensions").unwrap(),
+            "qemux86-64",
+            &HashSet::new(),
+        )
+        .unwrap_err()
+        .to_string()
+    }
+
+    fn roots(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ---- declaration parsing -------------------------------------------
+
+    #[test]
+    fn plain_string_dependency() {
+        let g = graph(
+            "extensions:\n\
+             \x20 weston-base: {}\n\
+             \x20 app-a:\n\
+             \x20   depends_on: [weston-base]\n",
+        );
+        let deps = &g.get("app-a").unwrap().depends_on;
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].name, "weston-base");
+        assert_eq!(deps[0].version, None);
+    }
+
+    #[test]
+    fn explicit_name_version_form() {
+        let g = graph(
+            "extensions:\n\
+             \x20 app-a:\n\
+             \x20   depends_on:\n\
+             \x20     - { name: weston-base, version: \">=1.2.0\" }\n",
+        );
+        let dep = &g.get("app-a").unwrap().depends_on[0];
+        assert_eq!(dep.name, "weston-base");
+        assert_eq!(dep.version.as_deref(), Some(">=1.2.0"));
+        assert!(dep.version_req().unwrap().is_some());
+    }
+
+    #[test]
+    fn single_key_shorthand_forms() {
+        let g = graph(
+            "extensions:\n\
+             \x20 app-a:\n\
+             \x20   depends_on:\n\
+             \x20     - { weston-base: \">=1.2.0\" }\n\
+             \x20     - { gfx-core: { version: \"^2\" } }\n\
+             \x20     - { plain-base: }\n",
+        );
+        let deps = &g.get("app-a").unwrap().depends_on;
+        assert_eq!(deps[0].name, "weston-base");
+        assert_eq!(deps[0].version.as_deref(), Some(">=1.2.0"));
+        assert_eq!(deps[1].name, "gfx-core");
+        assert_eq!(deps[1].version.as_deref(), Some("^2"));
+        assert_eq!(deps[2].name, "plain-base");
+        assert_eq!(deps[2].version, None);
+    }
+
+    #[test]
+    fn extension_literally_named_name_uses_explicit_form() {
+        // `- { name: "1.0" }` is the explicit form with a bogus name, not a
+        // shorthand for an extension called `name`. The explicit form is how
+        // you actually depend on one.
+        let g = graph(
+            "extensions:\n\
+             \x20 app-a:\n\
+             \x20   depends_on:\n\
+             \x20     - { name: name, version: \"^1\" }\n",
+        );
+        let dep = &g.get("app-a").unwrap().depends_on[0];
+        assert_eq!(dep.name, "name");
+        assert_eq!(dep.version.as_deref(), Some("^1"));
+    }
+
+    #[test]
+    fn template_names_are_interpolated_on_both_sides() {
+        let g = graph_for(
+            "extensions:\n\
+             \x20 \"avocado-bsp-{{ avocado.target }}\": { class: platform }\n\
+             \x20 app-a:\n\
+             \x20   depends_on: [\"avocado-bsp-{{ avocado.target }}\"]\n",
+            "jetson-orin-nano-devkit",
+        );
+        assert!(g.get("avocado-bsp-jetson-orin-nano-devkit").is_some());
+        assert_eq!(
+            g.get("app-a").unwrap().depends_on[0].name,
+            "avocado-bsp-jetson-orin-nano-devkit"
+        );
+        // …and it resolves as a normal edge.
+        let c = g.resolve(&roots(&["app-a"])).unwrap();
+        assert_eq!(
+            c.order,
+            vec!["avocado-bsp-jetson-orin-nano-devkit", "app-a"]
+        );
+    }
+
+    #[test]
+    fn invalid_version_requirement_is_rejected_at_parse() {
+        let err = graph_err(
+            "extensions:\n\
+             \x20 app-a:\n\
+             \x20   depends_on:\n\
+             \x20     - { name: weston-base, version: \"not-a-version\" }\n",
+        );
+        assert!(err.contains("weston-base"), "{err}");
+    }
+
+    #[test]
+    fn depends_on_must_be_a_list() {
+        let err = graph_err(
+            "extensions:\n\
+             \x20 app-a:\n\
+             \x20   depends_on: weston-base\n",
+        );
+        assert!(err.contains("must be a list"), "{err}");
+    }
+
+    #[test]
+    fn self_edge_is_rejected() {
+        let err = graph_err(
+            "extensions:\n\
+             \x20 app-a:\n\
+             \x20   depends_on: [app-a]\n",
+        );
+        assert!(err.contains("itself"), "{err}");
+    }
+
+    // ---- class ----------------------------------------------------------
+
+    #[test]
+    fn class_defaults_to_application_and_parses_platform() {
+        let g = graph(
+            "extensions:\n\
+             \x20 app-a: {}\n\
+             \x20 weston-base: { class: platform }\n\
+             \x20 app-b: { class: application }\n",
+        );
+        assert_eq!(g.get("app-a").unwrap().class, ExtensionClass::Application);
+        assert_eq!(
+            g.get("weston-base").unwrap().class,
+            ExtensionClass::Platform
+        );
+        assert_eq!(g.get("app-b").unwrap().class, ExtensionClass::Application);
+    }
+
+    #[test]
+    fn unknown_class_errors_rather_than_defaulting() {
+        let err = graph_err("extensions:\n \x20weston-base: { class: platfrom }\n");
+        assert!(err.contains("platfrom"), "{err}");
+    }
+
+    // ---- closure + ordering ---------------------------------------------
+
+    #[test]
+    fn dependency_is_ordered_before_its_dependent() {
+        let g = graph(
+            "extensions:\n\
+             \x20 weston-base: { class: platform }\n\
+             \x20 app-a:\n\
+             \x20   depends_on: [weston-base]\n",
+        );
+        let c = g.resolve(&roots(&["app-a"])).unwrap();
+        assert_eq!(c.order, vec!["weston-base", "app-a"]);
+        assert_eq!(c.roots, vec!["app-a"]);
+        assert_eq!(c.implied(), vec!["weston-base"]);
+    }
+
+    #[test]
+    fn transitive_chain_is_fully_expanded() {
+        let g = graph(
+            "extensions:\n\
+             \x20 base: { class: platform }\n\
+             \x20 mid:\n\
+             \x20   class: platform\n\
+             \x20   depends_on: [base]\n\
+             \x20 app-a:\n\
+             \x20   depends_on: [mid]\n",
+        );
+        let c = g.resolve(&roots(&["app-a"])).unwrap();
+        assert_eq!(c.order, vec!["base", "mid", "app-a"]);
+    }
+
+    #[test]
+    fn diamond_ships_the_shared_base_once() {
+        // D -> {B, C}, B -> A, C -> A
+        let g = graph(
+            "extensions:\n\
+             \x20 a: { class: platform }\n\
+             \x20 b: { class: platform, depends_on: [a] }\n\
+             \x20 c: { class: platform, depends_on: [a] }\n\
+             \x20 d: { depends_on: [b, c] }\n",
+        );
+        let c = g.resolve(&roots(&["d"])).unwrap();
+        assert_eq!(c.order, vec!["a", "b", "c", "d"]);
+        assert_eq!(c.order.iter().filter(|n| *n == "a").count(), 1);
+    }
+
+    #[test]
+    fn independent_roots_keep_author_order() {
+        let g = graph(
+            "extensions:\n\
+             \x20 weston-base: { class: platform }\n\
+             \x20 app-a: { depends_on: [weston-base] }\n\
+             \x20 app-b: { depends_on: [weston-base] }\n",
+        );
+        let c = g.resolve(&roots(&["app-a", "app-b"])).unwrap();
+        assert_eq!(c.order, vec!["weston-base", "app-a", "app-b"]);
+
+        // Reversing the author's list reverses only the tie, never an edge.
+        let c = g.resolve(&roots(&["app-b", "app-a"])).unwrap();
+        assert_eq!(c.order, vec!["weston-base", "app-b", "app-a"]);
+    }
+
+    #[test]
+    fn author_may_also_list_a_platform_explicitly() {
+        // Harmless and deduplicated — one entry, still ordered before its
+        // dependent, and no longer reported as "implied".
+        let g = graph(
+            "extensions:\n\
+             \x20 weston-base: { class: platform }\n\
+             \x20 app-a: { depends_on: [weston-base] }\n",
+        );
+        let c = g.resolve(&roots(&["app-a", "weston-base"])).unwrap();
+        assert_eq!(c.order, vec!["weston-base", "app-a"]);
+        assert!(c.implied().is_empty());
+    }
+
+    #[test]
+    fn duplicate_roots_are_deduplicated() {
+        let g = graph("extensions:\n \x20app-a: {}\n");
+        let c = g.resolve(&roots(&["app-a", "app-a"])).unwrap();
+        assert_eq!(c.order, vec!["app-a"]);
+        assert_eq!(c.roots, vec!["app-a"]);
+    }
+
+    // ---- failure modes ---------------------------------------------------
+
+    #[test]
+    fn cycle_is_reported_with_the_full_path() {
+        let g = graph(
+            "extensions:\n\
+             \x20 a: { depends_on: [b] }\n\
+             \x20 b: { depends_on: [c] }\n\
+             \x20 c: { depends_on: [a] }\n",
+        );
+        let err = g.resolve(&roots(&["a"])).unwrap_err().to_string();
+        assert!(err.contains("a -> b -> c -> a"), "{err}");
+    }
+
+    #[test]
+    fn cycle_not_touching_the_root_still_reports_only_the_loop() {
+        let g = graph(
+            "extensions:\n\
+             \x20 root: { depends_on: [b] }\n\
+             \x20 b: { depends_on: [c] }\n\
+             \x20 c: { depends_on: [b] }\n",
+        );
+        let err = g.resolve(&roots(&["root"])).unwrap_err().to_string();
+        assert!(err.contains("b -> c -> b"), "{err}");
+        assert!(!err.contains("root ->"), "{err}");
+    }
+
+    #[test]
+    fn missing_dependency_names_the_chain() {
+        let g = graph(
+            "extensions:\n\
+             \x20 app-a: { depends_on: [mid] }\n\
+             \x20 mid: { depends_on: [nope] }\n",
+        );
+        let err = g.resolve(&roots(&["app-a"])).unwrap_err().to_string();
+        assert!(err.contains("'nope' is not defined"), "{err}");
+        assert!(err.contains("app-a -> mid -> nope"), "{err}");
+    }
+
+    #[test]
+    fn missing_root_errors_without_a_chain_note() {
+        let g = graph("extensions:\n \x20app-a: {}\n");
+        let err = g.resolve(&roots(&["ghost"])).unwrap_err().to_string();
+        assert!(err.contains("'ghost' is not defined"), "{err}");
+        assert!(!err.contains("Required by"), "{err}");
+    }
+
+    // ---- RPM realization -------------------------------------------------
+
+    fn dep(name: &str, version: Option<&str>) -> ExtensionDependency {
+        ExtensionDependency {
+            name: name.to_string(),
+            version: version.map(str::to_string),
+        }
+    }
+
+    fn requires(version: Option<&str>) -> Vec<String> {
+        dep("weston-base", version).to_rpm_requires().unwrap()
+    }
+
+    #[test]
+    fn capability_is_a_virtual_provide_not_the_rpm_name() {
+        assert_eq!(rpm_capability("weston-base"), "avocado-ext(weston-base)");
+    }
+
+    #[test]
+    fn unconstrained_dependency_is_a_bare_requires() {
+        assert_eq!(requires(None), vec!["Requires: avocado-ext(weston-base)"]);
+        // `*` is a constraint that constrains nothing.
+        assert_eq!(
+            requires(Some("*")),
+            vec!["Requires: avocado-ext(weston-base)"]
+        );
+    }
+
+    #[test]
+    fn simple_comparators_map_one_to_one() {
+        assert_eq!(
+            requires(Some(">=1.2.0")),
+            vec!["Requires: avocado-ext(weston-base) >= 1.2.0"]
+        );
+        assert_eq!(
+            requires(Some("=1.2.0")),
+            vec!["Requires: avocado-ext(weston-base) = 1.2.0"]
+        );
+        assert_eq!(
+            requires(Some("<2.0.0")),
+            vec!["Requires: avocado-ext(weston-base) < 2.0.0"]
+        );
+    }
+
+    #[test]
+    fn caret_expands_to_explicit_bounds() {
+        assert_eq!(
+            requires(Some("^1.2.3")),
+            vec![
+                "Requires: avocado-ext(weston-base) >= 1.2.3",
+                "Requires: avocado-ext(weston-base) < 2.0.0",
+            ]
+        );
+        // Leading zeros narrow the compatible range.
+        assert_eq!(
+            requires(Some("^0.2.3")),
+            vec![
+                "Requires: avocado-ext(weston-base) >= 0.2.3",
+                "Requires: avocado-ext(weston-base) < 0.3.0",
+            ]
+        );
+        assert_eq!(
+            requires(Some("^0.0.3")),
+            vec![
+                "Requires: avocado-ext(weston-base) >= 0.0.3",
+                "Requires: avocado-ext(weston-base) < 0.0.4",
+            ]
+        );
+    }
+
+    #[test]
+    fn tilde_bounds_the_minor() {
+        assert_eq!(
+            requires(Some("~1.2.3")),
+            vec![
+                "Requires: avocado-ext(weston-base) >= 1.2.3",
+                "Requires: avocado-ext(weston-base) < 1.3.0",
+            ]
+        );
+        assert_eq!(
+            requires(Some("~1")),
+            vec![
+                "Requires: avocado-ext(weston-base) >= 1.0.0",
+                "Requires: avocado-ext(weston-base) < 2.0.0",
+            ]
+        );
+    }
+
+    #[test]
+    fn multi_comparator_range_emits_both_bounds() {
+        assert_eq!(
+            requires(Some(">=1.2, <2")),
+            vec![
+                "Requires: avocado-ext(weston-base) >= 1.2.0",
+                "Requires: avocado-ext(weston-base) < 2.0.0",
+            ]
+        );
+    }
+
+    #[test]
+    fn bare_version_is_caret_semantics() {
+        // Documented gotcha: `1.2.0` means ^1.2.0, not an exact pin.
+        assert_eq!(
+            requires(Some("1.2.0")),
+            vec![
+                "Requires: avocado-ext(weston-base) >= 1.2.0",
+                "Requires: avocado-ext(weston-base) < 2.0.0",
+            ]
+        );
+    }
+
+    #[test]
+    fn prerelease_lower_bound_uses_rpm_tilde_ordering() {
+        // RPM sorts `1.2.0~rc.1` before `1.2.0`, matching semver's rule that a
+        // pre-release precedes its release.
+        assert_eq!(
+            requires(Some(">=1.2.0-rc.1")),
+            vec!["Requires: avocado-ext(weston-base) >= 1.2.0~rc.1"]
+        );
+    }
+
+    // ---- runtime list: parent-first, author wins -------------------------
+
+    /// The deptest fixture shape: base <- app-a, base <- mid <- app-b.
+    fn fixture_graph() -> DependencyGraph {
+        graph(
+            "extensions:\n\
+             \x20 base: { class: platform }\n\
+             \x20 mid:  { class: platform, depends_on: [base] }\n\
+             \x20 app-a: { depends_on: [base] }\n\
+             \x20 app-b: { depends_on: [mid] }\n\
+             \x20 plain: {}\n",
+        )
+    }
+
+    fn names(entries: &[RuntimeEntry]) -> Vec<&str> {
+        entries.iter().map(|e| e.name.as_str()).collect()
+    }
+
+    #[test]
+    fn author_places_only_parents_and_deps_fall_under_them() {
+        let g = fixture_graph();
+        let out = g.resolve_runtime_list(&roots(&["app-a", "app-b"])).unwrap();
+        // Each parent immediately followed by what it pulls in.
+        assert_eq!(names(&out), vec!["app-a", "base", "app-b", "mid"]);
+        assert_eq!(
+            out.iter().map(|e| e.authored).collect::<Vec<_>>(),
+            vec![true, false, true, false]
+        );
+    }
+
+    #[test]
+    fn parent_outranks_the_dependency_it_pulled_in() {
+        // Merge priority is index-based (earlier = higher), so the dependent
+        // must precede its dependency or a base could shadow its app.
+        let g = fixture_graph();
+        let out = g.resolve_runtime_list(&roots(&["app-a"])).unwrap();
+        let pos = |n: &str| names(&out).iter().position(|x| *x == n).unwrap();
+        assert!(pos("app-a") < pos("base"));
+    }
+
+    #[test]
+    fn shared_dependency_appears_once_at_its_first_use() {
+        let g = fixture_graph();
+        let out = g.resolve_runtime_list(&roots(&["app-a", "app-b"])).unwrap();
+        assert_eq!(names(&out).iter().filter(|n| **n == "base").count(), 1);
+        // Placed under app-a, the first parent to need it — not repeated
+        // under mid.
+        assert_eq!(names(&out)[1], "base");
+    }
+
+    #[test]
+    fn explicitly_placed_dependency_keeps_the_authors_position() {
+        // The author put `base` last even though app-a implies it. Theirs is
+        // truth: one entry, at their position, not hoisted under app-a.
+        let g = fixture_graph();
+        let out = g
+            .resolve_runtime_list(&roots(&["app-a", "app-b", "base"]))
+            .unwrap();
+        assert_eq!(names(&out), vec!["app-a", "app-b", "mid", "base"]);
+        assert_eq!(names(&out).iter().filter(|n| **n == "base").count(), 1);
+        // …and it is reported as authored, not implied.
+        assert!(out.iter().find(|e| e.name == "base").unwrap().authored);
+    }
+
+    #[test]
+    fn explicitly_placing_a_transitive_dependency_also_wins() {
+        let g = fixture_graph();
+        let out = g.resolve_runtime_list(&roots(&["mid", "app-b"])).unwrap();
+        // `mid` authored first, pulling base under it; app-b then adds nothing
+        // because mid is already placed.
+        assert_eq!(names(&out), vec!["mid", "base", "app-b"]);
+        assert!(out.iter().find(|e| e.name == "mid").unwrap().authored);
+    }
+
+    #[test]
+    fn extensions_without_dependencies_are_untouched() {
+        let g = fixture_graph();
+        let out = g.resolve_runtime_list(&roots(&["plain", "app-a"])).unwrap();
+        assert_eq!(names(&out), vec!["plain", "app-a", "base"]);
+    }
+
+    #[test]
+    fn duplicate_author_entries_collapse_to_the_first() {
+        let g = fixture_graph();
+        let out = g.resolve_runtime_list(&roots(&["app-a", "app-a"])).unwrap();
+        assert_eq!(names(&out), vec!["app-a", "base"]);
+    }
+
+    #[test]
+    fn runtime_list_reports_the_same_failures_as_the_closure() {
+        let g = graph(
+            "extensions:\n\
+             \x20 app-a: { depends_on: [ghost] }\n",
+        );
+        let err = g
+            .resolve_runtime_list(&roots(&["app-a"]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("'ghost' is not defined"), "{err}");
+        assert!(err.contains("app-a -> ghost"), "{err}");
+    }
+
+    #[test]
+    fn runtime_list_rejects_a_cycle() {
+        let g = graph(
+            "extensions:\n\
+             \x20 a: { depends_on: [b] }\n\
+             \x20 b: { depends_on: [a] }\n",
+        );
+        assert!(g.resolve_runtime_list(&roots(&["a"])).is_err());
+    }
+
+    // ---- source types: inline / path / git / package ---------------------
+
+    #[test]
+    fn merged_remote_extension_resolves_like_any_other() {
+        // Once fetched, a git/package extension's own avocado.yaml has been
+        // merged, so `depends_on` is present and it is an ordinary node.
+        let g = graph(
+            "extensions:\n\
+             \x20 weston-base: { class: platform }\n\
+             \x20 app-a:\n\
+             \x20   source: { type: package, version: \"1.0.0\" }\n\
+             \x20   depends_on: [weston-base]\n",
+        );
+        assert_eq!(g.get("app-a").unwrap().origin, ExtensionOrigin::Defined);
+        let c = g.resolve(&roots(&["app-a"])).unwrap();
+        assert_eq!(c.order, vec!["weston-base", "app-a"]);
+    }
+
+    #[test]
+    fn unfetched_package_root_errors_instead_of_resolving_empty() {
+        // The stub carries no `depends_on`, which looks exactly like "has no
+        // dependencies". Resolving it as such would ship an image missing its
+        // platform base.
+        let g = graph_unfetched(
+            "extensions:\n\
+             \x20 app-a:\n\
+             \x20   source: { type: package, version: \"1.0.0\" }\n",
+            &["app-a"],
+        );
+        let err = g.resolve(&roots(&["app-a"])).unwrap_err().to_string();
+        assert!(err.contains("app-a"), "{err}");
+        assert!(err.contains("type: package"), "{err}");
+        assert!(err.contains("avocado ext fetch"), "{err}");
+    }
+
+    #[test]
+    fn unfetched_git_dependency_names_the_chain() {
+        let g = graph_unfetched(
+            "extensions:\n\
+             \x20 app-a: { depends_on: [weston-base] }\n\
+             \x20 weston-base:\n\
+             \x20   source: { type: git, url: \"https://example.invalid/x.git\" }\n",
+            &["weston-base"],
+        );
+        let err = g.resolve(&roots(&["app-a"])).unwrap_err().to_string();
+        assert!(err.contains("app-a -> weston-base"), "{err}");
+        assert!(err.contains("type: git"), "{err}");
+    }
+
+    #[test]
+    fn unreadable_path_source_suggests_checking_the_path_not_fetching() {
+        // `type: path` is read straight off the host at compose time, so a
+        // missing merge means a bad path, not a missing fetch.
+        let g = graph_unfetched(
+            "extensions:\n\
+             \x20 app-a: { depends_on: [local-base] }\n\
+             \x20 local-base:\n\
+             \x20   source: { type: path, path: \"../local-base\" }\n",
+            &["local-base"],
+        );
+        let err = g.resolve(&roots(&["app-a"])).unwrap_err().to_string();
+        assert!(err.contains("no readable avocado.yaml"), "{err}");
+        assert!(!err.contains("avocado ext fetch"), "{err}");
+    }
+
+    #[test]
+    fn unfetched_extension_outside_the_closure_is_harmless() {
+        // Only extensions actually reached by the walk are checked — an
+        // unrelated unfetched extension must not fail an unrelated build.
+        let g = graph_unfetched(
+            "extensions:\n\
+             \x20 app-a: {}\n\
+             \x20 unrelated:\n\
+             \x20   source: { type: package, version: \"1.0.0\" }\n",
+            &["unrelated"],
+        );
+        let c = g.resolve(&roots(&["app-a"])).unwrap();
+        assert_eq!(c.order, vec!["app-a"]);
+    }
+
+    // ---- lints -----------------------------------------------------------
+
+    #[test]
+    fn app_depending_on_app_warns() {
+        let g = graph(
+            "extensions:\n\
+             \x20 app-b: {}\n\
+             \x20 app-a: { depends_on: [app-b] }\n",
+        );
+        let c = g.resolve(&roots(&["app-a"])).unwrap();
+        let w = g.lint(&c);
+        assert_eq!(w.len(), 1);
+        assert!(w[0].contains("app-a"), "{}", w[0]);
+        assert!(w[0].contains("app-b"), "{}", w[0]);
+    }
+
+    #[test]
+    fn app_depending_on_platform_is_clean() {
+        let g = graph(
+            "extensions:\n\
+             \x20 weston-base: { class: platform }\n\
+             \x20 app-a: { depends_on: [weston-base] }\n",
+        );
+        let c = g.resolve(&roots(&["app-a"])).unwrap();
+        assert!(g.lint(&c).is_empty());
+    }
+
+    #[test]
+    fn platform_on_platform_is_clean() {
+        let g = graph(
+            "extensions:\n\
+             \x20 base: { class: platform }\n\
+             \x20 mid: { class: platform, depends_on: [base] }\n",
+        );
+        let c = g.resolve(&roots(&["mid"])).unwrap();
+        assert!(g.lint(&c).is_empty());
+    }
+
+    // ---- misc ------------------------------------------------------------
+
+    #[test]
+    fn extensions_without_depends_on_resolve_to_themselves() {
+        let g = graph("extensions:\n \x20app-a: { version: \"0.4.0\" }\n");
+        let c = g.resolve(&roots(&["app-a"])).unwrap();
+        assert_eq!(c.order, vec!["app-a"]);
+        assert!(c.implied().is_empty());
+        assert_eq!(g.get("app-a").unwrap().version.as_deref(), Some("0.4.0"));
+    }
+
+    #[test]
+    fn missing_extensions_section_yields_an_empty_graph() {
+        let g =
+            DependencyGraph::from_extensions_section(&Value::Null, "qemux86-64", &HashSet::new())
+                .unwrap();
+        assert!(g.is_empty());
+        assert!(g.resolve(&[]).unwrap().order.is_empty());
+    }
+}

--- a/src/utils/ext_fetch.rs
+++ b/src/utils/ext_fetch.rs
@@ -60,6 +60,40 @@ impl PackageFetchEntry {
     }
 }
 
+/// Delimiters around the post-install rpmdb report, so it can be picked out of
+/// dnf's own chatter on stdout.
+const INSTALLED_REPORT_BEGIN: &str = "---avocado-installed-extensions-begin---";
+const INSTALLED_REPORT_END: &str = "---avocado-installed-extensions-end---";
+
+/// Parse the `NAME VERSION-RELEASE` block emitted after a batched install.
+///
+/// Returns package name -> resolved version. Anything outside the delimiters
+/// is dnf output and ignored.
+fn parse_installed_report(stdout: &str) -> std::collections::HashMap<String, String> {
+    let mut out = std::collections::HashMap::new();
+    let mut inside = false;
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line == INSTALLED_REPORT_BEGIN {
+            inside = true;
+            continue;
+        }
+        if line == INSTALLED_REPORT_END {
+            break;
+        }
+        if !inside {
+            continue;
+        }
+        if let Some((name, version)) = line.split_once(char::is_whitespace) {
+            let (name, version) = (name.trim(), version.trim());
+            if !name.is_empty() && !version.is_empty() {
+                out.insert(name.to_string(), version.to_string());
+            }
+        }
+    }
+    out
+}
+
 /// Extension fetcher for downloading and installing remote extensions
 pub struct ExtensionFetcher {
     /// Path to the main configuration file
@@ -209,7 +243,12 @@ impl ExtensionFetcher {
     /// grouped by `repo_name` and each group gets its own transaction. In the
     /// overwhelmingly common case every entry has `repo_name: None` and this is
     /// a single group.
-    pub async fn fetch_packages(&self, entries: &[PackageFetchEntry], force: bool) -> Result<()> {
+    pub async fn fetch_packages(
+        &self,
+        entries: &[PackageFetchEntry],
+        force: bool,
+    ) -> Result<std::collections::HashMap<String, String>> {
+        let mut resolved = std::collections::HashMap::new();
         let mut repos: Vec<Option<String>> = Vec::new();
         for e in entries {
             if !repos.contains(&e.repo_name) {
@@ -223,11 +262,13 @@ impl ExtensionFetcher {
                 .filter(|e| e.repo_name == repo)
                 .cloned()
                 .collect();
-            self.fetch_package_group(&group, repo.as_deref(), force)
-                .await?;
+            resolved.extend(
+                self.fetch_package_group(&group, repo.as_deref(), force)
+                    .await?,
+            );
         }
 
-        Ok(())
+        Ok(resolved)
     }
 
     async fn fetch_package_group(
@@ -235,9 +276,9 @@ impl ExtensionFetcher {
         entries: &[PackageFetchEntry],
         repo_name: Option<&str>,
         force: bool,
-    ) -> Result<()> {
+    ) -> Result<std::collections::HashMap<String, String>> {
         if entries.is_empty() {
-            return Ok(());
+            return Ok(std::collections::HashMap::new());
         }
 
         if self.verbose {
@@ -326,6 +367,7 @@ fi
 if [ -n "$NESTED_SPECS" ]; then
     echo "Installing nested extensions into shared includes installroot:$NESTED_SPECS"
     mkdir -p "$AVOCADO_PREFIX/includes"
+
     # One transaction: dnf resolves each package's `Requires: avocado-ext(...)`
     # and pulls in any dependency extensions not named explicitly here.
     RPM_CONFIGDIR=$AVOCADO_SDK_PREFIX/usr/lib/rpm \
@@ -333,6 +375,15 @@ if [ -n "$NESTED_SPECS" ]; then
     $DNF_SDK_HOST $DNF_SDK_HOST_OPTS $DNF_SDK_COMBINED_REPO_CONF {repo_arg} \
         --installroot="$AVOCADO_PREFIX/includes" -y install $NESTED_SPECS
 fi
+
+# Report what the installroot actually holds now. The requested spec is not
+# the answer: `version: "*"` requests nothing in particular, and the depsolver
+# may have pulled in extensions nobody named. Only the rpmdb knows the truth,
+# and the lock needs the truth to be reproducible.
+echo "{INSTALLED_REPORT_BEGIN}"
+rpm --root="$AVOCADO_PREFIX/includes" -qa \
+    --queryformat '%{{NAME}} %{{VERSION}}-%{{RELEASE}}\n' 2>/dev/null | sort
+echo "{INSTALLED_REPORT_END}"
 "#
         );
 
@@ -351,18 +402,33 @@ fi
             ..Default::default()
         };
 
-        if !container_helper.run_in_container(run_config).await? {
+        let out = container_helper
+            .run_in_container_capture(run_config)
+            .await?;
+        if !out.success {
             return Err(anyhow::anyhow!(
-                "Failed to fetch package extension(s): {}",
+                "Failed to fetch package extension(s): {}{}",
                 entries
                     .iter()
                     .map(|e| e.ext_name.as_str())
                     .collect::<Vec<_>>()
-                    .join(", ")
+                    .join(", "),
+                crate::utils::container::container_failure_detail(
+                    &out.stderr,
+                    crate::utils::container::STDERR_TAIL_LINES
+                )
+                .map(|d| format!("\n{d}"))
+                .unwrap_or_default()
             ));
         }
 
-        Ok(())
+        // The container's own progress output is suppressed by capture, so
+        // echo it when the user asked to see it.
+        if self.verbose && !out.stdout.is_empty() {
+            print_info(out.stdout.trim_end(), OutputLevel::Normal);
+        }
+
+        Ok(parse_installed_report(&out.stdout))
     }
 
     /// Fetch an extension from the avocado package repository
@@ -652,6 +718,70 @@ echo "Successfully fetched extension '{ext_name}' from git"
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- post-install resolved-version report ---------------------------
+
+    #[test]
+    fn parses_the_delimited_report_and_ignores_dnf_chatter() {
+        let stdout = format!(
+            "Last metadata expiration check: 0:00:01 ago.\n\
+             Installing:\n\
+             \x20 avocado-ext-deptest-app-a  noarch  0.1.0-r0\n\
+             Complete!\n\
+             {INSTALLED_REPORT_BEGIN}\n\
+             avocado-ext-deptest-app-a 0.1.0-r0\n\
+             avocado-ext-deptest-base 1.2.0-r0\n\
+             avocado-ext-deptest-mid 0.3.0-r0\n\
+             {INSTALLED_REPORT_END}\n"
+        );
+        let got = parse_installed_report(&stdout);
+        assert_eq!(got.len(), 3);
+        assert_eq!(got["avocado-ext-deptest-base"], "1.2.0-r0");
+        assert_eq!(got["avocado-ext-deptest-mid"], "0.3.0-r0");
+        // The "Installing:" table above must not be mistaken for the report.
+        assert!(!got.contains_key("Installing:"));
+    }
+
+    #[test]
+    fn report_absent_or_empty_yields_nothing_rather_than_garbage() {
+        assert!(parse_installed_report("").is_empty());
+        assert!(parse_installed_report("Complete!\nno markers here\n").is_empty());
+        assert!(parse_installed_report(&format!(
+            "{INSTALLED_REPORT_BEGIN}\n{INSTALLED_REPORT_END}\n"
+        ))
+        .is_empty());
+    }
+
+    #[test]
+    fn report_tolerates_blank_and_malformed_lines() {
+        let stdout = format!(
+            "{INSTALLED_REPORT_BEGIN}\n\
+             \n\
+             no-version-here\n\
+             good-pkg 1.0.0-r0\n\
+             {INSTALLED_REPORT_END}\n"
+        );
+        let got = parse_installed_report(&stdout);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got["good-pkg"], "1.0.0-r0");
+    }
+
+    #[test]
+    fn a_locked_version_produces_a_pinned_spec() {
+        // The round trip that makes a rebuild reproducible: whatever the rpmdb
+        // reported becomes the spec handed to the next depsolve.
+        let e = PackageFetchEntry::from_package_source(
+            "avocado-ext-deptest-base",
+            None,
+            "1.2.0-r0",
+            None,
+        );
+        assert_eq!(e.package_spec, "avocado-ext-deptest-base-1.2.0-r0");
+        assert_ne!(
+            e.package_spec, "avocado-ext-deptest-base",
+            "a pinned entry must not degrade to a bare name"
+        );
+    }
 
     #[test]
     fn test_package_entry_uses_extension_name_by_default() {

--- a/src/utils/ext_fetch.rs
+++ b/src/utils/ext_fetch.rs
@@ -12,6 +12,54 @@ use crate::utils::config::ExtensionSource;
 use crate::utils::container::{RunConfig, SdkContainer};
 use crate::utils::output::{print_info, OutputLevel};
 
+/// One package-source extension to materialize in a batched fetch.
+///
+/// `package_spec` is the fully-resolved NEVRA (or bare name for `version: '*'`)
+/// the caller wants installed. It is passed to dnf explicitly so the depsolve
+/// cannot substitute a different version than the lock file pinned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageFetchEntry {
+    /// Extension name — also the directory it lands in under `includes/`.
+    pub ext_name: String,
+    /// RPM package name. Usually the extension name, but `source.package` can
+    /// rename it. Kept separate from `package_spec` because the layout query
+    /// matches on `%{name}` and a spec cannot be split back into name and
+    /// version unambiguously.
+    pub package_name: String,
+    /// Package spec handed to dnf (`<package_name>-<version>`, or just the name).
+    pub package_spec: String,
+    /// Optional `--repo=` restriction from `source.repo_name`.
+    pub repo_name: Option<String>,
+}
+
+impl PackageFetchEntry {
+    /// Build an entry from a `source: { type: package }` declaration.
+    ///
+    /// `package` overrides the RPM name when the extension is published under
+    /// a different one; otherwise the extension name is the package name.
+    /// `version: '*'` means "whatever the feed offers" and produces a bare
+    /// name, letting the depsolver choose.
+    pub fn from_package_source(
+        ext_name: &str,
+        package: Option<&str>,
+        version: &str,
+        repo_name: Option<&str>,
+    ) -> Self {
+        let package_name = package.unwrap_or(ext_name);
+        let package_spec = if version == "*" {
+            package_name.to_string()
+        } else {
+            format!("{package_name}-{version}")
+        };
+        Self {
+            ext_name: ext_name.to_string(),
+            package_name: package_name.to_string(),
+            package_spec,
+            repo_name: repo_name.map(str::to_string),
+        }
+    }
+}
+
 /// Extension fetcher for downloading and installing remote extensions
 pub struct ExtensionFetcher {
     /// Path to the main configuration file
@@ -138,6 +186,185 @@ impl ExtensionFetcher {
         Ok(ext_install_path)
     }
 
+    /// Fetch several package-source extensions in a single DNF transaction.
+    ///
+    /// This is the path that makes inter-extension dependencies work. Because
+    /// nested packages all install into the one shared `includes` installroot,
+    /// a single `dnf install a b c` lets the **depsolver** pull in each
+    /// extension's `Requires: avocado-ext(<dep>)` closure — dependencies are
+    /// discovered, downloaded, and installed in one transaction rather than
+    /// through repeated fetch/recompose/discover rounds. It also collapses N
+    /// container spin-ups into one.
+    ///
+    /// Every requested extension is passed explicitly with its locked NEVRA, so
+    /// the depsolve cannot drift off the lock file and a consumer's declared
+    /// version always beats whatever range a dependent's `Requires:` allows.
+    ///
+    /// Layout is still detected per package, in-script: only packages providing
+    /// `avocado-ext-layout(nested)` may share the installroot. Legacy packages
+    /// (content at `/`) are installed one at a time into their own
+    /// per-extension installroot exactly as before — they cannot be batched
+    /// without colliding.
+    /// A `--repo=` restriction applies to the whole transaction, so entries are
+    /// grouped by `repo_name` and each group gets its own transaction. In the
+    /// overwhelmingly common case every entry has `repo_name: None` and this is
+    /// a single group.
+    pub async fn fetch_packages(&self, entries: &[PackageFetchEntry], force: bool) -> Result<()> {
+        let mut repos: Vec<Option<String>> = Vec::new();
+        for e in entries {
+            if !repos.contains(&e.repo_name) {
+                repos.push(e.repo_name.clone());
+            }
+        }
+
+        for repo in repos {
+            let group: Vec<PackageFetchEntry> = entries
+                .iter()
+                .filter(|e| e.repo_name == repo)
+                .cloned()
+                .collect();
+            self.fetch_package_group(&group, repo.as_deref(), force)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn fetch_package_group(
+        &self,
+        entries: &[PackageFetchEntry],
+        repo_name: Option<&str>,
+        force: bool,
+    ) -> Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        if self.verbose {
+            print_info(
+                &format!(
+                    "Fetching {} package extension(s) in one transaction: {}",
+                    entries.len(),
+                    entries
+                        .iter()
+                        .map(|e| e.ext_name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+                OutputLevel::Normal,
+            );
+        }
+
+        // `<ext_name>|<package_name>|<package_spec>` triples. The package name
+        // is carried separately rather than parsed back out of the spec:
+        // `foo-1.2.0` cannot be split into name and version unambiguously in
+        // shell, and the layout query below matches on `%{name}`.
+        let triples = entries
+            .iter()
+            .map(|e| format!("\"{}|{}|{}\"", e.ext_name, e.package_name, e.package_spec))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let repo_arg = repo_name.map(|r| format!("--repo={r}")).unwrap_or_default();
+        let force_str = if force { "true" } else { "false" };
+
+        let script = format!(
+            r#"
+set -e
+
+DNF="RPM_CONFIGDIR=$AVOCADO_SDK_PREFIX/usr/lib/rpm RPM_ETCCONFIGDIR=$AVOCADO_SDK_PREFIX"
+
+# Layout detection for the WHOLE set in one query. Asking per package meant one
+# dnf metadata load each, which dominated the fetch: five extensions paid five
+# full repo loads just to learn where to put them. `--whatprovides` answers it
+# for every package at once, still from repo metadata with no payload download.
+NESTED_NAMES=$(RPM_CONFIGDIR=$AVOCADO_SDK_PREFIX/usr/lib/rpm RPM_ETCCONFIGDIR=$AVOCADO_SDK_PREFIX \
+    $DNF_SDK_HOST $DNF_SDK_HOST_OPTS $DNF_SDK_COMBINED_REPO_CONF {repo_arg} \
+    repoquery --whatprovides 'avocado-ext-layout(nested)' --qf '%{{name}}\n' 2>/dev/null | sort -u)
+
+NESTED_SPECS=""
+NESTED_NAMES_TO_REMOVE=""
+NESTED_DIRS=""
+
+for triple in {triples}; do
+    ext_name="${{triple%%|*}}"
+    rest="${{triple#*|}}"
+    pkg_name="${{rest%%|*}}"
+    spec="${{rest#*|}}"
+    ext_dir="$AVOCADO_PREFIX/includes/$ext_name"
+
+    if printf '%s\n' "$NESTED_NAMES" | grep -qxF "$pkg_name"; then
+        # Accumulate only — every dnf call for the nested set is batched below.
+        NESTED_SPECS="$NESTED_SPECS $spec"
+        NESTED_NAMES_TO_REMOVE="$NESTED_NAMES_TO_REMOVE $pkg_name"
+        NESTED_DIRS="$NESTED_DIRS $ext_dir"
+    else
+        # Legacy layout: content at /, so it needs its own installroot and
+        # cannot join the shared transaction.
+        echo "Extension '$ext_name': legacy layout -> per-extension installroot"
+        if [ "{force_str}" = "true" ]; then
+            rm -rf "$ext_dir"
+        fi
+        mkdir -p "$ext_dir"
+        RPM_CONFIGDIR=$AVOCADO_SDK_PREFIX/usr/lib/rpm \
+        RPM_ETCCONFIGDIR=$AVOCADO_SDK_PREFIX \
+        $DNF_SDK_HOST $DNF_SDK_HOST_OPTS $DNF_SDK_COMBINED_REPO_CONF {repo_arg} \
+            --installroot="$ext_dir" -y install "$spec"
+    fi
+done
+
+# --force: clear the whole nested set in ONE transaction. Removing per
+# extension meant a full dnf metadata load each, which is what dominated a
+# forced re-fetch — the install itself was already batched.
+if [ "{force_str}" = "true" ] && [ -n "$NESTED_NAMES_TO_REMOVE" ]; then
+    echo "Removing nested extensions for re-fetch:$NESTED_NAMES_TO_REMOVE"
+    RPM_CONFIGDIR=$AVOCADO_SDK_PREFIX/usr/lib/rpm RPM_ETCCONFIGDIR=$AVOCADO_SDK_PREFIX \
+        $DNF_SDK_HOST $DNF_SDK_HOST_OPTS --installroot="$AVOCADO_PREFIX/includes" \
+        -y remove $NESTED_NAMES_TO_REMOVE 2>/dev/null || true
+    for d in $NESTED_DIRS; do rm -rf "$d"; done
+fi
+
+if [ -n "$NESTED_SPECS" ]; then
+    echo "Installing nested extensions into shared includes installroot:$NESTED_SPECS"
+    mkdir -p "$AVOCADO_PREFIX/includes"
+    # One transaction: dnf resolves each package's `Requires: avocado-ext(...)`
+    # and pulls in any dependency extensions not named explicitly here.
+    RPM_CONFIGDIR=$AVOCADO_SDK_PREFIX/usr/lib/rpm \
+    RPM_ETCCONFIGDIR=$AVOCADO_SDK_PREFIX \
+    $DNF_SDK_HOST $DNF_SDK_HOST_OPTS $DNF_SDK_COMBINED_REPO_CONF {repo_arg} \
+        --installroot="$AVOCADO_PREFIX/includes" -y install $NESTED_SPECS
+fi
+"#
+        );
+
+        let container_helper = SdkContainer::new().verbose(self.verbose);
+        let run_config = RunConfig {
+            container_image: self.container_image.clone(),
+            target: self.target.clone(),
+            command: script,
+            verbose: self.verbose,
+            source_environment: true,
+            interactive: false,
+            repo_url: self.repo_url.clone(),
+            repo_release: self.repo_release.clone(),
+            container_args: self.container_args.clone(),
+            sdk_arch: self.sdk_arch.clone(),
+            ..Default::default()
+        };
+
+        if !container_helper.run_in_container(run_config).await? {
+            return Err(anyhow::anyhow!(
+                "Failed to fetch package extension(s): {}",
+                entries
+                    .iter()
+                    .map(|e| e.ext_name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Fetch an extension from the avocado package repository
     ///
     /// Installs the extension package into the SHARED `$AVOCADO_PREFIX/includes`
@@ -145,6 +372,7 @@ impl ExtensionFetcher {
     /// top-level `/<ext_name>/` dir, so the content lands at `includes/<ext_name>/` and a
     /// single rpmdb tracks every installed extension (proper tracking, clean upgrades,
     /// version management, no cross-extension file collisions).
+    #[allow(dead_code)]
     async fn fetch_from_repo(
         &self,
         ext_name: &str,
@@ -424,6 +652,52 @@ echo "Successfully fetched extension '{ext_name}' from git"
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_package_entry_uses_extension_name_by_default() {
+        let e = PackageFetchEntry::from_package_source("weston-base", None, "1.2.0", None);
+        assert_eq!(e.ext_name, "weston-base");
+        assert_eq!(e.package_spec, "weston-base-1.2.0");
+        assert_eq!(e.repo_name, None);
+    }
+
+    #[test]
+    fn test_package_entry_keeps_name_separate_from_spec() {
+        // The layout query matches on %{name}; `app-a-0.1.0` cannot be split
+        // back into name and version in shell, so the name is carried.
+        let e = PackageFetchEntry::from_package_source("app-a", None, "0.1.0", None);
+        assert_eq!(e.package_name, "app-a");
+        assert_eq!(e.package_spec, "app-a-0.1.0");
+    }
+
+    #[test]
+    fn test_package_entry_honors_a_package_rename() {
+        // `source.package` publishes the extension under a different RPM name.
+        // The install spec must use it, while the extension name (and so the
+        // includes/<name>/ directory) stays as declared.
+        let e = PackageFetchEntry::from_package_source(
+            "weston-base",
+            Some("avocado-ext-weston-base"),
+            "1.2.0",
+            None,
+        );
+        assert_eq!(e.ext_name, "weston-base");
+        assert_eq!(e.package_name, "avocado-ext-weston-base");
+        assert_eq!(e.package_spec, "avocado-ext-weston-base-1.2.0");
+    }
+
+    #[test]
+    fn test_package_entry_wildcard_version_is_an_unpinned_spec() {
+        // `*` hands version choice to the depsolver rather than pinning.
+        let e = PackageFetchEntry::from_package_source("app-a", None, "*", None);
+        assert_eq!(e.package_spec, "app-a");
+    }
+
+    #[test]
+    fn test_package_entry_carries_repo_restriction() {
+        let e = PackageFetchEntry::from_package_source("app-a", None, "1.0.0", Some("my-repo"));
+        assert_eq!(e.repo_name.as_deref(), Some("my-repo"));
+    }
 
     #[test]
     fn test_extension_fetcher_creation() {

--- a/src/utils/ext_fetch.rs
+++ b/src/utils/ext_fetch.rs
@@ -32,7 +32,52 @@ pub struct PackageFetchEntry {
     pub repo_name: Option<String>,
 }
 
+/// Reject values that would be unsafe or ambiguous once interpolated into the
+/// fetch shell script.
+///
+/// The script builds `<ext>|<pkg>|<spec>` triples and splits them in shell, so
+/// a value containing whitespace, a quote, `|`, or a shell metacharacter would
+/// at best corrupt the split and at worst execute. Validating is better than
+/// escaping here: these are RPM package names and directory names under
+/// `includes/`, so none of those characters is ever legitimate — a value
+/// carrying one is a config error worth reporting, not something to quote and
+/// pass through.
+fn validate_shell_safe(field: &str, value: &str) -> Result<()> {
+    const FORBIDDEN: &[char] = &[
+        '|', '\'', '"', '`', '$', '\\', ';', '&', '<', '>', '(', ')', '{', '}', '[', ']', '*', '?',
+        '!', '#', '~', '\n', '\r', '\t',
+    ];
+    if value.is_empty() {
+        anyhow::bail!("Extension {field} is empty.");
+    }
+    if let Some(bad) = value
+        .chars()
+        .find(|c| c.is_whitespace() || FORBIDDEN.contains(c))
+    {
+        anyhow::bail!(
+            "Extension {field} '{value}' contains the character {bad:?}, which is not \
+             valid in an RPM package name or an extension directory name."
+        );
+    }
+    Ok(())
+}
+
 impl PackageFetchEntry {
+    /// Check every value that reaches the fetch script.
+    ///
+    /// Called once per entry before the script is assembled, so a bad name is
+    /// reported by name rather than producing a confusing shell error inside
+    /// the container.
+    fn validate(&self) -> Result<()> {
+        validate_shell_safe("name", &self.ext_name)?;
+        validate_shell_safe("package name", &self.package_name)?;
+        validate_shell_safe("package spec", &self.package_spec)?;
+        if let Some(repo) = &self.repo_name {
+            validate_shell_safe("repo name", repo)?;
+        }
+        Ok(())
+    }
+
     /// Build an entry from a `source: { type: package }` declaration.
     ///
     /// `package` overrides the RPM name when the extension is published under
@@ -279,6 +324,12 @@ impl ExtensionFetcher {
     ) -> Result<std::collections::HashMap<String, String>> {
         if entries.is_empty() {
             return Ok(std::collections::HashMap::new());
+        }
+
+        // Everything below is interpolated into a shell script. Check it here,
+        // once, rather than trusting that config values are well-formed.
+        for entry in entries {
+            entry.validate()?;
         }
 
         if self.verbose {
@@ -781,6 +832,55 @@ mod tests {
             e.package_spec, "avocado-ext-deptest-base",
             "a pinned entry must not degrade to a bare name"
         );
+    }
+
+    // ---- shell-safety validation ----------------------------------------
+
+    #[test]
+    fn ordinary_names_validate() {
+        let e = PackageFetchEntry::from_package_source(
+            "avocado-ext-deptest-base",
+            None,
+            "1.2.0-r0",
+            Some("my-repo"),
+        );
+        assert!(e.validate().is_ok());
+    }
+
+    #[test]
+    fn shell_metacharacters_are_rejected() {
+        for bad in [
+            "ext;rm -rf /",
+            "ext$(whoami)",
+            "ext`id`",
+            "ext name",
+            "ext|other",
+            "ext'quote",
+            "ext\"quote",
+            "ext\nnewline",
+        ] {
+            let e = PackageFetchEntry::from_package_source(bad, None, "1.0.0", None);
+            assert!(
+                e.validate().is_err(),
+                "should have rejected {bad:?} before it reached the shell"
+            );
+        }
+    }
+
+    #[test]
+    fn the_pipe_delimiter_is_rejected_in_every_field() {
+        // The script splits `<ext>|<pkg>|<spec>`, so a pipe anywhere corrupts
+        // the split even without being dangerous.
+        let e = PackageFetchEntry::from_package_source("app", Some("pkg|x"), "1.0.0", None);
+        assert!(e.validate().is_err());
+        let e = PackageFetchEntry::from_package_source("app", None, "1.0.0", Some("repo|x"));
+        assert!(e.validate().is_err());
+    }
+
+    #[test]
+    fn empty_values_are_rejected() {
+        let e = PackageFetchEntry::from_package_source("", None, "1.0.0", None);
+        assert!(e.validate().is_err());
     }
 
     #[test]

--- a/src/utils/lockfile.rs
+++ b/src/utils/lockfile.rs
@@ -1486,6 +1486,17 @@ impl LockFile {
     }
 
     /// Get the source metadata for a fetched extension
+    /// Resolved package versions recorded for an extension's sysroot.
+    ///
+    /// Used to fingerprint a dependency so its dependents invalidate when its
+    /// contents change.
+    pub fn get_extension_packages(&self, target: &str, ext_name: &str) -> Option<&PackageVersions> {
+        self.targets
+            .get(target)
+            .and_then(|tl| tl.extensions.get(ext_name))
+            .map(|ext| &ext.packages)
+    }
+
     pub fn get_extension_source(
         &self,
         target: &str,

--- a/src/utils/lockfile.rs
+++ b/src/utils/lockfile.rs
@@ -275,9 +275,24 @@ pub struct ExtensionSourceLock {
     /// RPM package name (may differ from extension name)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub package: Option<String>,
-    /// Actual installed version
+    /// Actual installed version, as reported by the installroot's rpmdb after
+    /// the transaction — not the version that was *requested*.
+    ///
+    /// The distinction is the whole point of the field. Writing back the
+    /// request means a `version: "*"` declaration round-trips as `"*"` and
+    /// pins nothing, so two builds a week apart can resolve to different
+    /// extensions with a lock file that claims otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// True when this extension was pulled in by the depsolver rather than
+    /// declared in the config.
+    ///
+    /// Recorded so a clean checkout can reproduce the same closure: nothing
+    /// in `avocado.yaml` names these, so without the lock naming them there
+    /// is no way to pin them, and the first fetch on a fresh tree would
+    /// re-solve freely.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub implied: bool,
 }
 
 /// Lock data for a single extension — unifies sysroot packages and source metadata
@@ -778,6 +793,9 @@ impl LockFile {
                                             source_type: "package".to_string(),
                                             package: Some(pkg_name.clone()),
                                             version: Some(ver_str.to_string()),
+                                            // Legacy-format migration: these came
+                                            // from a declared entry.
+                                            implied: false,
                                         });
                                     }
                                 }
@@ -1479,6 +1497,31 @@ impl LockFile {
             .and_then(|ext| ext.source.as_ref())
     }
 
+    /// Extensions the lock recorded as pulled in by the depsolver rather than
+    /// declared in the config, with their pinned sources.
+    ///
+    /// These are the entries nothing in `avocado.yaml` names, so the lock is
+    /// the only record that they belong to the closure at all. A fetch has to
+    /// seed them explicitly or a clean checkout will re-solve them freely.
+    ///
+    /// Returned owned and sorted so the caller can mutate the lock while
+    /// iterating, and so the resulting transaction is deterministic.
+    pub fn implied_extension_sources(&self, target: &str) -> Vec<(String, ExtensionSourceLock)> {
+        let Some(target_locks) = self.targets.get(target) else {
+            return Vec::new();
+        };
+        let mut out: Vec<(String, ExtensionSourceLock)> = target_locks
+            .extensions
+            .iter()
+            .filter_map(|(name, ext)| {
+                let source = ext.source.as_ref()?;
+                source.implied.then(|| (name.clone(), source.clone()))
+            })
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
+    }
+
     /// Set the source metadata for a fetched extension
     pub fn set_extension_source(
         &mut self,
@@ -1614,6 +1657,63 @@ mod tests {
         let lock = LockFile::new();
         assert_eq!(lock.version, LOCKFILE_VERSION);
         assert!(lock.targets.is_empty());
+    }
+
+    // ---- implied (depsolver-pulled) extension pins ----------------------
+
+    fn src(pkg: &str, version: &str, implied: bool) -> ExtensionSourceLock {
+        ExtensionSourceLock {
+            source_type: "package".to_string(),
+            package: Some(pkg.to_string()),
+            version: Some(version.to_string()),
+            implied,
+        }
+    }
+
+    #[test]
+    fn implied_sources_are_separable_from_declared_ones() {
+        let mut lock = LockFile::new();
+        lock.set_extension_source("t", "app-a", src("app-a", "0.1.0-r0", false));
+        lock.set_extension_source("t", "base", src("base", "1.2.0-r0", true));
+        lock.set_extension_source("t", "mid", src("mid", "0.3.0-r0", true));
+
+        let implied = lock.implied_extension_sources("t");
+        let names: Vec<&str> = implied.iter().map(|(n, _)| n.as_str()).collect();
+        // Sorted, so the replayed transaction is deterministic.
+        assert_eq!(names, vec!["base", "mid"]);
+        assert_eq!(implied[0].1.version.as_deref(), Some("1.2.0-r0"));
+    }
+
+    #[test]
+    fn implied_sources_are_empty_for_an_unknown_target() {
+        let mut lock = LockFile::new();
+        lock.set_extension_source("t", "base", src("base", "1.2.0-r0", true));
+        assert!(lock.implied_extension_sources("other-target").is_empty());
+    }
+
+    #[test]
+    fn implied_defaults_to_false_and_is_omitted_when_false() {
+        // Additive field: existing locks deserialize with implied=false, and a
+        // declared entry must not start emitting a new key.
+        let json = r#"{"type":"package","package":"app-a","version":"0.1.0-r0"}"#;
+        let parsed: ExtensionSourceLock = serde_json::from_str(json).unwrap();
+        assert!(!parsed.implied);
+
+        let round = serde_json::to_string(&parsed).unwrap();
+        assert!(
+            !round.contains("implied"),
+            "declared entries must stay byte-identical: {round}"
+        );
+    }
+
+    #[test]
+    fn implied_true_survives_a_round_trip() {
+        let s = src("base", "1.2.0-r0", true);
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains("implied"));
+        let back: ExtensionSourceLock = serde_json::from_str(&json).unwrap();
+        assert!(back.implied);
+        assert_eq!(back.version.as_deref(), Some("1.2.0-r0"));
     }
 
     #[test]
@@ -2589,6 +2689,7 @@ avocado-sdk-toolchain 0.1.0-r0.x86_64_avocadosdk
                 source_type: "package".to_string(),
                 package: Some("avocado-ext-remote".to_string()),
                 version: Some("1.0.0-1.el9.x86_64".to_string()),
+                implied: false,
             },
         );
 
@@ -2624,6 +2725,7 @@ avocado-sdk-toolchain 0.1.0-r0.x86_64_avocadosdk
                 source_type: "package".to_string(),
                 package: None,
                 version: None,
+                implied: false,
             },
         );
         lock.clear_extension(target, ext_name);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,7 @@ pub mod config_edit;
 pub mod container;
 #[cfg(target_os = "macos")]
 pub mod disk_writer;
+pub mod ext_deps;
 pub mod ext_fetch;
 pub mod host_copy;
 pub mod image_signing;

--- a/src/utils/stamps.rs
+++ b/src/utils/stamps.rs
@@ -1060,7 +1060,57 @@ pub fn compute_ext_install_input_hash(
     config: &serde_yaml::Value,
     ext_name: &str,
 ) -> Result<StampInputs> {
+    compute_ext_install_input_hash_with_deps(config, ext_name, &[])
+}
+
+/// Like [`compute_ext_install_input_hash`], but folds in the state of the
+/// extensions this one was seeded from.
+///
+/// An extension de-duplicated against a dependency only ships the files that
+/// dependency does *not* provide, so its image is a function of the
+/// dependency's contents as well as its own config. Without that in the hash,
+/// changing a dependency leaves every dependent's stamp valid and their
+/// sysroots stale.
+///
+/// The dangerous direction is subtle: if a dependency **drops** a package, the
+/// dependency rebuilds correctly while the dependent keeps an image that
+/// omitted those files precisely because the dependency used to supply them.
+/// Nothing then provides them, and the gap only appears in the merged `/usr`
+/// on-device. Over-invalidating costs a rebuild; under-invalidating ships a
+/// broken image.
+///
+/// `dep_state` is `(dependency name, fingerprint)` — typically the
+/// dependency's resolved package versions plus its own source version, taken
+/// from the lock. Topological install order guarantees those are current
+/// before a dependent's hash is computed.
+///
+/// Known gap: a fingerprint built from the lock's declared packages does not
+/// move when a *transitive* rpm dependency drifts beneath the dependency (say
+/// openssl bumping under openssh while openssh's own version holds). Catching
+/// that needs the dependency's full sysroot NVRA set.
+pub fn compute_ext_install_input_hash_with_deps(
+    config: &serde_yaml::Value,
+    ext_name: &str,
+    dep_state: &[(String, String)],
+) -> Result<StampInputs> {
     let mut hash_data = serde_yaml::Mapping::new();
+
+    if !dep_state.is_empty() {
+        // Sorted so the hash does not depend on map iteration order.
+        let mut sorted = dep_state.to_vec();
+        sorted.sort();
+        let mut deps = serde_yaml::Mapping::new();
+        for (name, fingerprint) in sorted {
+            deps.insert(
+                serde_yaml::Value::String(name),
+                serde_yaml::Value::String(fingerprint),
+            );
+        }
+        hash_data.insert(
+            serde_yaml::Value::String(format!("ext.{ext_name}.seeded_from")),
+            serde_yaml::Value::Mapping(deps),
+        );
+    }
 
     if let Some(ext) = config.get("extensions").and_then(|e| e.get(ext_name)) {
         if let Some(deps) = ext.get("packages") {
@@ -3336,6 +3386,69 @@ extensions:
         compute_ext_install_input_hash(value, "my-ext")
             .unwrap()
             .config_hash
+    }
+
+    fn ext_install_hash_with_deps(value: &serde_yaml::Value, deps: &[(String, String)]) -> String {
+        compute_ext_install_input_hash_with_deps(value, "my-ext", deps)
+            .unwrap()
+            .config_hash
+    }
+
+    fn dep(name: &str, fingerprint: &str) -> (String, String) {
+        (name.to_string(), fingerprint.to_string())
+    }
+
+    #[test]
+    fn dependency_change_invalidates_the_dependent() {
+        // The reason this exists: a de-duplicated extension only ships what
+        // its dependency does not provide, so its image is a function of the
+        // dependency's contents. Without this the dependent's stamp stays
+        // valid, its sysroot stays seeded from the old dependency, and if the
+        // dependency *dropped* a package nothing provides those files at all.
+        let cfg = ext_with_extras("");
+        let before = ext_install_hash_with_deps(&cfg, &[dep("base", "1.2.0|openssh=9.6p1")]);
+        let after = ext_install_hash_with_deps(&cfg, &[dep("base", "1.2.0|openssh=9.7p1")]);
+        assert_ne!(
+            before, after,
+            "a dependency's package change must invalidate its dependent"
+        );
+    }
+
+    #[test]
+    fn dependency_version_bump_invalidates_the_dependent() {
+        let cfg = ext_with_extras("");
+        let before = ext_install_hash_with_deps(&cfg, &[dep("base", "1.2.0|openssh=9.6p1")]);
+        let after = ext_install_hash_with_deps(&cfg, &[dep("base", "1.3.0|openssh=9.6p1")]);
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn identical_dependency_state_is_stable() {
+        // Over-invalidating costs a needless rebuild every run, which erodes
+        // trust in stamps as much as under-invalidating does.
+        let cfg = ext_with_extras("");
+        let a = ext_install_hash_with_deps(&cfg, &[dep("base", "1.2.0|openssh=9.6p1")]);
+        let b = ext_install_hash_with_deps(&cfg, &[dep("base", "1.2.0|openssh=9.6p1")]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn dependency_order_does_not_affect_the_hash() {
+        let cfg = ext_with_extras("");
+        let a = ext_install_hash_with_deps(&cfg, &[dep("base", "1"), dep("mid", "2")]);
+        let b = ext_install_hash_with_deps(&cfg, &[dep("mid", "2"), dep("base", "1")]);
+        assert_eq!(a, b, "hash must not depend on iteration order");
+    }
+
+    #[test]
+    fn no_dependencies_matches_the_plain_hash() {
+        // Extensions without `depends_on` must keep their existing stamps —
+        // this change must not invalidate every extension in every project.
+        let cfg = ext_with_extras("");
+        assert_eq!(
+            ext_install_hash(&cfg),
+            ext_install_hash_with_deps(&cfg, &[])
+        );
     }
 
     fn ext_build_hash(value: &serde_yaml::Value) -> String {


### PR DESCRIPTION
Lets an extension declare that it needs another extension, so a shared runtime stack is factored into one platform extension instead of every consumer bundling its own copy.

```yaml
extensions:
  weston-base:
    class: platform
    packages: { weston: '*', wayland: '*' }
  kiosk-a:
    depends_on:
      - { name: weston-base, version: "^1.2.0" }
```

The author names only what they care about; the platform bases those depend on arrive on their own.

## Measured effect

Two apps on a shared weston stack, `intel-x86-64-v3`, against a live feed. Control is an app with identical packages but no `depends_on`, measured in the same run:

```
weston-base (shared platform)   48.3 MB
control app (no dedup)          51.8 MB   ships its own copy of weston
kiosk-a (dedup)                  3.5 MB   weston gone, keeps its own openssh
kiosk-b (dedup)                  2.3 MB   weston gone, keeps its own ca-certificates
```

Per app: **51.8 MB -> 3.5 MB (93%)**. Whole set: **150.7 MB -> 54.1 MB, saving 96.6 MB (64%)**.

Two independent checks that this is real: the amount saved equals `weston-base`'s payload exactly, and kiosk-a's remainder equals the openssh payload measured separately. The arithmetic closes to the byte in both directions.

Full writeup: `avocado-ai/features/ext-ext-deps/deduplication-report.md`.

## How it works

An extension's image is the net-new files over whatever its rpmdb claims is installed. Every extension seeded that rpmdb from the rootfs, so a dependency's packages looked absent and dnf installed a second private copy. Seeding from the dependency's sysroot instead makes them look present and dnf omits them — `already installed. Nothing to do.`

No new image format, no runtime object store, no change to how avocadoctl merges.

## Decisions worth reviewer attention

**Virtual capability, not the RPM name.** `source.package` can rename a package, which would break a literal `Requires: weston-base`. Depending on `avocado-ext(<name>)` is rename-proof.

**Two deliberately opposite orderings.** `ext install` orders dependencies first (a dep's sysroot must exist to seed from). The runtime manifest orders parent first — `merge_idx = count - 1 - index` means earlier wins, so an app must outrank the base it pulled in. Swapping them silently inverts merge precedence.

**Lock drift: warn by default, `--locked` to fail.** Mirrors `cargo --locked` / `npm ci`. The conflict is only reachable because something the author changed invalidated the old solution, and the lock is committed so the update lands as a reviewable diff. Downgrades fail regardless — a constraint dragging a shared base backwards has no benign reading.

**An unfetched extension is refused, not assumed empty.** A `git`/`package` extension that hasn't been fetched is a bare `source:` stub, and a stub with no `depends_on` is shape-identical to one that genuinely has none. Resolving it as dependency-free would silently drop its subtree.

## Also fixed along the way

- The lock never recorded the dependency closure, and `version: "*"` round-tripped as `"*"` — a lock that pinned nothing while looking like it did. Resolved versions now come from the installroot's rpmdb after the transaction.
- `ext fetch` discovery and `find_extension_in_dependency_tree` read declarations where they needed the composed value, so depsolver-pulled extensions were invisible and unaddressable by name.
- Dependents went stale when a dependency changed. The quiet direction: a dependency *dropping* a package leaves the dependent shipping an image that omitted those files because the dependency used to supply them — the gap only appears in the merged /usr on-device.
- Batched the layout probe and `--force` removes: a forced re-fetch went from six dnf transactions to two.

## Verification

2641 tests. `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo build`, `cargo test` all pass by exit code. No dependency changes (`Cargo.toml`/`Cargo.lock` untouched).

## Known limitations

- An extension with two or more direct dependencies de-duplicates against the first only; packages unique to the others still ship twice. It warns and names them. The full union needs `rpm --justdb` header replay.
- Transitive rpm drift beneath a dependency is not detected (openssl bumping under openssh with openssh's own version unchanged).
- Extensions published before this change carry no `avocado-ext(...)` provides, so every dependency target must be republished before any dependent ships. Worth deciding whether `Requires:` should be opt-in for one release.
- A deduplicated image is intentionally not standalone. Nothing on-device yet verifies it merged with the base it was built against — that needs the manifest sealing work.
- `runtime build`'s stamp pre-check still reads the unexpanded runtime list, so it and `AVOCADO_EXT_LIST` disagree about whether pulled-in dependencies need stamps.
- `avocado ext deps` still reads only the deprecated `packages.<dep>.extensions` form.