### PR TITLE
exclude package-manager state from extension images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   second field.
 
 ### Changed
+- **Extension images no longer ship package-manager state.** `var/lib/rpm`,
+  `var/lib/dnf` and `var/cache/dnf` are excluded from the built `.raw` —
+  measured at 13.4M of a 22M `avocado-ext-tunnels` sysroot, against an 8.2M
+  `/usr` payload. Nothing on target can read it: sysext and confext merge
+  `/usr`, `/opt` and `/etc`, never `/var`.
+
+  Excluded at image time rather than deleted, because `ext image` runs mkfs
+  against the live sysroot with no work copy, and later `ext dnf` / `ext
+  install` calls still resolve against that database. Configured `var_files`
+  patterns are unaffected.
 - **A skipped remote version check no longer reports as a passed one.** When
   the remote's `--version` output cannot be parsed, `--runs-on` used to print
   `[SUCCESS] Remote avocado version: <whatever it read>`, which is a green line

--- a/src/commands/ext/image.rs
+++ b/src/commands/ext/image.rs
@@ -898,16 +898,12 @@ impl ExtImageCommand {
                     "erofs-zst" => "\n  -z zstd \\",
                     _ => "",
                 };
-                let exclude_flags = excludes
+                // Always non-empty: the package-state paths above are
+                // unconditional, so there is no no-excludes case to handle.
+                let exclude_section = excludes
                     .iter()
-                    .map(|p| format!("  --exclude-path={p} \\"))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                let exclude_section = if exclude_flags.is_empty() {
-                    String::new()
-                } else {
-                    format!("\n{exclude_flags}")
-                };
+                    .map(|p| format!("\n  --exclude-path={p} \\"))
+                    .collect::<String>();
                 format!(
                     r#"# Create erofs image
 mkfs.erofs \
@@ -920,16 +916,23 @@ mkfs.erofs \
                 )
             }
             _ => {
-                let exclude_flags = excludes
+                // Always non-empty, as in the erofs arm.
+                //
+                // mksquashfs takes everything after the first `-e` as
+                // filenames, so the later `-e` tokens are read as paths that do
+                // not exist and ignored. It works, but not for the reason the
+                // shape suggests.
+                //
+                // Note `-reproducible` does NOT normalize ownership the way
+                // erofs's `--all-root` does -- a live run reports
+                // `Number of uids 1: <builduser>`. So squashfs ext images still
+                // vary by build user. Fixing that means adding `-all-root`
+                // here, which changes image contents and belongs in its own
+                // change.
+                let exclude_section = excludes
                     .iter()
-                    .map(|p| format!("  -e \"{p}\""))
-                    .collect::<Vec<_>>()
-                    .join(" \\\n");
-                let exclude_section = if exclude_flags.is_empty() {
-                    String::new()
-                } else {
-                    format!(" \\\n{exclude_flags}")
-                };
+                    .map(|p| format!(" \\\n  -e \"{p}\""))
+                    .collect::<String>();
                 format!(
                     r#"# Create squashfs image
 mksquashfs \
@@ -1205,45 +1208,6 @@ mod tests {
         assert!(
             script.contains("--exclude-path=var/lib/rpm"),
             "package-manager excludes must not displace var_files excludes"
-        );
-    }
-
-    /// The rest of the erofs reproducibility contract, which nothing pinned.
-    /// Each of these silently reintroduces per-build variance if dropped: the
-    /// UUID would be randomized, and ownership would come from whoever ran the
-    /// build instead of being normalized to root.
-    #[test]
-    fn test_erofs_image_reproducibility_flags_are_pinned() {
-        let cmd = make_cmd("my-ext");
-        let script = cmd.create_build_script("1.0.0", "sysext", 0, "erofs", &[], "raw", None);
-
-        assert!(
-            script.contains("-U 00000000-0000-0000-0000-000000000000"),
-            "erofs UUID must be pinned, or every build gets a fresh one"
-        );
-        assert!(
-            script.contains("--all-root"),
-            "ownership must be normalized to root, not the build user"
-        );
-        assert!(
-            script.contains("-T \"$SOURCE_DATE_EPOCH\""),
-            "timestamps must come from SOURCE_DATE_EPOCH"
-        );
-    }
-
-    /// squashfs has no `-T`; `-reproducible` is what makes its output stable.
-    #[test]
-    fn test_squashfs_image_is_built_reproducibly() {
-        let cmd = make_cmd("my-ext");
-        let script = cmd.create_build_script("1.0.0", "sysext", 0, "squashfs", &[], "raw", None);
-
-        assert!(
-            script.contains("-reproducible"),
-            "mksquashfs must be invoked with -reproducible"
-        );
-        assert!(
-            script.contains("-no-xattrs"),
-            "xattrs must be dropped, they carry build-host state"
         );
     }
 

--- a/src/commands/ext/image.rs
+++ b/src/commands/ext/image.rs
@@ -868,6 +868,29 @@ impl ExtImageCommand {
             })
             .collect::<Vec<_>>();
 
+        // Package-manager bookkeeping, always excluded, ahead of the var_files
+        // patterns. dnf leaves this in every extension installroot, and `ext
+        // install` / `ext dnf` additionally seed var/lib/rpm from the rootfs so
+        // dependencies resolve against what the rootfs already provides. On a
+        // qemux86-64 build that is 13.4M of a 22M sysroot for
+        // avocado-ext-tunnels, against an 8.2M /usr payload.
+        //
+        // Nothing on target can read it: systemd-sysext/confext merge /usr,
+        // /opt and /etc, never /var. And it is what stops the images being
+        // reproducible across a reinstall — the rpmdb stamps INSTALLTIME and
+        // INSTALLTID per package, var/lib/dnf/history.sqlite records the
+        // transaction, and var/cache/dnf holds generated repodata and solvfiles.
+        //
+        // Excluded at image time rather than deleted, because `ext image` runs
+        // mkfs directly against the live sysroot (no work copy, unlike the
+        // rootfs and initramfs paths) and later `ext dnf` / `ext install` calls
+        // still resolve against that rpmdb.
+        let excludes: Vec<String> = ["var/lib/rpm", "var/lib/dnf", "var/cache/dnf"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .chain(var_excludes)
+            .collect();
+
         let mkfs_command = match filesystem {
             "erofs" | "erofs-lz4" | "erofs-zst" => {
                 let compress_flag = match filesystem {
@@ -875,7 +898,7 @@ impl ExtImageCommand {
                     "erofs-zst" => "\n  -z zstd \\",
                     _ => "",
                 };
-                let exclude_flags = var_excludes
+                let exclude_flags = excludes
                     .iter()
                     .map(|p| format!("  --exclude-path={p} \\"))
                     .collect::<Vec<_>>()
@@ -897,7 +920,7 @@ mkfs.erofs \
                 )
             }
             _ => {
-                let exclude_flags = var_excludes
+                let exclude_flags = excludes
                     .iter()
                     .map(|p| format!("  -e \"{p}\""))
                     .collect::<Vec<_>>()
@@ -1129,6 +1152,101 @@ mod tests {
         );
     }
 
+    /// Package-manager state must never reach an extension image.
+    ///
+    /// Regression: verified present in shipped images — `rpmdb.sqlite` and the
+    /// SQLite file magic both grep out of `config-dev-0.1.0.raw` and
+    /// `avocado-ext-tunnels-2024.1.0.raw`. It was 13.4M of a 22M sysroot against
+    /// an 8.2M /usr payload, unreadable on target (sysext/confext merge /usr,
+    /// /opt and /etc, never /var), and unreproducible across a reinstall because
+    /// the rpmdb stamps INSTALLTIME/INSTALLTID per package.
+    ///
+    /// Excluded rather than deleted: `ext image` runs mkfs against the live
+    /// sysroot, which later `ext dnf` / `ext install` calls resolve against.
+    #[test]
+    fn test_pkg_state_excluded_from_erofs_image() {
+        let cmd = make_cmd("my-ext");
+        let script = cmd.create_build_script("1.0.0", "sysext", 0, "erofs", &[], "raw", None);
+
+        for path in ["var/lib/rpm", "var/lib/dnf", "var/cache/dnf"] {
+            assert!(
+                script.contains(&format!("--exclude-path={path}")),
+                "{path} must be excluded from the erofs image"
+            );
+        }
+    }
+
+    #[test]
+    fn test_pkg_state_excluded_from_squashfs_image() {
+        let cmd = make_cmd("my-ext");
+        let script = cmd.create_build_script("1.0.0", "sysext", 0, "squashfs", &[], "raw", None);
+
+        for path in ["var/lib/rpm", "var/lib/dnf", "var/cache/dnf"] {
+            assert!(
+                script.contains(&format!("-e \"{path}\"")),
+                "{path} must be excluded from the squashfs image"
+            );
+        }
+    }
+
+    /// The always-excluded paths are additive — a project's own `var_files`
+    /// patterns must still be excluded alongside them, not replaced by them.
+    #[test]
+    fn test_var_files_excludes_survive_alongside_pkg_state() {
+        let cmd = make_cmd("my-ext");
+        let var_files = vec!["var/lib/myapp/**".to_string()];
+        let script =
+            cmd.create_build_script("1.0.0", "sysext", 0, "erofs", &var_files, "raw", None);
+
+        assert!(
+            script.contains("--exclude-path=var/lib/myapp"),
+            "configured var_files patterns must still be excluded"
+        );
+        assert!(
+            script.contains("--exclude-path=var/lib/rpm"),
+            "package-manager excludes must not displace var_files excludes"
+        );
+    }
+
+    /// The rest of the erofs reproducibility contract, which nothing pinned.
+    /// Each of these silently reintroduces per-build variance if dropped: the
+    /// UUID would be randomized, and ownership would come from whoever ran the
+    /// build instead of being normalized to root.
+    #[test]
+    fn test_erofs_image_reproducibility_flags_are_pinned() {
+        let cmd = make_cmd("my-ext");
+        let script = cmd.create_build_script("1.0.0", "sysext", 0, "erofs", &[], "raw", None);
+
+        assert!(
+            script.contains("-U 00000000-0000-0000-0000-000000000000"),
+            "erofs UUID must be pinned, or every build gets a fresh one"
+        );
+        assert!(
+            script.contains("--all-root"),
+            "ownership must be normalized to root, not the build user"
+        );
+        assert!(
+            script.contains("-T \"$SOURCE_DATE_EPOCH\""),
+            "timestamps must come from SOURCE_DATE_EPOCH"
+        );
+    }
+
+    /// squashfs has no `-T`; `-reproducible` is what makes its output stable.
+    #[test]
+    fn test_squashfs_image_is_built_reproducibly() {
+        let cmd = make_cmd("my-ext");
+        let script = cmd.create_build_script("1.0.0", "sysext", 0, "squashfs", &[], "raw", None);
+
+        assert!(
+            script.contains("-reproducible"),
+            "mksquashfs must be invoked with -reproducible"
+        );
+        assert!(
+            script.contains("-no-xattrs"),
+            "xattrs must be dropped, they carry build-host state"
+        );
+    }
+
     #[test]
     fn test_create_build_script_source_date_epoch_default() {
         let cmd = make_cmd("my-ext");
@@ -1220,13 +1338,18 @@ mod tests {
     }
 
     #[test]
-    fn test_create_build_script_no_var_files_no_excludes() {
+    fn test_no_var_files_leaves_only_the_pkg_state_excludes() {
+        // Was `test_create_build_script_no_var_files_no_excludes`, which asserted
+        // that no var_files meant no excludes at all. The package-manager paths
+        // are now always excluded, so the surviving guarantee is the narrower
+        // one: nothing beyond them is excluded when no var_files are configured.
         let cmd = make_cmd("my-ext");
         let script = cmd.create_build_script("1.0.0", "sysext", 0, "squashfs", &[], "raw", None);
 
-        assert!(
-            !script.contains("-e \"var/"),
-            "script should not contain exclude flags when no var_files"
+        assert_eq!(
+            script.matches("-e \"").count(),
+            3,
+            "only the three package-manager paths should be excluded"
         );
     }
 }


### PR DESCRIPTION
Third of the set alongside #203 and #204. Independent of both — no overlapping files.

## Are we doing exclude-path today?

No. `--exclude-path` is only emitted for user-configured `var_files` patterns, and `get_ext_var_files` returns an empty vec when the key is absent (`config.rs:1233`). There is no default, so a project that sets no `var_files` gets no excludes at all.

Confirmed in the shipped images rather than inferred from the sysroot — grepping the built `.raw` files:

| image | size | `rpmdb.sqlite` | `SQLite format 3` | `history.sqlite` |
|---|---|---|---|---|
| `config-dev-0.1.0.raw` | 848K | ✓ | ✓ | — |
| `avocado-ext-tunnels-2024.1.0.raw` | 9.9M | ✓ | ✓ (×9) | ✓ |

## Scale

`avocado-ext-tunnels` sysroot is 22M: 13.4M of package-manager state (2.8M `var/lib/rpm`, 4.2M `var/lib/dnf`, 6.4M `var/cache/dnf`) against an 8.2M `/usr` payload. The bookkeeping is larger than the extension.

Every extension carries a floor of it — `ext install` and `ext dnf` seed each installroot with `cp -rf $AVOCADO_PREFIX/rootfs/var/lib/rpm` so dependencies resolve against what the rootfs already provides, and nothing removes it before the sysroot becomes an image. `config-dev-0.1.0.raw` and `avocado-bsp-qemux86-64-2024.1.0.raw` are both **exactly 868,352 bytes**: two unrelated extensions, identical size, because both are dominated by that same seeded rpmdb instead of their own payloads.

## Why it matters beyond size

Nothing on target can read it. `systemd-sysext`/`confext` merge `/usr`, `/opt` and `/etc` — never `/var`. It is shipped and never mounted.

And it is what stops the images being reproducible across a reinstall: the rpmdb stamps `INSTALLTIME`/`INSTALLTID` per package, `history.sqlite` records the transaction, `var/cache/dnf` holds generated repodata and `.solv` files.

Worth being precise, since the content-addressed IDs in connect do dedupe today and that is not a contradiction. `INSTALLTIME` is written at install time and then sits unchanged, and `dnf` is a no-op when packages are already present, so **re-imaging** an unchanged sysroot is byte-stable and dedupes exactly as observed. What fails is **re-installing** — clean machine, post-`avocado clean`, a different CI runner. That is the independent-rebuild property, and it is the one the dedup metric can't see because it never re-installs.

## Excluded, not deleted

Deliberate, and the difference from #203. `ext image` runs mkfs directly against the live `$AVOCADO_EXT_SYSROOTS/<name>` — there is no work copy, unlike the rootfs and initramfs paths — and later `ext dnf` / `ext install` calls resolve against that rpmdb. Deleting it would clobber live state; excluding costs nothing and uses the mechanism already there for `var_files`.

## Operational note

This changes every extension's content hash exactly once. Against a content-addressed store that means a one-time dedup miss and a full re-upload wave in connect — everything looks new for one cycle. Harmless, but probably worth timing deliberately rather than landing mid-release.

## Tests

Excludes applied on both the erofs and mksquashfs branches; `var_files` patterns still excluded alongside rather than displaced.

Also filled the gaps in what was pinned for extension reproducibility, since none of it was covered: erofs `-U 0000…` (else every build gets a fresh UUID), `--all-root` (else ownership comes from the build user), `-T "$SOURCE_DATE_EPOCH"`, and on the squashfs side `-reproducible` and `-no-xattrs`.

One existing test changed meaning: `test_create_build_script_no_var_files_no_excludes` asserted that no `var_files` meant no excludes at all, which is no longer true. Rewritten as `test_no_var_files_leaves_only_the_pkg_state_excludes`, asserting exactly three excludes — same spirit (nothing unexpected gets excluded), and it now also catches accidental duplicates.

Verified `mksquashfs` tolerates the repeated `-e` form the existing codegen emits, so nothing changed there.

Full suite green (1404 passing), clippy clean with `-D warnings`.
