### PR TITLE
fix(container): derive PTY allocation from the environment, not intent

### DIFF
--- a/src/commands/connect/upload.rs
+++ b/src/commands/connect/upload.rs
@@ -848,6 +848,7 @@ impl ConnectUploadCommand {
                 Ok(parts) => parts,
                 Err(e) => {
                     let _ = tokio::process::Command::new(&container_tool)
+                        // stdio-flags-ok: docker stop timeout in seconds, not a tty
                         .args(["stop", "-t", "2", &container_name_ref])
                         .stdout(Stdio::null())
                         .stderr(Stdio::null())

--- a/src/utils/container.rs
+++ b/src/utils/container.rs
@@ -1181,10 +1181,16 @@ impl SdkContainer {
             extra_args.extend(args.clone());
         }
 
-        // Same intent-vs-capability rule as the local path: a remote container
-        // gets a PTY only if this process actually has one to forward.
+        // Same intent-vs-capability rule as the local path, including the
+        // per-run TUI context. Using `for_intent` here would consult only the
+        // global renderer, so a caller that set `tui_context` without
+        // registering one would get `-i`/`-t` on the remote path while its
+        // output is being captured — the exact local/remote divergence this
+        // module exists to remove.
+        let mut caps = crate::utils::interactivity::StdioCapabilities::detect();
+        caps.tui_active |= config.tui_context.is_some();
         for flag in
-            crate::utils::interactivity::ContainerStdio::for_intent(config.interactive).flags()
+            crate::utils::interactivity::ContainerStdio::decide(config.interactive, &caps).flags()
         {
             extra_args.push((*flag).to_string());
         }
@@ -3170,7 +3176,10 @@ mod tests {
             // link that was missing, and it holds whether the suite runs from
             // a terminal or from CI.
             for interactive in [true, false] {
-                let expected = crate::utils::interactivity::ContainerStdio::for_intent(interactive);
+                let expected = crate::utils::interactivity::ContainerStdio::decide(
+                    interactive,
+                    &crate::utils::interactivity::StdioCapabilities::detect(),
+                );
                 let cmd = argv(interactive);
                 assert_eq!(
                     has_tty_flag(&cmd),

--- a/src/utils/container.rs
+++ b/src/utils/container.rs
@@ -1181,8 +1181,12 @@ impl SdkContainer {
             extra_args.extend(args.clone());
         }
 
-        if config.interactive {
-            extra_args.push("-it".to_string());
+        // Same intent-vs-capability rule as the local path: a remote container
+        // gets a PTY only if this process actually has one to forward.
+        for flag in
+            crate::utils::interactivity::ContainerStdio::for_intent(config.interactive).flags()
+        {
+            extra_args.push((*flag).to_string());
         }
 
         let extra_args_refs: Vec<&str> = extra_args.iter().map(|s| s.as_str()).collect();
@@ -1253,17 +1257,20 @@ impl SdkContainer {
         // TTY) and skip -i too — dnf prompts would deadlock against
         // an empty stdin. Treat JSON mode as the same constraint set
         // as TUI mode.
-        let global_tui_active = crate::utils::tui::get_active_renderer().is_some();
-        let json_active = crate::utils::output_format::is_json_output_active();
-        if config.interactive && !json_active {
-            // Explicit interactive mode (e.g. avocado shell): full -it
-            container_cmd.push("-i".to_string());
-            container_cmd.push("-t".to_string());
-        } else if config.tui_context.is_none() && !global_tui_active && !json_active {
-            // Non-TUI mode: keep stdin open for prompts, no PTY
-            container_cmd.push("-i".to_string());
+        // Intent (`config.interactive`) is combined with what the environment
+        // can actually provide by `ContainerStdio` — crucially including
+        // whether stdin is a terminal, which decides whether `-t` is even
+        // legal. See utils::interactivity for the full matrix and why this
+        // must not be decided here.
+        let mut caps = crate::utils::interactivity::StdioCapabilities::detect();
+        // A per-run TUI context counts as TUI-active even when no global
+        // renderer is registered.
+        caps.tui_active |= config.tui_context.is_some();
+
+        let stdio = crate::utils::interactivity::ContainerStdio::decide(config.interactive, &caps);
+        for flag in stdio.flags() {
+            container_cmd.push((*flag).to_string());
         }
-        // TUI mode / JSON mode: no -i, no -t (output is piped)
 
         // Add FUSE device and capability for bindfs support
         container_cmd.push("--device".to_string());

--- a/src/utils/container.rs
+++ b/src/utils/container.rs
@@ -3113,6 +3113,112 @@ async fn read_output_stream<R: tokio::io::AsyncRead + Unpin>(
 mod tests {
     use super::*;
 
+    /// Wiring tests for container stdio.
+    ///
+    /// `utils::interactivity` tests the *decision*; these test that the
+    /// decision is actually applied to the argv. That distinction matters:
+    /// the original bug was not a wrong decision, it was that the assembled
+    /// command never consulted stdin at all. Deleting the `stdio.flags()`
+    /// loop leaves every interactivity unit test green — only these fail.
+    mod stdio_wiring {
+        use super::*;
+        use crate::utils::volume::VolumeState;
+        use std::io::IsTerminal;
+
+        fn container() -> SdkContainer {
+            SdkContainer::new()
+        }
+
+        fn volume_state() -> VolumeState {
+            VolumeState::new(PathBuf::from("/tmp/avocado-test"), "docker".to_string())
+        }
+
+        fn argv(interactive: bool) -> Vec<String> {
+            let config = RunConfig {
+                container_image: "example/sdk:test".to_string(),
+                target: "qemux86-64".to_string(),
+                command: "true".to_string(),
+                interactive,
+                ..Default::default()
+            };
+            container()
+                .build_container_command(
+                    &config,
+                    &["true".to_string()],
+                    &HashMap::new(),
+                    &volume_state(),
+                )
+                .expect("command assembly should not fail")
+        }
+
+        /// Whether `-t` appears as a standalone argument (not as part of
+        /// `--platform` values or a path).
+        fn has_tty_flag(cmd: &[String]) -> bool {
+            // stdio-flags-ok: asserting on the assembled argv, not building it
+            cmd.iter().any(|a| a == "-t")
+        }
+
+        fn has_stdin_flag(cmd: &[String]) -> bool {
+            // stdio-flags-ok: asserting on the assembled argv, not building it
+            cmd.iter().any(|a| a == "-i")
+        }
+
+        #[test]
+        fn assembled_command_matches_the_stdio_decision() {
+            // Environment-independent: whatever the harness's stdin is, the
+            // argv must agree with what `interactivity` decided. This is the
+            // link that was missing, and it holds whether the suite runs from
+            // a terminal or from CI.
+            for interactive in [true, false] {
+                let expected = crate::utils::interactivity::ContainerStdio::for_intent(interactive);
+                let cmd = argv(interactive);
+                assert_eq!(
+                    has_tty_flag(&cmd),
+                    expected.allocates_tty(),
+                    "interactive={interactive}: tty flag in argv disagrees with {expected:?}"
+                );
+                assert_eq!(
+                    has_stdin_flag(&cmd),
+                    expected.keeps_stdin(),
+                    "interactive={interactive}: stdin flag in argv disagrees with {expected:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn never_requests_a_pty_without_a_terminal() {
+            // The original regression, asserted directly against the argv.
+            // Under CI (and any piped run) stdin is not a terminal, so an
+            // interactive command must still assemble without `-t` — Docker
+            // rejects that combination outright.
+            if std::io::stdin().is_terminal() {
+                // Running from a terminal; the precondition doesn't hold here.
+                // `assembled_command_matches_the_stdio_decision` still covers
+                // the linkage, and CI exercises this branch for real.
+                return;
+            }
+            let cmd = argv(true);
+            assert!(
+                !has_tty_flag(&cmd),
+                "asked for -t with no terminal on stdin; docker refuses this: {cmd:?}"
+            );
+            assert!(
+                has_stdin_flag(&cmd),
+                "stdin should stay open so piped answers still work: {cmd:?}"
+            );
+        }
+
+        #[test]
+        fn a_tty_flag_never_appears_without_stdin() {
+            for interactive in [true, false] {
+                let cmd = argv(interactive);
+                if has_tty_flag(&cmd) {
+                    assert!(has_stdin_flag(&cmd), "-t without -i in {cmd:?}");
+                }
+            }
+        }
+    }
+
     #[test]
     fn failure_detail_none_for_blank_stderr() {
         assert_eq!(container_failure_detail("", 10), None);

--- a/src/utils/container.rs
+++ b/src/utils/container.rs
@@ -2025,6 +2025,7 @@ impl SdkContainer {
                         // Stop the container gracefully
                         if let Some(name) = container_name {
                             let stop_result = AsyncCommand::new(&self.container_tool)
+                                // stdio-flags-ok: docker stop timeout in seconds, not a tty
                                 .args(["stop", "-t", "2", name])
                                 .stdout(Stdio::null())
                                 .stderr(Stdio::null())
@@ -2149,6 +2150,7 @@ impl SdkContainer {
                 // Stop the container gracefully
                 if let Some(name) = container_name {
                     let _ = AsyncCommand::new(&self.container_tool)
+                        // stdio-flags-ok: docker stop timeout in seconds, not a tty
                         .args(["stop", "-t", "2", name])
                         .stdout(Stdio::null())
                         .stderr(Stdio::null())

--- a/src/utils/disk_writer.rs
+++ b/src/utils/disk_writer.rs
@@ -291,11 +291,26 @@ impl DiskWriter {
     }
 
     fn prompt_disk_selection(&self, count: usize) -> Result<usize> {
+        // Without a terminal this loop never terminates: `read_line` returns
+        // Ok(0) at EOF leaving `input` empty, the parse fails, and it spins
+        // printing "Invalid selection" forever. Fail with something actionable
+        // instead of hanging.
+        if !crate::utils::interactivity::can_prompt_user() {
+            anyhow::bail!(
+                "Multiple removable devices were found, but there is no terminal \
+                 to ask which one to use.\n\
+                 Pass the device explicitly instead of selecting it interactively."
+            );
+        }
         loop {
             print!("Select device [1-{}]: ", count);
             std::io::stdout().flush()?;
             let mut input = String::new();
-            std::io::stdin().lock().read_line(&mut input)?;
+            // EOF also breaks the loop, so a closed stdin cannot spin even if
+            // the guard above is ever bypassed.
+            if std::io::stdin().lock().read_line(&mut input)? == 0 {
+                anyhow::bail!("stdin closed while waiting for a device selection");
+            }
             if let Ok(n) = input.trim().parse::<usize>() {
                 if n >= 1 && n <= count {
                     return Ok(n - 1);
@@ -309,6 +324,12 @@ impl DiskWriter {
     }
 
     fn confirm(&self, prompt: &str) -> Result<bool> {
+        // No terminal means no consent. This gates a destructive raw-device
+        // write, so an unanswerable prompt must read as "no", never as a
+        // default yes.
+        if !crate::utils::interactivity::can_prompt_user() {
+            return Ok(false);
+        }
         print!("{}", prompt);
         std::io::stdout().flush()?;
         let mut input = String::new();

--- a/src/utils/interactivity.rs
+++ b/src/utils/interactivity.rs
@@ -139,6 +139,23 @@ impl ContainerStdio {
         Self::decide(wants_interactive, &StdioCapabilities::detect())
     }
 
+    /// Whether a PTY is allocated. Prefer this to inspecting [`Self::flags`]
+    /// so callers and tests never have to spell `-t` themselves — which also
+    /// keeps them clear of the source guard that forbids those literals.
+    ///
+    /// Consumed by tests today; `allow(dead_code)` matches how the crate
+    /// already handles lib-public items the binary happens not to call.
+    #[allow(dead_code)]
+    pub fn allocates_tty(&self) -> bool {
+        matches!(self, Self::StdinAndTty)
+    }
+
+    /// Whether stdin is left open, with or without a PTY.
+    #[allow(dead_code)]
+    pub fn keeps_stdin(&self) -> bool {
+        matches!(self, Self::StdinOnly | Self::StdinAndTty)
+    }
+
     /// The docker/podman flags this arrangement implies.
     ///
     /// The single place `-i` and `-t` are spelled. Anything else pushing them
@@ -253,6 +270,68 @@ mod tests {
                     }
                 }
             }
+        }
+    }
+
+    // ---- the environment bridge ----------------------------------------
+    //
+    // `detect`, `for_intent`, and `can_prompt_user` read the real process
+    // environment, which is exactly where the original bug lived — the pure
+    // decision was never wrong, it simply was not asked about stdin. These
+    // assert invariants that hold whether the suite runs from a terminal or
+    // from CI, rather than hard-coding either, so they cannot pass in one
+    // place and fail in the other.
+
+    #[test]
+    fn for_intent_actually_consults_stdin() {
+        let caps = StdioCapabilities::detect();
+        let got = ContainerStdio::for_intent(true);
+        let expect_pty = caps.stdin_is_tty && !caps.json_active && !caps.forced_noninteractive;
+        assert_eq!(
+            got == ContainerStdio::StdinAndTty,
+            expect_pty,
+            "for_intent disagreed with detected capabilities {caps:?} -> {got:?}"
+        );
+    }
+
+    #[test]
+    fn a_noninteractive_command_never_gets_a_pty_in_any_environment() {
+        assert_ne!(
+            ContainerStdio::for_intent(false),
+            ContainerStdio::StdinAndTty
+        );
+    }
+
+    #[test]
+    fn can_prompt_user_agrees_with_the_container_decision() {
+        // If we would give a container a PTY, we can also prompt ourselves,
+        // and vice versa. Divergence would mean the two halves of the module
+        // disagree about what "interactive" means.
+        assert_eq!(
+            can_prompt_user(),
+            ContainerStdio::for_intent(true) == ContainerStdio::StdinAndTty
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn forced_noninteractive_env_var_is_honored_end_to_end() {
+        let prev = std::env::var("AVOCADO_NONINTERACTIVE").ok();
+
+        std::env::set_var("AVOCADO_NONINTERACTIVE", "1");
+        assert!(StdioCapabilities::detect().forced_noninteractive);
+        assert_ne!(
+            ContainerStdio::for_intent(true),
+            ContainerStdio::StdinAndTty,
+            "AVOCADO_NONINTERACTIVE must suppress the PTY even on a terminal"
+        );
+        assert!(!can_prompt_user());
+
+        std::env::remove_var("AVOCADO_NONINTERACTIVE");
+        assert!(!StdioCapabilities::detect().forced_noninteractive);
+
+        if let Some(v) = prev {
+            std::env::set_var("AVOCADO_NONINTERACTIVE", v);
         }
     }
 

--- a/src/utils/interactivity.rs
+++ b/src/utils/interactivity.rs
@@ -134,11 +134,6 @@ impl ContainerStdio {
         }
     }
 
-    /// Detect the environment and decide in one step.
-    pub fn for_intent(wants_interactive: bool) -> Self {
-        Self::decide(wants_interactive, &StdioCapabilities::detect())
-    }
-
     /// Whether a PTY is allocated. Prefer this to inspecting [`Self::flags`]
     /// so callers and tests never have to spell `-t` themselves — which also
     /// keeps them clear of the source guard that forbids those literals.
@@ -285,7 +280,7 @@ mod tests {
     #[test]
     fn for_intent_actually_consults_stdin() {
         let caps = StdioCapabilities::detect();
-        let got = ContainerStdio::for_intent(true);
+        let got = ContainerStdio::decide(true, &StdioCapabilities::detect());
         let expect_pty = caps.stdin_is_tty && !caps.json_active && !caps.forced_noninteractive;
         assert_eq!(
             got == ContainerStdio::StdinAndTty,
@@ -297,7 +292,7 @@ mod tests {
     #[test]
     fn a_noninteractive_command_never_gets_a_pty_in_any_environment() {
         assert_ne!(
-            ContainerStdio::for_intent(false),
+            ContainerStdio::decide(false, &StdioCapabilities::detect()),
             ContainerStdio::StdinAndTty
         );
     }
@@ -309,7 +304,8 @@ mod tests {
         // disagree about what "interactive" means.
         assert_eq!(
             can_prompt_user(),
-            ContainerStdio::for_intent(true) == ContainerStdio::StdinAndTty
+            ContainerStdio::decide(true, &StdioCapabilities::detect())
+                == ContainerStdio::StdinAndTty
         );
     }
 
@@ -321,7 +317,7 @@ mod tests {
         std::env::set_var("AVOCADO_NONINTERACTIVE", "1");
         assert!(StdioCapabilities::detect().forced_noninteractive);
         assert_ne!(
-            ContainerStdio::for_intent(true),
+            ContainerStdio::decide(true, &StdioCapabilities::detect()),
             ContainerStdio::StdinAndTty,
             "AVOCADO_NONINTERACTIVE must suppress the PTY even on a terminal"
         );

--- a/src/utils/interactivity.rs
+++ b/src/utils/interactivity.rs
@@ -62,6 +62,27 @@ impl StdioCapabilities {
     }
 }
 
+/// Whether this process can meaningfully prompt the user *itself* — as
+/// opposed to handing stdio to a container.
+///
+/// Host-side prompts fail differently and more quietly than the container
+/// case. `stdin().read_line()` at EOF returns `Ok(0)` and leaves the buffer
+/// empty: no error, no signal, just an empty answer. A confirmation that
+/// treats empty as "no" degrades safely, but a `loop { read_line; complain }`
+/// spins forever printing to a log nobody is reading.
+///
+/// Anything that blocks on the user must check this first and take a defined
+/// path when it is false — usually erroring with a flag to pass instead.
+///
+/// Currently consulted only from the macOS-only disk writer, hence the
+/// targeted allow: it is genuinely unused elsewhere today, and a blanket
+/// `allow(dead_code)` would hide it going unused on macOS too.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn can_prompt_user() -> bool {
+    let caps = StdioCapabilities::detect();
+    caps.stdin_is_tty && !caps.json_active && !caps.forced_noninteractive
+}
+
 /// The stdio arrangement a container should be given.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContainerStdio {

--- a/src/utils/interactivity.rs
+++ b/src/utils/interactivity.rs
@@ -1,0 +1,253 @@
+//! Whether this process can offer a human at the keyboard — and what that
+//! means for the stdio flags handed to a container.
+//!
+//! # The trap this exists to close
+//!
+//! Every command that runs a container builds a `RunConfig` and writes
+//! `interactive: <bool>` by hand. There are ~100 such sites. That field is a
+//! statement of *intent* ("this command wants to prompt"), but it was being
+//! used directly as a *capability* ("a terminal is attached"), so any command
+//! declaring intent became unusable wherever no terminal exists — agents, CI,
+//! pipes, the desktop app driver. Docker refuses outright:
+//!
+//! ```text
+//! cannot attach stdin to a TTY-enabled container because stdin is not a terminal
+//! ```
+//!
+//! The output layer already gets this right: [`crate::utils::output::should_use_tui`]
+//! ANDs intent (no explicit opt-out) with capability (`stderr().is_terminal()`,
+//! not CI). Container stdio simply never asked the same question — and it has
+//! to ask it of **stdin**, not stderr. That asymmetry is the whole bug.
+//!
+//! # The shape of the fix
+//!
+//! Intent stays where it is; call sites are unchanged. Capability is detected
+//! once, here, and the two are combined by one pure function whose entire
+//! truth table is tested. A new command can set `interactive: true` and still
+//! work headless, because the runner downgrades instead of failing.
+//!
+//! Adding a command that runs a container? Say what it *wants* and let this
+//! decide what it *gets*. Never hand-roll `-i` / `-t`.
+
+use std::io::IsTerminal;
+
+/// What the environment can actually support, detected once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StdioCapabilities {
+    /// A real terminal is attached to stdin. The one signal the old code
+    /// never consulted.
+    pub stdin_is_tty: bool,
+    /// NDJSON event stream — the desktop app driver, not a person. Its stdin
+    /// is a pipe, and a dnf prompt would deadlock against it.
+    pub json_active: bool,
+    /// A TUI renderer owns the terminal; container output is piped to it.
+    pub tui_active: bool,
+    /// Explicit opt-out for scripted and agent-driven runs, independent of
+    /// whether a tty happens to be attached.
+    pub forced_noninteractive: bool,
+}
+
+impl StdioCapabilities {
+    pub fn detect() -> Self {
+        Self {
+            stdin_is_tty: std::io::stdin().is_terminal(),
+            json_active: crate::utils::output_format::is_json_output_active(),
+            tui_active: crate::utils::tui::get_active_renderer().is_some(),
+            // `CI` is deliberately *not* consulted here. `should_use_tui`
+            // checks it to avoid painting a TUI into a build log, but a CI job
+            // may still legitimately pipe answers to a prompt. The tty check
+            // already covers the case that matters.
+            forced_noninteractive: std::env::var("AVOCADO_NONINTERACTIVE").is_ok(),
+        }
+    }
+}
+
+/// The stdio arrangement a container should be given.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerStdio {
+    /// Neither `-i` nor `-t`: output is piped and captured, nothing will be
+    /// read from stdin.
+    Piped,
+    /// `-i` only: stdin stays open so prompts can be answered from a pipe or
+    /// heredoc, but no PTY is allocated. dnf prompts still work here — they
+    /// just lose the progress-bar rendering.
+    StdinOnly,
+    /// `-i -t`: a real person at a real terminal.
+    StdinAndTty,
+}
+
+impl ContainerStdio {
+    /// Combine what the command wants with what the environment can give.
+    ///
+    /// `wants_interactive` is the caller's intent — `RunConfig::interactive`.
+    ///
+    /// The only way to reach [`ContainerStdio::StdinAndTty`] is for the caller
+    /// to want it *and* for stdin to actually be a terminal. Everything else
+    /// degrades rather than failing, which is what makes the command usable
+    /// headless.
+    pub fn decide(wants_interactive: bool, caps: &StdioCapabilities) -> Self {
+        // JSON mode: a machine is driving. Prose and prompts both break the
+        // event stream, and a prompt would block forever on a pipe nobody is
+        // writing to.
+        if caps.json_active {
+            return Self::Piped;
+        }
+
+        if wants_interactive && !caps.forced_noninteractive {
+            return if caps.stdin_is_tty {
+                Self::StdinAndTty
+            } else {
+                // Wanted a terminal, hasn't got one. Keep stdin open so a
+                // piped answer still lands; do NOT ask for a PTY, which is
+                // the error Docker refuses on.
+                Self::StdinOnly
+            };
+        }
+
+        // Non-interactive commands: a TUI owns the terminal, so its output is
+        // captured; otherwise leave stdin open for the occasional prompt.
+        if caps.tui_active {
+            Self::Piped
+        } else {
+            Self::StdinOnly
+        }
+    }
+
+    /// Detect the environment and decide in one step.
+    pub fn for_intent(wants_interactive: bool) -> Self {
+        Self::decide(wants_interactive, &StdioCapabilities::detect())
+    }
+
+    /// The docker/podman flags this arrangement implies.
+    ///
+    /// The single place `-i` and `-t` are spelled. Anything else pushing them
+    /// onto a container command line is a bug.
+    pub fn flags(&self) -> &'static [&'static str] {
+        match self {
+            Self::Piped => &[],
+            Self::StdinOnly => &["-i"],
+            Self::StdinAndTty => &["-i", "-t"],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every capability combination, so the matrix is documented and locked
+    /// rather than living in one branch of a 400-line function.
+    fn caps(
+        stdin_is_tty: bool,
+        json_active: bool,
+        tui_active: bool,
+        forced: bool,
+    ) -> StdioCapabilities {
+        StdioCapabilities {
+            stdin_is_tty,
+            json_active,
+            tui_active,
+            forced_noninteractive: forced,
+        }
+    }
+
+    #[test]
+    fn interactive_with_a_terminal_gets_a_pty() {
+        let c = caps(true, false, false, false);
+        assert_eq!(
+            ContainerStdio::decide(true, &c),
+            ContainerStdio::StdinAndTty
+        );
+        assert_eq!(ContainerStdio::decide(true, &c).flags(), &["-i", "-t"]);
+    }
+
+    #[test]
+    fn interactive_without_a_terminal_degrades_instead_of_failing() {
+        // The regression this module exists for: an agent, a pipe, or a CI
+        // job running a command that declares `interactive: true`. Docker
+        // rejects `-i -t` here, so we must not ask for it — but stdin stays
+        // open so a piped answer still works.
+        let c = caps(false, false, false, false);
+        assert_eq!(ContainerStdio::decide(true, &c), ContainerStdio::StdinOnly);
+        assert_eq!(ContainerStdio::decide(true, &c).flags(), &["-i"]);
+    }
+
+    #[test]
+    fn json_mode_never_takes_stdin_even_when_interactive_is_wanted() {
+        // A prompt would deadlock against the driver's pipe.
+        for stdin_tty in [true, false] {
+            let c = caps(stdin_tty, true, false, false);
+            assert_eq!(ContainerStdio::decide(true, &c), ContainerStdio::Piped);
+            assert_eq!(ContainerStdio::decide(false, &c), ContainerStdio::Piped);
+        }
+    }
+
+    #[test]
+    fn forced_noninteractive_suppresses_the_pty_even_on_a_terminal() {
+        let c = caps(true, false, false, true);
+        assert_eq!(ContainerStdio::decide(true, &c), ContainerStdio::StdinOnly);
+    }
+
+    #[test]
+    fn tui_mode_pipes_noninteractive_commands() {
+        let c = caps(true, false, true, false);
+        assert_eq!(ContainerStdio::decide(false, &c), ContainerStdio::Piped);
+    }
+
+    #[test]
+    fn tui_mode_still_yields_to_an_explicitly_interactive_command() {
+        // `avocado shell` under a TUI still needs the terminal.
+        let c = caps(true, false, true, false);
+        assert_eq!(
+            ContainerStdio::decide(true, &c),
+            ContainerStdio::StdinAndTty
+        );
+    }
+
+    #[test]
+    fn noninteractive_without_tui_keeps_stdin_open_for_prompts() {
+        let c = caps(false, false, false, false);
+        assert_eq!(ContainerStdio::decide(false, &c), ContainerStdio::StdinOnly);
+    }
+
+    #[test]
+    fn a_pty_requires_both_intent_and_capability() {
+        // Exhaustive: the only route to StdinAndTty is (wants && stdin_tty &&
+        // !json && !forced). Anything else must degrade.
+        for wants in [true, false] {
+            for stdin_tty in [true, false] {
+                for json in [true, false] {
+                    for tui in [true, false] {
+                        for forced in [true, false] {
+                            let c = caps(stdin_tty, json, tui, forced);
+                            let got = ContainerStdio::decide(wants, &c);
+                            let expected_pty = wants && stdin_tty && !json && !forced;
+                            assert_eq!(
+                                got == ContainerStdio::StdinAndTty,
+                                expected_pty,
+                                "wants={wants} stdin_tty={stdin_tty} json={json} \
+                                 tui={tui} forced={forced} -> {got:?}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn no_arrangement_asks_for_a_tty_without_stdin() {
+        // `-t` without `-i` is never valid for our use; assert the flag sets
+        // stay well-formed.
+        for s in [
+            ContainerStdio::Piped,
+            ContainerStdio::StdinOnly,
+            ContainerStdio::StdinAndTty,
+        ] {
+            let f = s.flags();
+            if f.contains(&"-t") {
+                assert!(f.contains(&"-i"), "{s:?} asks for -t without -i");
+            }
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,7 @@ pub mod ext_fetch;
 pub mod host_copy;
 pub mod image_signing;
 pub mod install_method;
+pub mod interactivity;
 pub mod interpolation;
 pub mod jcs;
 pub mod kab_wrap;

--- a/src/utils/nfs_server.rs
+++ b/src/utils/nfs_server.rs
@@ -549,6 +549,7 @@ impl NfsServer {
 
             // Stop the container
             let _ = AsyncCommand::new(container_tool)
+                // stdio-flags-ok: docker stop timeout in seconds, not a tty
                 .args(["stop", "-t", "2", container_name])
                 .output()
                 .await;

--- a/src/utils/vm/forward.rs
+++ b/src/utils/vm/forward.rs
@@ -61,6 +61,7 @@ pub async fn start(paths: &VmPaths, ssh_port: u16) -> Result<u32> {
         "BatchMode=yes",
         "-o",
         "LogLevel=ERROR",
+        // stdio-flags-ok: ssh identity file, not stdin
         "-i",
         paths.ssh_key().to_str().context("ssh key path utf-8")?,
         "-p",

--- a/src/utils/vm/ssh.rs
+++ b/src/utils/vm/ssh.rs
@@ -45,6 +45,7 @@ impl SshTarget {
         vec![
             "-p".into(),
             self.port.to_string(),
+            // stdio-flags-ok: ssh identity file, not stdin
             "-i".into(),
             self.key.to_string_lossy().into_owned(),
             "-o".into(),

--- a/src/utils/vm/supervisor.rs
+++ b/src/utils/vm/supervisor.rs
@@ -533,6 +533,7 @@ fn spawn_ssh_tunnel(args: &RunArgs) -> Result<u32> {
         "BatchMode=yes",
         "-o",
         "LogLevel=ERROR",
+        // stdio-flags-ok: ssh identity file, not stdin
         "-i",
         args.ssh_key.to_str().context("ssh key path utf-8")?,
         "-p",

--- a/src/utils/volume.rs
+++ b/src/utils/volume.rs
@@ -478,6 +478,7 @@ impl VolumeManager {
         for container_id in &containers {
             // Stop the container gracefully with short timeout
             let _ = AsyncCommand::new(&self.container_tool)
+                // stdio-flags-ok: docker stop timeout in seconds, not a tty
                 .args(["stop", "-t", "1", container_id])
                 .output()
                 .await;

--- a/tests/no_hand_rolled_stdio_flags.rs
+++ b/tests/no_hand_rolled_stdio_flags.rs
@@ -36,11 +36,23 @@ fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
+/// Opt-out for the handful of places where `-t` legitimately means something
+/// else — `docker stop -t <seconds>` is a timeout, not a terminal.
+///
+/// An explicit marker rather than pattern-matching on `"stop"`: it forces the
+/// author to state why, and it cannot silently widen to cover a real PTY flag
+/// that happens to sit on the same line.
+const ALLOW_MARKER: &str = "stdio-flags-ok";
+
 /// Flag spellings that hand a PTY or stdin to a container.
+///
+/// Deliberately catches the bare literals, not just `push(...)`. An earlier
+/// version only looked for `push("-t"` and `"-it"`, which let
+/// `.args(["run", "-i", "-t", img])` through untouched — the guard has to
+/// cover every way the argument list can be built, or it just moves the trap
+/// one refactor away.
 fn offending_snippets(line: &str) -> Option<&'static str> {
-    // Only flag string literals that *are* the switch, not prose mentioning
-    // it, and not unrelated uses like `docker stop -t 2`.
-    const NEEDLES: [&str; 3] = ["\"-it\"", "push(\"-t\"", "push(\"-i\""];
+    const NEEDLES: [&str; 3] = ["\"-it\"", "\"-t\"", "\"-i\""];
     NEEDLES.into_iter().find(|n| line.contains(n))
 }
 
@@ -64,10 +76,20 @@ fn container_stdio_flags_come_only_from_the_interactivity_module() {
         let Ok(text) = fs::read_to_string(&file) else {
             continue;
         };
-        for (i, line) in text.lines().enumerate() {
+        let lines: Vec<&str> = text.lines().collect();
+        for (i, line) in lines.iter().enumerate() {
             let trimmed = line.trim_start();
             // Comments and doc comments may legitimately discuss the flags.
             if trimmed.starts_with("//") {
+                continue;
+            }
+            // The marker may sit on the line itself or, more readably, on the
+            // line above it.
+            let allowed_here = line.contains(ALLOW_MARKER);
+            let allowed_above = i
+                .checked_sub(1)
+                .is_some_and(|p| lines[p].contains(ALLOW_MARKER));
+            if allowed_here || allowed_above {
                 continue;
             }
             if let Some(needle) = offending_snippets(line) {

--- a/tests/no_hand_rolled_stdio_flags.rs
+++ b/tests/no_hand_rolled_stdio_flags.rs
@@ -1,0 +1,91 @@
+//! Guard: container stdio flags are decided in exactly one place.
+//!
+//! `-i` / `-t` must come from `utils::interactivity::ContainerStdio`, which
+//! combines what a command *wants* with what the environment can actually
+//! provide. A site that pushes them directly has, by construction, skipped the
+//! "is stdin even a terminal?" question — and that is the bug this guards:
+//!
+//! ```text
+//! cannot attach stdin to a TTY-enabled container because stdin is not a terminal
+//! ```
+//!
+//! Which makes the command unusable for agents, CI, pipes, and the desktop
+//! app driver. Reviewing for this by eye does not scale across ~100
+//! `RunConfig` construction sites, so it is checked here instead.
+//!
+//! If this fails: don't add an exemption. Call `ContainerStdio::for_intent`
+//! (or `::decide`) and push `.flags()`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The one module allowed to spell these flags.
+const SANCTIONED: &str = "interactivity.rs";
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Flag spellings that hand a PTY or stdin to a container.
+fn offending_snippets(line: &str) -> Option<&'static str> {
+    // Only flag string literals that *are* the switch, not prose mentioning
+    // it, and not unrelated uses like `docker stop -t 2`.
+    const NEEDLES: [&str; 3] = ["\"-it\"", "push(\"-t\"", "push(\"-i\""];
+    NEEDLES.into_iter().find(|n| line.contains(n))
+}
+
+#[test]
+fn container_stdio_flags_come_only_from_the_interactivity_module() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    rust_sources(&src, &mut files);
+    assert!(
+        !files.is_empty(),
+        "found no sources under {}",
+        src.display()
+    );
+
+    let mut violations = Vec::new();
+
+    for file in files {
+        if file.file_name().is_some_and(|n| n == SANCTIONED) {
+            continue;
+        }
+        let Ok(text) = fs::read_to_string(&file) else {
+            continue;
+        };
+        for (i, line) in text.lines().enumerate() {
+            let trimmed = line.trim_start();
+            // Comments and doc comments may legitimately discuss the flags.
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            if let Some(needle) = offending_snippets(line) {
+                violations.push(format!(
+                    "{}:{}: {} — use ContainerStdio::for_intent(..).flags()",
+                    file.display(),
+                    i + 1,
+                    needle
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "container stdio flags must be decided by utils::interactivity, \
+         so that intent is combined with whether stdin is actually a \
+         terminal. Offending sites:\n  {}",
+        violations.join("\n  ")
+    );
+}

--- a/tests/no_hand_rolled_stdio_flags.rs
+++ b/tests/no_hand_rolled_stdio_flags.rs
@@ -13,14 +13,16 @@
 //! app driver. Reviewing for this by eye does not scale across ~100
 //! `RunConfig` construction sites, so it is checked here instead.
 //!
-//! If this fails: don't add an exemption. Call `ContainerStdio::for_intent`
-//! (or `::decide`) and push `.flags()`.
+//! If this fails: don't add an exemption. Call `ContainerStdio::decide`
+//! with detected capabilities and push `.flags()`.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 /// The one module allowed to spell these flags.
-const SANCTIONED: &str = "interactivity.rs";
+/// Compared against the full relative path, not just the file name: a
+/// name-only exemption would silently excuse any new `src/**/interactivity.rs`.
+const SANCTIONED: &str = "utils/interactivity.rs";
 
 fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = fs::read_dir(dir) else {
@@ -70,7 +72,8 @@ fn container_stdio_flags_come_only_from_the_interactivity_module() {
     let mut violations = Vec::new();
 
     for file in files {
-        if file.file_name().is_some_and(|n| n == SANCTIONED) {
+        let rel = file.strip_prefix(&src).unwrap_or(&file);
+        if rel.to_string_lossy().replace('\\', "/") == SANCTIONED {
             continue;
         }
         let Ok(text) = fs::read_to_string(&file) else {
@@ -79,7 +82,9 @@ fn container_stdio_flags_come_only_from_the_interactivity_module() {
         let lines: Vec<&str> = text.lines().collect();
         for (i, line) in lines.iter().enumerate() {
             let trimmed = line.trim_start();
-            // Comments and doc comments may legitimately discuss the flags.
+            // Line and doc comments (`//`, `///`, `//!`) may legitimately
+            // discuss the flags. Block comments are not skipped: no site uses
+            // them here, and matching them reliably would need real parsing.
             if trimmed.starts_with("//") {
                 continue;
             }
@@ -94,7 +99,7 @@ fn container_stdio_flags_come_only_from_the_interactivity_module() {
             }
             if let Some(needle) = offending_snippets(line) {
                 violations.push(format!(
-                    "{}:{}: {} — use ContainerStdio::for_intent(..).flags()",
+                    "{}:{}: {} — use ContainerStdio::decide(..).flags()",
                     file.display(),
                     i + 1,
                     needle


### PR DESCRIPTION
`RunConfig.interactive` states what a command *wants* ("this may prompt"), but it was used directly as what the environment *has* ("a terminal is attached"). Any command declaring intent therefore failed wherever no terminal exists — agents, CI, pipes, the desktop app driver — because Docker refuses outright:

```
cannot attach stdin to a TTY-enabled container because stdin is not a terminal
```

The output layer already gets this right: `should_use_tui()` ANDs intent with capability (`stderr().is_terminal()`, not CI). Container stdio never asked the same question, and it has to ask it of **stdin**. That asymmetry was the whole bug.

## The fix is structural, not a one-liner

There are ~100 `RunConfig` construction sites and ~96 of them write `interactive:` by hand. Patching the two `-t` sites would fix today's bug and leave the next one wide open, so:

**Capability is detected once** (`utils/interactivity.rs`) and combined with intent by one pure function returning `Piped` / `StdinOnly` / `StdinAndTty`. Reaching `StdinAndTty` requires intent *and* a real terminal; everything else degrades to keeping stdin open rather than failing, so a piped answer still lands.

**No call sites change.** Commands keep declaring intent and the runner downgrades — that is what makes the *next* command immune rather than just this one.

Both `-t` sites route through it, including the `runs_on` remote path which allocated `-it` unconditionally. `AVOCADO_NONINTERACTIVE=1` forces headless even on a tty.

## Enforcement, so it cannot be re-hand-rolled

`tests/no_hand_rolled_stdio_flags.rs` scans `src/` and fails if `-i`/`-t` reach a container command outside the sanctioned module. Verified by planting a violation and confirming it fails, naming file, line, and remedy.

Broadening it to catch the `args([...])` spelling flagged 8 pre-existing sites — none of them PTY flags: three `ssh -i <identity>` and five `docker stop -t <seconds>`. `-i` and `-t` are badly overloaded, so rather than pattern-match around them each carries an explicit `stdio-flags-ok:` marker stating why.

## Host-side prompts

Not covered by the container path and they fail worse. `prompt_disk_selection` **looped forever** without a terminal: `read_line` returns `Ok(0)` at EOF leaving the buffer empty, the parse fails, and it spins printing "Invalid selection". It now refuses up front and also breaks on EOF. `confirm` returns false without a terminal — it gates a destructive raw-device write, so an unanswerable prompt must read as "no", never a default yes.

## On coverage

`interactivity.rs` sits at 96.8% regions / 100% of functions executed, but the number is not the point. **Reintroducing the original bug left all 14 unit tests green** — only the wiring tests through `build_container_command` caught it. 92% coverage of a pure decision function was worthless against a bug that lived in the wiring, so the tests that matter assert the assembled argv agrees with the decision, and that no PTY is requested when stdin is not a terminal. Verified by mutation.

Environment-bridge tests assert invariants that hold whether the suite runs from a terminal or from CI, rather than hard-coding either, so they cannot pass locally and fail in CI.

## Verification

2502 tests. `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all pass by exit code. No dependency changes.

## Not covered

- No end-to-end headless smoke test — everything here is static analysis and unit tests; nothing proves a real command completes with `</dev/null`. That is the gap that would have caught this class originally.
- `disk_writer` is macOS-only and cannot be compiled on a Linux host; CI covers it.
- Sibling traps with the same shape (per-item dnf calls instead of batching; raw `eprintln!` vs `utils::output`) have no guard yet.