### PR TITLE
purge package-manager state from rootfs and initramfs images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   second field.
 
 ### Changed
+- **Rootfs and initramfs images no longer ship package-manager state.** The
+  rpmdb, `var/lib/dnf`, `var/cache/dnf` and dnf's own logs (`dnf.log`,
+  `dnf.rpm.log`, `hawkey.log`) are removed from the staged copy before the
+  image is built — measured at ~13MB of a qemux86-64 rootfs and 14MB of a
+  123MB initramfs. Nothing on target reads any of it; these systems have no
+  runtime package manager. Only the staged copy is touched, so the shared
+  sysroot keeps its database and `ext install` / `runtime install` still seed
+  their installroots from it.
+
+  Anything inspecting a built image for installed packages — `rpm -qa` against
+  a loop-mounted rootfs, say — needs to query the sysroot or the lockfile
+  instead. This is a necessary step toward reproducible images but not a
+  sufficient one on its own; archive mtime normalization is separate.
 - **A skipped remote version check no longer reports as a passed one.** When
   the remote's `--version` output cannot be parsed, `--runs-on` used to print
   `[SUCCESS] Remote avocado version: <whatever it read>`, which is a green line

--- a/src/commands/initramfs/image.rs
+++ b/src/commands/initramfs/image.rs
@@ -101,11 +101,13 @@ if [ -d "$INITRAMFS_SYSROOT/usr" ]; then
 
     # Purge package-manager bookkeeping from the work copy before archiving.
     # Same reasoning as the rootfs image — see the comment in
-    # `generate_rootfs_build_script`. Measured 14MB of a 123MB qemux86-64
-    # initramfs (2.5M rpmdb, 4.3M var/lib/dnf, 6.4M var/cache/dnf), all of it
-    # unreproducible and none of it read by anything in an initrd.
+    # `generate_rootfs_build_script`, including why dnf's logs come too and why
+    # this is necessary but not sufficient for reproducibility. Measured 14MB
+    # of a 123MB qemux86-64 initramfs (2.5M rpmdb, 4.3M var/lib/dnf, 6.4M
+    # var/cache/dnf), none of it read by anything in an initrd.
     echo "Purging package-manager state from initramfs image"
     rm -rf "$INITRAMFS_WORK/var/lib/rpm" "$INITRAMFS_WORK/var/lib/dnf" "$INITRAMFS_WORK/var/cache/dnf"
+    rm -f "$INITRAMFS_WORK/var/log/dnf.log" "$INITRAMFS_WORK/var/log/dnf.rpm.log" "$INITRAMFS_WORK/var/log/hawkey.log"
 
     # Build initramfs image using configured filesystem format
     INITRAMFS_FS="{initramfs_filesystem}"
@@ -443,7 +445,14 @@ mod tests {
             "",
         );
 
-        for path in ["var/lib/rpm", "var/lib/dnf", "var/cache/dnf"] {
+        for path in [
+            "var/lib/rpm",
+            "var/lib/dnf",
+            "var/cache/dnf",
+            "var/log/dnf.log",
+            "var/log/dnf.rpm.log",
+            "var/log/hawkey.log",
+        ] {
             assert!(
                 script.contains(&format!("\"$INITRAMFS_WORK/{path}\"")),
                 "{path} must be purged from the work copy before archiving"
@@ -458,11 +467,5 @@ mod tests {
             .find("cpio --reproducible")
             .expect("cpio step present");
         assert!(purge_at < cpio_at, "purge must precede cpio creation");
-
-        // The shared sysroot keeps its rpmdb — the build ID query reads it.
-        assert!(
-            !script.contains("$INITRAMFS_SYSROOT/var/lib/rpm"),
-            "the shared sysroot's rpmdb must not be removed"
-        );
     }
 }

--- a/src/commands/initramfs/image.rs
+++ b/src/commands/initramfs/image.rs
@@ -99,6 +99,14 @@ if [ -d "$INITRAMFS_SYSROOT/usr" ]; then
         echo "AVOCADO_OS_BUILD_ID=$INITRAMFS_BUILD_ID" >> "$INITRAMFS_WORK/usr/lib/os-release-initrd"
     fi
 
+    # Purge package-manager bookkeeping from the work copy before archiving.
+    # Same reasoning as the rootfs image — see the comment in
+    # `generate_rootfs_build_script`. Measured 14MB of a 123MB qemux86-64
+    # initramfs (2.5M rpmdb, 4.3M var/lib/dnf, 6.4M var/cache/dnf), all of it
+    # unreproducible and none of it read by anything in an initrd.
+    echo "Purging package-manager state from initramfs image"
+    rm -rf "$INITRAMFS_WORK/var/lib/rpm" "$INITRAMFS_WORK/var/lib/dnf" "$INITRAMFS_WORK/var/cache/dnf"
+
     # Build initramfs image using configured filesystem format
     INITRAMFS_FS="{initramfs_filesystem}"
     INITRAMFS_OUTPUT="$OUTPUT_DIR/avocado-image-initramfs-$TARGET_ARCH.$INITRAMFS_FS"
@@ -414,5 +422,47 @@ export AVOCADO_OS_VERSION_ID
 
         print_success("Built initramfs image.", OutputLevel::Normal);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: the staged initramfs carried 14MB of dnf/rpm state (2.5M
+    /// rpmdb, 4.3M var/lib/dnf, 6.4M var/cache/dnf) into the cpio. Nothing in
+    /// an initrd reads it, and it made the archive unreproducible — the rpmdb
+    /// records INSTALLTIME/INSTALLTID per package and var/cache/dnf holds
+    /// generated repodata, so the same package set produced different bytes.
+    #[test]
+    fn test_initramfs_purges_package_manager_state_before_archiving() {
+        let script = generate_initramfs_build_script(
+            "00000000-0000-0000-0000-000000000000",
+            "cpio.zst",
+            None,
+            "",
+        );
+
+        for path in ["var/lib/rpm", "var/lib/dnf", "var/cache/dnf"] {
+            assert!(
+                script.contains(&format!("\"$INITRAMFS_WORK/{path}\"")),
+                "{path} must be purged from the work copy before archiving"
+            );
+        }
+
+        // The purge only helps if it runs before the archive is created.
+        let purge_at = script
+            .find("Purging package-manager state")
+            .expect("purge step present");
+        let cpio_at = script
+            .find("cpio --reproducible")
+            .expect("cpio step present");
+        assert!(purge_at < cpio_at, "purge must precede cpio creation");
+
+        // The shared sysroot keeps its rpmdb — the build ID query reads it.
+        assert!(
+            !script.contains("$INITRAMFS_SYSROOT/var/lib/rpm"),
+            "the shared sysroot's rpmdb must not be removed"
+        );
     }
 }

--- a/src/commands/rootfs/image.rs
+++ b/src/commands/rootfs/image.rs
@@ -172,6 +172,25 @@ if [ -d "$ROOTFS_SYSROOT/usr" ]; then
     sed -i '/^AVOCADO_OS_BUILD_ID=/d' "$ROOTFS_SYSROOT/usr/lib/os-release"
     echo "AVOCADO_OS_BUILD_ID=$OS_BUILD_ID" >> "$ROOTFS_SYSROOT/usr/lib/os-release"
 
+    # Purge package-manager bookkeeping from the work copy before imaging.
+    #
+    # dnf installs into the sysroot leave ~13MB of state behind (measured on a
+    # qemux86-64 rootfs: 2.0M rpmdb, 6.4M var/cache/dnf). Nothing on target
+    # consumes it — there is no runtime package manager — and it is what keeps
+    # the image from being reproducible: the rpmdb records INSTALLTIME and
+    # INSTALLTID per package, var/lib/dnf/history.sqlite records the
+    # transaction, and var/cache/dnf holds generated repodata plus solvfiles.
+    # While those are in the tree, two installs of the same package set never
+    # produce identical image bytes.
+    #
+    # Runs after post_install so state left by a hook's own dnf call is caught
+    # too. Safe for identity and for extension priming: the build ID above
+    # queries $ROOTFS_SYSROOT, and the installroot seeding in `ext install` /
+    # `runtime install` copies from $AVOCADO_PREFIX/rootfs — all the pristine
+    # sysroot, never this work copy.
+    echo "Purging package-manager state from rootfs image"
+    rm -rf "$ROOTFS_WORK/var/lib/rpm" "$ROOTFS_WORK/var/lib/dnf" "$ROOTFS_WORK/var/cache/dnf"
+
     # Build rootfs image using configured filesystem format
     ROOTFS_FS="{rootfs_filesystem}"
     ROOTFS_OUTPUT="$OUTPUT_DIR/avocado-image-rootfs-$TARGET_ARCH.$ROOTFS_FS"
@@ -543,6 +562,42 @@ mod tests {
             script.contains("avocado prune"),
             "script must also point at `avocado prune`, since clean alone does not \
              clear abandoned volumes that can shadow a build"
+        );
+    }
+
+    #[test]
+    fn test_rootfs_purges_package_manager_state_before_imaging() {
+        // Regression: ~13MB of dnf/rpm bookkeeping was being imaged into the
+        // rootfs. Nothing on target consumes it, and it blocked reproducible
+        // images — the rpmdb stamps INSTALLTIME/INSTALLTID per package and
+        // var/cache/dnf holds generated repodata, so the same package set
+        // produced different image bytes on every install.
+        let script = generate_rootfs_build_script(
+            "00000000-0000-0000-0000-000000000000",
+            "erofs-lz4",
+            None,
+            "",
+        );
+
+        for path in ["var/lib/rpm", "var/lib/dnf", "var/cache/dnf"] {
+            assert!(
+                script.contains(&format!("\"$ROOTFS_WORK/{path}\"")),
+                "{path} must be purged from the work copy before imaging"
+            );
+        }
+
+        // The purge only helps if it runs before the image is built.
+        let purge_at = script
+            .find("Purging package-manager state")
+            .expect("purge step present");
+        let mkfs_at = script.find("mkfs.erofs").expect("mkfs step present");
+        assert!(purge_at < mkfs_at, "purge must precede mkfs");
+
+        // The shared sysroot keeps its rpmdb: the build ID reads it, and so
+        // does the installroot seeding in `ext install` / `runtime install`.
+        assert!(
+            !script.contains("$ROOTFS_SYSROOT/var/lib/rpm"),
+            "the shared sysroot's rpmdb must not be removed"
         );
     }
 

--- a/src/commands/rootfs/image.rs
+++ b/src/commands/rootfs/image.rs
@@ -183,6 +183,17 @@ if [ -d "$ROOTFS_SYSROOT/usr" ]; then
     # While those are in the tree, two installs of the same package set never
     # produce identical image bytes.
     #
+    # dnf's own logs go with it. The rootfs install omits $DNF_SDK_HOST_OPTS,
+    # which is what redirects logdir/cachedir/persistdir to the SDK prefix — so
+    # the same omission that lands var/cache/dnf and var/lib/dnf in the sysroot
+    # also lands dnf.log, dnf.rpm.log and hawkey.log in var/log, each line
+    # stamped with a wall-clock time.
+    #
+    # Removing all of this is necessary for a reproducible image but not
+    # sufficient: the archive's own mtime handling is a separate problem, and
+    # the removal itself restamps the directories it empties. That is #199's
+    # half, not this one's.
+    #
     # Runs after post_install so state left by a hook's own dnf call is caught
     # too. Safe for identity and for extension priming: the build ID above
     # queries $ROOTFS_SYSROOT, and the installroot seeding in `ext install` /
@@ -190,6 +201,7 @@ if [ -d "$ROOTFS_SYSROOT/usr" ]; then
     # sysroot, never this work copy.
     echo "Purging package-manager state from rootfs image"
     rm -rf "$ROOTFS_WORK/var/lib/rpm" "$ROOTFS_WORK/var/lib/dnf" "$ROOTFS_WORK/var/cache/dnf"
+    rm -f "$ROOTFS_WORK/var/log/dnf.log" "$ROOTFS_WORK/var/log/dnf.rpm.log" "$ROOTFS_WORK/var/log/hawkey.log"
 
     # Build rootfs image using configured filesystem format
     ROOTFS_FS="{rootfs_filesystem}"
@@ -579,7 +591,14 @@ mod tests {
             "",
         );
 
-        for path in ["var/lib/rpm", "var/lib/dnf", "var/cache/dnf"] {
+        for path in [
+            "var/lib/rpm",
+            "var/lib/dnf",
+            "var/cache/dnf",
+            "var/log/dnf.log",
+            "var/log/dnf.rpm.log",
+            "var/log/hawkey.log",
+        ] {
             assert!(
                 script.contains(&format!("\"$ROOTFS_WORK/{path}\"")),
                 "{path} must be purged from the work copy before imaging"
@@ -592,13 +611,6 @@ mod tests {
             .expect("purge step present");
         let mkfs_at = script.find("mkfs.erofs").expect("mkfs step present");
         assert!(purge_at < mkfs_at, "purge must precede mkfs");
-
-        // The shared sysroot keeps its rpmdb: the build ID reads it, and so
-        // does the installroot seeding in `ext install` / `runtime install`.
-        assert!(
-            !script.contains("$ROOTFS_SYSROOT/var/lib/rpm"),
-            "the shared sysroot's rpmdb must not be removed"
-        );
     }
 
     #[test]


### PR DESCRIPTION
Found while reviewing #199. Splitting it out because it stands on its own and touches both image paths, not just the cpio.

## What

`dnf` installs into the shared sysroots leave package-manager bookkeeping behind, and `cp -a` carries it into the work copy that gets imaged. Measured on a `qemux86-64` build:

| tree | size | pkg-manager state |
|---|---|---|
| `rootfs` | 138M | 2.0M `var/lib/rpm`, 6.4M `var/cache/dnf` |
| `initramfs` | 123M | 2.5M `var/lib/rpm`, 4.3M `var/lib/dnf`, 6.4M `var/cache/dnf` |

dnf's logs come along too — `var/log/dnf.log`, `dnf.rpm.log`, `hawkey.log`, each line wall-clock stamped. `rootfs/install.rs` omits `$DNF_SDK_HOST_OPTS`, which is what redirects `logdir`/`cachedir`/`persistdir` at the SDK prefix, so the single omission that puts `var/cache/dnf` and `var/lib/dnf` in the sysroot puts the logs in `var/log`. Caught by @jetm in review.

Two problems with shipping it.

**It's dead weight.** There is no runtime package manager on target, so nothing ever reads any of it. That's ~13M off the rootfs and ~14M off the initramfs (11% of the staged tree).

**It blocks reproducibility.** Every package records a wall-clock stamp in the rpmdb:

```
busybox-udhcpc  INSTALLTIME=1773929326  INSTALLTID=1773929326
libsmartcols1   INSTALLTIME=1773929329  INSTALLTID=1773929326
```

240 of them in the initramfs. On top of that `var/lib/dnf/history.sqlite` records the transaction itself, and `var/cache/dnf` holds generated repodata plus per-repo `.solv` solvfiles. While any of that is in the tree, the same package set produces different image bytes on every install — a runtime build and a standalone build will never agree — regardless of how the archive or `mkfs` step is invoked.

To be exact about what this earns: removing it is **necessary and not sufficient**. `cpio --reproducible` is `--device-independent` on GNU cpio 2.15 and does not touch mtime, and the `rm` itself restamps the directories it empties. See the #199 section below.

## How

One `rm -rf` plus one `rm -f` per script, placed after `post_install` so state left by a hook's own `dnf` call is caught too.

Deliberately **not** added to `DEFAULT_ROOTFS_POST_INSTALL` / `DEFAULT_INITRAMFS_POST_INSTALL`: a user who defines `post_install` replaces those lists wholesale, and would silently lose both the size win and reproducibility.

## Safety

The pristine sysroots keep their rpmdb. Checked every consumer:

- `AVOCADO_OS_BUILD_ID` queries read `$ROOTFS_SYSROOT` / `$INITRAMFS_SYSROOT`
- installroot seeding in `ext install`, `ext dnf`, `runtime install`, `runtime dnf` copies from `$AVOCADO_PREFIX/rootfs`

None of them touch the work copy. Tests assert the sysroot rpmdb is not removed, so that stays true.

## Interaction with #199

Overlapping hunk — both insert into the same spot between the release-file injection and the archive step, and `initramfs/image.rs` gains a `mod tests` in both. On rebase the purge must land **before** #199's mtime-normalization pass, otherwise the `rm` re-stamps `/var/lib` and `/var/cache` with wall-clock time and undoes part of what that pass is for.

Neither PR alone gives a reproducible initramfs: #199 normalizes metadata, this normalizes contents. Both are needed.

## Test

Two regression tests, one per script: all six paths are purged from the work copy and the purge precedes `mkfs`/`cpio`. Deleting either `rm` line fails them.

These originally also asserted `!contains("$ROOTFS_SYSROOT/var/lib/rpm")`, which @jetm pointed out was vacuous — that string has no occurrences to begin with, and the build-ID query it claimed to protect is spelled `--root "$ROOTFS_SYSROOT"` with `--dbpath`. Removed rather than repaired; the sysroot's safety is argued above and is not something a substring check establishes.

Full suite green, clippy clean with `-D warnings`.

