### PR TITLE
feat(image): derive AVOCADO_OS_BUILD_ID from the assembled work tree

### DIFF
--- a/src/commands/initramfs/image.rs
+++ b/src/commands/initramfs/image.rs
@@ -11,12 +11,14 @@ use crate::utils::{
     host_copy::copy_volume_path_to_host,
     kab_wrap::generate_kab_wrap_script,
     output::{print_error, print_info, print_success, OutputLevel},
-    permissions::{mapping_from_hashmap, render_users_groups_script},
+    permissions::{mapping_from_map, render_users_groups_script},
     runs_on::RunsOnContext,
     target::resolve_target_required,
 };
 
-use crate::commands::rootfs::image::{render_hook_block, resolve_install_hooks, NAMESPACE_UUID};
+use crate::commands::rootfs::image::{
+    render_build_id_block, render_hook_block, resolve_install_hooks, BuildIdSpec, NAMESPACE_UUID,
+};
 
 /// Default post-install commands for the initramfs build. Same shape as
 /// `DEFAULT_ROOTFS_POST_INSTALL` but for `$INITRAMFS_WORK`, plus the
@@ -86,16 +88,13 @@ if [ -d "$INITRAMFS_SYSROOT/usr" ]; then
 
 {post_install_block}
 
-    # Compute deterministic build ID for initramfs.
-    #
-    # LC_ALL=C for the same reason as the cpio pipeline below: this hash becomes
-    # $INITRAMFS_BUILD_ID, which is appended to initrd-release and
-    # os-release-initrd *inside* the archive. Collation drift would reorder the
-    # NEVRA list, change the hash, and so change the archive contents for an
-    # otherwise unchanged package set.
-    INITRAMFS_PKG_NEVRA=$(rpm -qa --queryformat '%{{NEVRA}}\n' --root "$INITRAMFS_SYSROOT" | LC_ALL=C sort)
-    INITRAMFS_PKG_HASH=$(echo "$INITRAMFS_PKG_NEVRA" | sha256sum | awk '{{print $1}}')
-    INITRAMFS_BUILD_ID=$(python3 -c "import uuid; print(uuid.uuid5(uuid.UUID('{namespace_uuid}'), '$INITRAMFS_PKG_HASH'))")
+    # Compute the deterministic build id from the assembled work tree (see
+    # render_build_id_block). Taken before the identity injection below so the
+    # hash can't depend on the id it is about to write. LC_ALL=C throughout for
+    # the same reason as the cpio pipeline: collation must not reorder the hash
+    # inputs (the id lands in initrd-release / os-release-initrd inside the
+    # archive, so a shift would change the archive for an unchanged tree).
+{build_id_block}
 
     # Inject identity into initrd-release and os-release-initrd
     if [ -f "$INITRAMFS_WORK/usr/lib/initrd-release" ]; then
@@ -168,10 +167,17 @@ if [ -d "$INITRAMFS_SYSROOT/usr" ]; then
 else
     echo "No initramfs sysroot found — skipping initramfs image build."
 fi"#,
-        namespace_uuid = namespace_uuid,
         initramfs_filesystem = initramfs_filesystem,
         post_install_block = post_install_block,
         permissions_section = permissions_section,
+        build_id_block = render_build_id_block(&BuildIdSpec {
+            namespace_uuid,
+            work_var: "INITRAMFS_WORK",
+            sysroot_var: "INITRAMFS_SYSROOT",
+            rpm_args: "",
+            id_var: "INITRAMFS_BUILD_ID",
+            identity_files: &["usr/lib/initrd-release", "usr/lib/os-release-initrd"],
+        }),
     )
 }
 
@@ -268,8 +274,8 @@ impl InitramfsImageCommand {
             .initramfs_default()
             .and_then(|img| config.resolve_image_permissions(img))
             .map(|p| {
-                let users = mapping_from_hashmap(p.users.as_ref());
-                let groups = mapping_from_hashmap(p.groups.as_ref());
+                let users = mapping_from_map(p.users.as_ref());
+                let groups = mapping_from_map(p.groups.as_ref());
                 render_users_groups_script(
                     users.as_ref(),
                     groups.as_ref(),
@@ -536,6 +542,27 @@ mod tests {
             !script.contains("| sort)") && !script.contains("| sort |"),
             "an unpinned sort remains in the generated initramfs script"
         );
+    }
+
+    /// Initramfs derives its id through the same render_build_id_block as rootfs
+    /// (NEVRA package hash + work-tree content hash, rpmdb pruned), so the two
+    /// images can't diverge on the correctness-critical id logic (ENG-2441).
+    #[test]
+    fn test_build_id_uses_shared_tree_hash() {
+        let s = generate_initramfs_build_script("ns", "cpio.zst", None, "");
+        assert!(s.contains("TREE_HASH="), "work-tree content hash present");
+        assert!(s.contains("-path ./var/lib/rpm"), "rpmdb pruned");
+        assert!(
+            s.contains("INITRAMFS_BUILD_ID=$(python3"),
+            "id assigned to the initramfs var"
+        );
+        assert!(
+            s.contains("'$PKG_HASH:$TREE_HASH'"),
+            "package + tree hash folded"
+        );
+        // Both initramfs identity files are canonicalized before hashing.
+        assert!(s.contains(r#"[ -f "$INITRAMFS_WORK/usr/lib/initrd-release" ]"#));
+        assert!(s.contains(r#"[ -f "$INITRAMFS_WORK/usr/lib/os-release-initrd" ]"#));
     }
 
     /// gzip already omits MTIME/FNAME when reading stdin, but `-n` keeps that

--- a/src/commands/rootfs/image.rs
+++ b/src/commands/rootfs/image.rs
@@ -11,7 +11,7 @@ use crate::utils::{
     host_copy::copy_volume_path_to_host,
     kab_wrap::generate_kab_wrap_script,
     output::{print_error, print_info, print_success, OutputLevel},
-    permissions::{mapping_from_hashmap, render_users_groups_script},
+    permissions::{mapping_from_map, render_users_groups_script},
     runs_on::RunsOnContext,
     target::resolve_target_required,
 };
@@ -92,6 +92,105 @@ fi"
     }
 }
 
+/// Work-relative paths pruned from the build-id tree hash: their bytes are
+/// nondeterministic across builds and are either not part of the image identity
+/// or already covered elsewhere.
+/// - `var/lib/rpm`: the rpmdb sqlite embeds install timestamps — which is
+///   exactly why package identity is hashed from the NEVRA set (`PKG_HASH`),
+///   not these bytes.
+/// - `var/cache`, `var/log`: dnf caches and logs, build-varying.
+const BUILD_ID_TREE_PRUNES: &[&str] = &["./var/lib/rpm", "./var/cache", "./var/log"];
+
+/// The differences between the rootfs and initramfs build-id derivations, fed to
+/// [`render_build_id_block`].
+pub struct BuildIdSpec<'a> {
+    /// Namespace UUID for the uuid5 derivation.
+    pub namespace_uuid: &'a str,
+    /// Shell variable naming the assembled work dir (e.g. `ROOTFS_WORK`).
+    pub work_var: &'a str,
+    /// Shell variable naming the sysroot holding the rpmdb (e.g. `ROOTFS_SYSROOT`).
+    pub sysroot_var: &'a str,
+    /// Extra `rpm` args to locate the db — rootfs passes `--dbpath /var/lib/rpm`,
+    /// initramfs the empty string (default path).
+    pub rpm_args: &'a str,
+    /// Shell variable to assign the derived id (e.g. `OS_BUILD_ID`).
+    pub id_var: &'a str,
+    /// Work-relative identity files to canonicalize before hashing (strip any
+    /// AVOCADO_* fields a prior build injected), e.g. `usr/lib/os-release`.
+    pub identity_files: &'a [&'a str],
+}
+
+/// Render the shell that derives a deterministic build id into `spec.id_var`.
+///
+/// The id is `uuid5(namespace, "$PKG_HASH:$TREE_HASH")`:
+/// - `PKG_HASH` is the sorted NEVRA set — a stable package identity that does
+///   not depend on the nondeterministic rpmdb *bytes* (so a version-only bump
+///   with an identical file payload still moves the id).
+/// - `TREE_HASH` is a content hash of the assembled work tree, so *any*
+///   rootfs-affecting change — `permissions:`, `post_install`, `overlay:`,
+///   anything future — moves the id and therefore OTAs. It hashes exactly what
+///   the image carries: sorted path, type, mode, symlink target, and file
+///   content. It excludes what the image build normalizes away (`mkfs.erofs -T`
+///   mtimes, `--all-root` ownership) and what is fs-dependent (directory
+///   sizes), so it can't churn on noise the image doesn't hold.
+///   [`BUILD_ID_TREE_PRUNES`] are excluded.
+///
+/// Must be invoked AFTER the permissions and post_install steps and BEFORE the
+/// os-release identity lines are appended: the derivation strips `AVOCADO_*`
+/// from the identity files first, so the hash can't depend on a prior build's
+/// id (self-reference) or the possibly-unpinned runtime version.
+pub fn render_build_id_block(spec: &BuildIdSpec) -> String {
+    let BuildIdSpec {
+        namespace_uuid,
+        work_var,
+        sysroot_var,
+        rpm_args,
+        id_var,
+        identity_files,
+    } = *spec;
+
+    // Strip any AVOCADO_* fields a prior build injected into the identity files
+    // (the work copy inherits them from the sysroot) so the tree hash is stable.
+    let strip = identity_files
+        .iter()
+        .map(|f| {
+            format!(
+                "    if [ -f \"${work_var}/{f}\" ]; then\n        \
+                 sed -i '/^AVOCADO_OS_BUILD_ID=/d;/^AVOCADO_RUNTIME_NAME=/d;/^AVOCADO_RUNTIME_VERSION=/d' \"${work_var}/{f}\"\n    fi"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let prune = BUILD_ID_TREE_PRUNES
+        .iter()
+        .map(|p| format!("-path {p}"))
+        .collect::<Vec<_>>()
+        .join(" -o ");
+
+    format!(
+        r#"    # Canonicalize the identity files before hashing (see render_build_id_block).
+{strip}
+
+    # Deterministic package identity from the NEVRA set — independent of the
+    # rpmdb *bytes*, which embed install timestamps (hence var/lib/rpm is pruned
+    # from the tree hash below). LC_ALL=C so collation can't reorder it.
+    PKG_NEVRA=$(rpm {rpm_args} -qa --queryformat '%{{NEVRA}}\n' --root "${sysroot_var}" | LC_ALL=C sort)
+    PKG_HASH=$(echo "$PKG_NEVRA" | sha256sum | awk '{{print $1}}')
+
+    # Content hash of the assembled work tree: the id must move iff the image
+    # bytes move. Hash only what the image carries — sorted path, type, mode,
+    # symlink target, file content — excluding what the image build normalizes
+    # out (mtime, ownership) or what is fs-dependent (directory sizes). %m is the
+    # octal mode, %l the symlink target (empty for non-links).
+    BUILD_ID_META=$(cd "${work_var}" && find . \( {prune} \) -prune -o -printf '%y %m %P\t%l\n' | LC_ALL=C sort)
+    BUILD_ID_CONTENT=$(cd "${work_var}" && find . \( {prune} \) -prune -o -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum)
+    TREE_HASH=$(printf '%s\n%s\n' "$BUILD_ID_META" "$BUILD_ID_CONTENT" | sha256sum | awk '{{print $1}}')
+
+    {id_var}=$(python3 -c "import uuid; print(uuid.uuid5(uuid.UUID('{namespace_uuid}'), '$PKG_HASH:$TREE_HASH'))")"#
+    )
+}
+
 /// Generate the shell script fragment that builds a rootfs image from the shared sysroot.
 ///
 /// The generated script expects these shell variables to be set:
@@ -156,17 +255,11 @@ if [ -d "$ROOTFS_SYSROOT/usr" ]; then
 
 {post_install_block}
 
-    # Compute deterministic AVOCADO_OS_BUILD_ID from installed packages
-    # LC_ALL=C so NEVRA ordering — and therefore this hash and the
-    # AVOCADO_OS_BUILD_ID injected into os-release inside the image — can't
-    # shift with the container's collation.
-    PKG_NEVRA=$(rpm --dbpath /var/lib/rpm -qa --queryformat '%{{NEVRA}}\n' --root "$ROOTFS_SYSROOT" | LC_ALL=C sort)
-    PKG_HASH=$(echo "$PKG_NEVRA" | sha256sum | awk '{{print $1}}')
-    OS_BUILD_ID=$(python3 -c "import uuid; print(uuid.uuid5(uuid.UUID('{namespace_uuid}'), '$PKG_HASH'))")
+{build_id_block}
 
-    # Inject identity into os-release (work copy for the image, sysroot for stone)
-    # Strip any prior injected fields from the work copy before appending
-    sed -i '/^AVOCADO_OS_BUILD_ID=/d;/^AVOCADO_RUNTIME_NAME=/d;/^AVOCADO_RUNTIME_VERSION=/d' "$ROOTFS_WORK/usr/lib/os-release"
+    # Inject identity into os-release (work copy for the image, sysroot for stone).
+    # The work copy was canonicalized (AVOCADO_* stripped) during id derivation,
+    # so these appends land in a clean file.
     echo "AVOCADO_OS_BUILD_ID=$OS_BUILD_ID" >> "$ROOTFS_WORK/usr/lib/os-release"
     echo "AVOCADO_RUNTIME_NAME=$RUNTIME_NAME" >> "$ROOTFS_WORK/usr/lib/os-release"
     echo "AVOCADO_RUNTIME_VERSION=$RUNTIME_VERSION" >> "$ROOTFS_WORK/usr/lib/os-release"
@@ -214,10 +307,17 @@ if [ -d "$ROOTFS_SYSROOT/usr" ]; then
 else
     echo "No rootfs sysroot found — skipping rootfs image build."
 fi"#,
-        namespace_uuid = namespace_uuid,
         rootfs_filesystem = rootfs_filesystem,
         post_install_block = post_install_block,
         permissions_section = permissions_section,
+        build_id_block = render_build_id_block(&BuildIdSpec {
+            namespace_uuid,
+            work_var: "ROOTFS_WORK",
+            sysroot_var: "ROOTFS_SYSROOT",
+            rpm_args: "--dbpath /var/lib/rpm",
+            id_var: "OS_BUILD_ID",
+            identity_files: &["usr/lib/os-release"],
+        }),
     )
 }
 
@@ -314,8 +414,8 @@ impl RootfsImageCommand {
             .rootfs_default()
             .and_then(|img| config.resolve_image_permissions(img))
             .map(|p| {
-                let users = mapping_from_hashmap(p.users.as_ref());
-                let groups = mapping_from_hashmap(p.groups.as_ref());
+                let users = mapping_from_map(p.users.as_ref());
+                let groups = mapping_from_map(p.groups.as_ref());
                 render_users_groups_script(
                     users.as_ref(),
                     groups.as_ref(),
@@ -569,5 +669,93 @@ mod tests {
             guard_pos < perms_pos,
             "the /etc/passwd guard must run before the permissions/user-creation section"
         );
+    }
+
+    fn rootfs_script() -> String {
+        generate_rootfs_build_script(
+            "00000000-0000-0000-0000-000000000000",
+            "erofs-lz4",
+            None,
+            "",
+        )
+    }
+
+    #[test]
+    fn test_build_id_is_pkg_hash_plus_tree_hash() {
+        // ENG-2441: the id folds a content hash of the assembled work tree in
+        // beside the NEVRA package hash, so any rootfs-affecting change moves it.
+        let s = rootfs_script();
+        assert!(s.contains("PKG_HASH="), "package identity retained");
+        assert!(s.contains("TREE_HASH="), "work-tree content hash present");
+        assert!(
+            s.contains("uuid.uuid5(uuid.UUID('00000000-0000-0000-0000-000000000000'), '$PKG_HASH:$TREE_HASH')"),
+            "id must derive from both the package hash and the tree hash"
+        );
+    }
+
+    #[test]
+    fn test_tree_hash_prunes_nondeterministic_paths_and_excludes_metadata() {
+        // The rpmdb (install timestamps) and dnf caches/logs would churn the id
+        // every build, and mtime/ownership are normalized out of the image — so
+        // none may feed the hash. It hashes type, mode (%m), path (%P) and
+        // symlink target (%l) only.
+        let s = rootfs_script();
+        for pruned in [
+            "-path ./var/lib/rpm",
+            "-path ./var/cache",
+            "-path ./var/log",
+        ] {
+            assert!(s.contains(pruned), "tree hash must prune {pruned}");
+        }
+        assert!(
+            s.contains(r"-printf '%y %m %P\t%l\n'"),
+            "hash covers type/mode/path/link"
+        );
+        // No mtime (%T*), user (%u/%U) or group (%g/%G) directives leak in.
+        for meta in ["%T", "%u", "%U", "%g", "%G"] {
+            assert!(!s.contains(meta), "tree hash must not depend on {meta}");
+        }
+    }
+
+    #[test]
+    fn test_build_id_computed_before_identity_is_injected() {
+        // Taking the hash after the os-release identity append would make the id
+        // depend on itself (and on the possibly-unpinned runtime version), so the
+        // derivation — including the strip that canonicalizes os-release — must
+        // finish before anything is appended.
+        let s = rootfs_script();
+        let strip = s
+            .find("sed -i '/^AVOCADO_OS_BUILD_ID=/d")
+            .expect("identity strip present");
+        let tree = s.find("TREE_HASH=").expect("tree hash present");
+        let derive = s
+            .find("OS_BUILD_ID=$(python3")
+            .expect("id derivation present");
+        let append = s
+            .find(r#"echo "AVOCADO_OS_BUILD_ID=$OS_BUILD_ID" >>"#)
+            .expect("identity append present");
+        assert!(
+            strip < tree && tree < derive && derive < append,
+            "order must be: strip identity -> tree hash -> derive id -> append identity"
+        );
+    }
+
+    #[test]
+    fn test_render_build_id_block_shape() {
+        // Direct contract check on the shared helper both images use.
+        let block = render_build_id_block(&BuildIdSpec {
+            namespace_uuid: "11111111-1111-1111-1111-111111111111",
+            work_var: "WK",
+            sysroot_var: "SR",
+            rpm_args: "--dbpath /var/lib/rpm",
+            id_var: "MY_ID",
+            identity_files: &["usr/lib/os-release"],
+        });
+        assert!(block.contains(r#"[ -f "$WK/usr/lib/os-release" ]"#));
+        assert!(block.contains(r#"--root "$SR""#));
+        assert!(block.contains(r#"rpm --dbpath /var/lib/rpm -qa"#));
+        assert!(block.contains(r#"cd "$WK" && find ."#));
+        assert!(block.contains("MY_ID=$(python3"));
+        assert!(block.contains("'$PKG_HASH:$TREE_HASH'"));
     }
 }

--- a/src/commands/runtime/build.rs
+++ b/src/commands/runtime/build.rs
@@ -6,7 +6,7 @@ use crate::utils::{
     config::{ComposedConfig, Config, ImageConfig},
     container::{RunConfig, SdkContainer, TuiContext},
     output::{print_error, print_info, print_success, OutputLevel},
-    permissions::{mapping_from_hashmap, render_users_groups_script},
+    permissions::{mapping_from_map, render_users_groups_script},
     runs_on::RunsOnContext,
     stamps::{
         compute_runtime_build_input_hash, compute_runtime_install_input_hash,
@@ -2285,8 +2285,8 @@ echo "Docker image priming complete.""#,
             let Some(perms) = image.and_then(|img| config.resolve_image_permissions(img)) else {
                 return String::new();
             };
-            let users = mapping_from_hashmap(perms.users.as_ref());
-            let groups = mapping_from_hashmap(perms.groups.as_ref());
+            let users = mapping_from_map(perms.users.as_ref());
+            let groups = mapping_from_map(perms.groups.as_ref());
             render_users_groups_script(users.as_ref(), groups.as_ref(), etc_dir, None)
         };
 

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -835,10 +835,16 @@ pub struct ImageConfig {
 /// (rootfs or initramfs). Values are kept as raw YAML so the existing
 /// dynamic field parser in [`crate::utils::permissions`] can consume them
 /// without re-typing every shadow attribute.
+///
+/// `BTreeMap` (not `HashMap`) so users/groups are provisioned in a stable,
+/// key-sorted order: `render_users_groups_script` appends to /etc/passwd and
+/// /etc/group in iteration order and auto-assigns UID/GID in that order, so a
+/// random per-process `HashMap` order would otherwise reshuffle the generated
+/// script — and the auto-assigned UIDs — on every build.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct PermissionsConfig {
-    pub users: Option<HashMap<String, serde_yaml::Value>>,
-    pub groups: Option<HashMap<String, serde_yaml::Value>>,
+    pub users: Option<BTreeMap<String, serde_yaml::Value>>,
+    pub groups: Option<BTreeMap<String, serde_yaml::Value>>,
 }
 
 /// Provision profile configuration

--- a/src/utils/permissions.rs
+++ b/src/utils/permissions.rs
@@ -372,13 +372,16 @@ echo "Set proper permissions on authentication files""#
     script_lines.join("")
 }
 
-/// Convert an `Option<&HashMap<String, serde_yaml::Value>>` (the shape
+/// Convert an `Option<&BTreeMap<String, serde_yaml::Value>>` (the shape
 /// stored in [`crate::utils::config::PermissionsConfig`]) into an owned
-/// `serde_yaml::Mapping` ref appropriate for [`render_users_groups_script`].
+/// `serde_yaml::Mapping` appropriate for [`render_users_groups_script`].
+///
+/// `BTreeMap` iterates in key order, so the resulting `Mapping` — and the
+/// users/groups the script then provisions — are deterministic across builds.
 ///
 /// Returns `None` if the input is `None` or empty.
-pub fn mapping_from_hashmap(
-    src: Option<&std::collections::HashMap<String, serde_yaml::Value>>,
+pub fn mapping_from_map(
+    src: Option<&std::collections::BTreeMap<String, serde_yaml::Value>>,
 ) -> Option<Mapping> {
     let map = src?;
     if map.is_empty() {
@@ -472,5 +475,31 @@ mod tests {
         let script = render_users_groups_script(None, Some(&groups), "/etc", None);
         assert!(script.contains("Creating group 'docker'"));
         assert!(script.contains("chown root:root \"/etc/passwd\""));
+    }
+
+    #[test]
+    fn mapping_from_map_provisions_in_sorted_order() {
+        // ENG-2441: users/groups come from a BTreeMap, so mapping_from_map must
+        // preserve key-sorted order — the generated passwd appends and the
+        // auto-assigned UIDs follow it, and a stable order is what stops the
+        // build id (and any UID a user omits) from churning every build.
+        let mut users = std::collections::BTreeMap::new();
+        users.insert("zeta".to_string(), user(""));
+        users.insert("alpha".to_string(), user(""));
+        users.insert("mike".to_string(), user(""));
+
+        let mapping = mapping_from_map(Some(&users)).expect("non-empty map yields Some");
+        let keys: Vec<&str> = mapping.iter().filter_map(|(k, _)| k.as_str()).collect();
+        assert_eq!(keys, ["alpha", "mike", "zeta"]);
+
+        let script = render_users_groups_script(Some(&mapping), None, "/etc", None);
+        let a = script.find("Creating user 'alpha'").unwrap();
+        let m = script.find("Creating user 'mike'").unwrap();
+        let z = script.find("Creating user 'zeta'").unwrap();
+        assert!(a < m && m < z, "users must be provisioned in sorted order");
+
+        // Empty / absent maps still fold to nothing.
+        assert!(mapping_from_map(None).is_none());
+        assert!(mapping_from_map(Some(&std::collections::BTreeMap::new())).is_none());
     }
 }


### PR DESCRIPTION
Fixes ENG-2441. Follow-up to ENG-2437 / #208.

## Problem

The build id enumerated its inputs — the package NEVRA set, and in #208 the auth files — so anything off that list was invisible to the OTA gate, and the same bug recurred once per input (permissions, then overlay, then `post_install`). The list only grows.

## Change

Replace the component list with a **content hash of the assembled work tree**, folded in beside the NEVRA hash:

```
AVOCADO_OS_BUILD_ID = uuid5(ns, "$PKG_HASH:$TREE_HASH")
```

via a shared `render_build_id_block(&BuildIdSpec)` so rootfs and initramfs can't diverge on the correctness-critical id logic. `TREE_HASH` moves iff the image bytes move → subsumes packages, permissions, overlay, `post_install`, and anything future.

### What `TREE_HASH` hashes (and deliberately doesn't)

Covers exactly what the image carries — sorted path, type, mode (`%m`), symlink target (`%l`), and file content. **Excludes**:
- **mtime and ownership** — `mkfs.erofs` normalizes these out (`-T "${SOURCE_DATE_EPOCH:-0}"`, `--all-root`), so hashing them would churn the id on noise the image never carries.
- **directory sizes** — fs-dependent.
- **`var/lib/rpm`** — the rpmdb sqlite embeds install timestamps (exactly why package identity is the NEVRA `PKG_HASH`, not these bytes). Pruned; `PKG_HASH` covers packages deterministically, including a version-only bump with an identical file payload.
- **`var/cache`, `var/log`** — dnf caches/logs, build-varying.

### Ordering (a hard requirement, enforced by a test)

The hash is taken **after** permissions/`post_install` and **before** the os-release identity append, and the derivation strips the `AVOCADO_*` fields from the identity files first. Taking it after the append would make the id depend on itself and on the possibly-unpinned runtime version (`runtimes.<name>.version` defaults to a per-build `uuid_v4()` fragment — see ENG-2444) → an OTA on every build.

### Prerequisite (same PR): `HashMap` → `BTreeMap`

`PermissionsConfig.users/groups` were a `HashMap`, whose per-process iteration order reshuffled the `/etc/passwd` appends and the auto-assigned UID/GIDs every build. With `id = f(tree)` that would churn the id every build, so this switches to `BTreeMap` (key-sorted, deterministic). No config-format impact — a `BTreeMap` deserializes from a YAML mapping identically.

## Migration note

The id formula changes, so **every existing image re-ids once** on the first rebuild after this lands (a single OS OTA even if nothing else changed). Steady state is churn-free thereafter.

## Tests

Unit tests: id = `$PKG_HASH:$TREE_HASH`; prunes present; no mtime/owner directives; strip → tree-hash → derive → append ordering; both images share `render_build_id_block`; BTreeMap provisions in sorted order. Full lib suite green; fmt/clippy clean (only the pre-existing `Option::zip` warning).

Empirically validated the exact GNU pipeline in a Linux container: determinism across two builds with differing mtimes/rpmdb bytes ✓, mtime ignored ✓, owner ignored ✓, rpmdb-churn pruned ✓, content/mode/symlink changes detected ✓.

## ⚠️ Pre-merge gate — determinism runbook (must run on a real SDK build/target)

Unit tests prove the script *structure*; only building twice proves the *tree* is reproducible. Draft until these pass:

1. **Build-twice reproducibility (essential).** `clean && prune && install -f && build` twice on the same machine → **same** `AVOCADO_OS_BUILD_ID`. If not, diff the two work trees (metadata via `find … -printf '%y %m %P\t%l\n' | sort`; content via `find -type f | sort | xargs sha256sum`). Prime suspects: `usr/etc/ld.so.cache`, systemd preset `*.wants/*` symlinks, `usr/lib/opkg/alternatives`, depmod `modules.*`. Fix at source or add to `BUILD_ID_TREE_PRUNES`.
2. **Cross-machine / fresh checkout** — same config → same id (catches host-leaking nondeterminism).
3. **Permissions reorder is inert** — reorder `users:`/`groups:` in YAML → id unchanged (BTreeMap check).
4. **Sensitivity** — each of {add a user, edit an `overlay/` file, edit `post_install`, add/remove a `rootfs.packages` entry} → a **different** id.
5. **On-device** — unchanged deploy → device logs `OS already at target version … skipping`; permissions-only change → device downloads + applies the OS bundle.

I could not run 1/2 here (no SDK container/target).

## Sequencing

Depends on nothing, but per the ticket: land #208, then ENG-2440 (stamp correctness), then this. Also relates to ENG-2444 (unpinned runtime version).