### PR TITLE
Fix ext packaging against an rpm 4.20 SDK sysroot

### DIFF
--- a/src/commands/ext/package.rs
+++ b/src/commands/ext/package.rs
@@ -724,6 +724,15 @@ fi
 # tracks all installed extensions).
 cat > SPECS/package.spec << SPEC_EOF
 %define _buildhost reproducible
+# The payload is already-built target content, so rpm has to package it verbatim.
+# Two stock behaviours get in the way: the build-root policy scripts run the
+# container's host toolchain (strip and friends) over target binaries, and the
+# noarch guard rejects a payload carrying target ELF. These packages are noarch
+# by design - a target routes on the avocado-target provides below, not on the
+# package arch - so both checks are false positives here.
+# Comments must stay macro-free; rpm expands macros inside spec comments.
+%define __os_install_post %{{nil}}
+%define _binaries_in_noarch_packages_terminate_build 0
 AutoReqProv: no
 
 Name: {name}

--- a/src/commands/sdk/install.rs
+++ b/src/commands/sdk/install.rs
@@ -979,7 +979,15 @@ if [ -n "$AVOCADO_SDK_REPO_URL" ]; then
 fi
 
 mkdir -p $AVOCADO_SDK_PREFIX/usr/lib/rpm
-cp -r /usr/lib/rpm/* $AVOCADO_SDK_PREFIX/usr/lib/rpm/
+# Seed the rpm config from the container image only when the sysroot has none.
+# nativesdk-rpm installs its own macros at this path, and they have to match the
+# rpm binaries in the sysroot rather than the ones in the image, which can be a
+# release behind. An image on rpm 4.19 overwriting a wrynose sysroot drops the
+# %mkbuilddir stage macros that rpm 4.20 requires, and rpmbuild then fails every
+# `avocado ext package` with "Couldn't exec %{__spec_builddir_cmd}".
+if [ ! -f $AVOCADO_SDK_PREFIX/usr/lib/rpm/macros ]; then
+    cp -r /usr/lib/rpm/* $AVOCADO_SDK_PREFIX/usr/lib/rpm/
+fi
 
 # Before calling DNF, $AVOCADO_SDK_PREFIX/usr/lib/rpm/macros needs to be updated to point:
 #   - /usr -> $AVOCADO_SDK_PREFIX/usr


### PR DESCRIPTION
## Problem

`avocado ext package` fails outright when the SDK sysroot carries rpm 4.20, which
is what a Yocto 6.0 (wrynose) build produces:

```
Executing(%mkbuilddir): %{__spec_builddir_cmd} .../var/tmp/rpm-tmp.st84kd
error: Couldn't exec %{__spec_builddir_cmd}: No such file or directory
error: failed to create package build directory /tmp/tmp.XXXX/BUILD/...: Bad file descriptor
```

The macro prints unexpanded because it is undefined, and the `Bad file descriptor`
is a downstream artifact of the failed exec rather than a real I/O or space
problem - which makes this look like a broken `/tmp` when it is not.

The SDK bootstrap copies the container image's `/usr/lib/rpm` over the sysroot's
on every run, so the macro set tracks the image's rpm rather than the rpm the
sysroot actually executes:

| Layer | rpm | defines `%__spec_builddir_cmd` |
|---|---|---|
| SDK container image (`sdk:2024-edge`) | 4.19.1.1 | no |
| `nativesdk-rpm` installed in the sysroot | 4.20.1 | yes |
| File on disk in the sysroot | the image's 4.19 copy | no |

That was invisible while both sides were 4.19. rpm 4.20 added the `%mkbuilddir`
build stage, which expands a macro the 4.19 file does not carry, so rpmbuild
cannot run at all.

Restoring the macros that `nativesdk-rpm` ships exposes two further failures in
the generated spec, both from rpm applying its stock build-root policy to a
payload that is already built for the target:

- the post-install scripts run the host toolchain over target binaries -
  `%__strip` is hardcoded to `/usr/bin/strip`, which the SDK container does not
  ship, so `%install` aborts;
- the noarch guard then rejects the package outright once file classification
  sees target ELF.

## Solution

Let the sysroot's own rpm own its configuration, and stop rpm from rewriting a
payload it should only be wrapping.

The bootstrap now seeds `/usr/lib/rpm` from the image only when the sysroot has
no macros yet, so `nativesdk-rpm`'s copy survives afterwards. The image is free
to lag the SDK by a release - it is the binaries in the sysroot that decide which
macro set is correct, so the package that ships them has to win. This holds in
both skew directions, and an image whose rpm is newer than the sysroot's is
equally wrong.

The generated extension spec disables the two checks that do not fit this package
shape. A target selects an extension through its `avocado-target` provides, so
noarch is a deliberate marker rather than the accident the guard exists to catch,
and running a host `strip` against a target binary would corrupt the payload even
on an image that does carry strip.

## Key changes

- `sdk/install.rs`: seed the sysroot's rpm config from the container image only
  when it has none, instead of overwriting it on every bootstrap.
- `ext/package.rs`: set `%__os_install_post %{nil}` in the generated spec so the
  build-root policy scripts leave the payload alone.
- `ext/package.rs`: set `_binaries_in_noarch_packages_terminate_build 0`, since
  extension RPMs are noarch by design and carry target content.
- Comments in the spec heredoc are kept macro-free - rpm expands macros inside
  spec comments, and naming the strip macro in prose emitted a
  `Macro expanded in comment` warning on every package.

## Reviewer notes

**Not repaired by this change:** a sysroot an earlier build already clobbered
keeps its stale macros, because the file is present and the copy is skipped.
Those volumes need `avocado clean` or a reinstall of `nativesdk-rpm`. The
upgrade path is fine - a scarthgap-to-wrynose bump rewrites the file as part of
the package upgrade, and the new guard stops the next bootstrap undoing it.

**Two related items deliberately left alone**, both worth a decision:

1. `sdk/package.rs` builds its spec the same way and gained neither define. Its
   payload is also SDK-built target content, so the `%__strip` failure should
   reach it once the macros are correct; unlike extensions, those RPMs carry a
   real arch, so only the strip half applies. Not reproduced here, and whether
   SDK packages *want* stripping is a design question rather than a bug.
2. The SDK image tag is derived from the extension's declared `distro.release`,
   and the extensions in `avocado-os` still declare `2024`. Packaging a 2026
   target therefore runs in `sdk:2024-edge` (rpm 4.19) even though
   `sdk:2026-edge` exists and carries 4.20.1. Fixing this repo makes the skew
   survivable; aligning those configs would remove it, but that is a release
   decision, not a CLI one.

**Verification.** Packaged six extensions for an `imx93-frdm` target against a
locally built wrynose feed - the same invocation previously died at
`%mkbuilddir`, and it now exits 0. Carried on through a full provisioning run:
install pulled the wrynose artifacts, build composed a 461MB `/var` with all
seven extensions and `sshd.socket` enabled, and the resulting card's runtime
manifest lists every extension. `cargo fmt`, `cargo clippy -D warnings`, and
`cargo test` are clean.

`utils::interpolation::tests::test_basic_env_interpolation` is flaky on main and
unrelated to this change: it calls `env::set_var` and races other tests that
mutate process environment. It passes in isolation and under
`--test-threads=1`.
